### PR TITLE
`Development`: Add translation to review dialog

### DIFF
--- a/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.html
+++ b/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.html
@@ -42,12 +42,10 @@
       [required]="true"
     />
     <ul class="review-checkboxes">
-      <!-- Will be added together with notifications
       <li>
         <p-checkbox [(ngModel)]="notifyApplicant" [binary]="true" />
-        <label>Notify the applicant</label>
+        <label jhiTranslate="evaluation.notifyApplicant">Notify the applicant</label>
       </li>
-      -->
       <li>
         <p-checkbox [(ngModel)]="closeJob" [binary]="true" />
         <label jhiTranslate="evaluation.closeJobAndRejectAll"></label>
@@ -58,20 +56,21 @@
 
 <!-- ───────── Template rendered in REJECT mode ───────── -->
 <ng-template #rejectTemplate>
-  <jhi-dropdown
-    [items]="rejectReasons"
-    [label]="'evaluation.reason' | translate"
-    [required]="true"
-    [selected]="selectedRejectReason()"
-    [placeholder]="'evaluation.selectReason' | translate"
-    (selectedChange)="onSelectChange($event)"
-  />
-  <ul class="review-checkboxes">
-    <!-- Will be added together with notifications
-    <li>
-      <p-checkbox [(ngModel)]="notifyApplicant" [binary]="true" />
-      <label>Notify the applicant</label>
-    </li>
-    -->
-  </ul>
+  <div>
+    <jhi-dropdown
+      [items]="rejectReasons"
+      [label]="'evaluation.reason' | translate"
+      [required]="true"
+      [selected]="selectedRejectReason()"
+      [placeholder]="'evaluation.selectReason' | translate"
+      [translateItems]="true"
+      (selectedChange)="onSelectChange($event)"
+    />
+    <ul class="review-checkboxes">
+      <li>
+        <p-checkbox [(ngModel)]="notifyApplicant" [binary]="true" />
+        <label jhiTranslate="evaluation.notifyApplicant">Notify the applicant</label>
+      </li>
+    </ul>
+  </div>
 </ng-template>

--- a/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.scss
+++ b/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.scss
@@ -25,6 +25,7 @@
 
     .job-name {
       color: var(--p-text-disabled);
+
       .icon {
         color: var(--p-primary-color);
       }
@@ -33,11 +34,10 @@
 
   .review-checkboxes {
     list-style: none;
-    padding: 0;
-    margin: 1rem 0;
+    margin-top: 2rem;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 2rem;
 
     li {
       display: flex;

--- a/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.ts
@@ -80,19 +80,19 @@ export class ReviewDialogComponent {
   // TODO adapt to translation keys when dropdown is adjusted
   rejectReasons: DropdownOption[] = [
     {
-      name: 'Job already filled',
+      name: 'evaluation.rejectReasons.jobFilled',
       value: 'JOB_FILLED',
     },
     {
-      name: 'Job outdated',
+      name: 'evaluation.rejectReasons.jobOutdated',
       value: 'JOB_OUTDATED',
     },
     {
-      name: 'Failed requirements',
+      name: 'evaluation.rejectReasons.failedRequirements',
       value: 'FAILED_REQUIREMENTS',
     },
     {
-      name: 'Other reason',
+      name: 'evaluation.rejectReasons.otherReason',
       value: 'OTHER_REASON',
     },
   ];

--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -38,6 +38,14 @@
     "selectReason": "Wähle einen Grund...",
 
     "closeJobAndRejectAll": "Stelle schließen und alle anderen Bewerbungen ablehnen",
+    "notifyApplicant": "Bewerber*in benachrichtigen",
+
+    "rejectReasons": {
+      "jobFilled": "Position bereits besetzt",
+      "jobOutdated": "Position nicht mehr aktuell",
+      "failedRequirements": "Anforderungen nicht erfüllt",
+      "otherReason": "Anderer Grund"
+    },
 
     "defaultAcceptMessage": "<p>Sehr geehrte*r {{APPLICANT_FIRST_NAME}},</p><br /><p>ich freue mich, Ihnen mitteilen zu können, dass Sie für die Position <b>{{JOB_NAME}}</b> in unserer Forschungsgruppe angenommen wurden. Ihr fachlicher Hintergrund, Ihre Motivation und Ihr Potenzial zur Mitgestaltung unserer akademischen und anwendungsorientierten Forschung haben uns überzeugt.</p><br /><p>In dieser Rolle übernehmen Sie die Verantwortung für Ihr Forschungsprojekt – einschließlich der inhaltlichen Ausrichtung, der Veröffentlichung Ihrer Ergebnisse und der aktiven Mitarbeit an laufenden Teamaktivitäten. Die Position erfordert ein hohes Maß an Engagement, Eigenständigkeit und Kommunikationsfähigkeit.</p><br /><p>Wir sind überzeugt von Ihrem Potenzial und freuen uns auf die Impulse, die Sie in unsere Gruppe und die wissenschaftliche Gemeinschaft einbringen werden.</p><br /><p><b>Bitte bestätigen Sie die Annahme dieses Angebots so bald wie möglich und kontaktieren Sie mich unter <a href=\"mailto:{{ PROFESSOR_EMAIL }}\">{{ PROFESSOR_EMAIL }}</a>, um die nächsten Schritte zu besprechen.</b></p><br /><br /><p>Mit freundlichen Grüßen,<br /><br />{{PROFESSOR_FIRST_NAME}}<br /><br />{{PROFESSOR_FIRST_NAME}} {{PROFESSOR_LAST_NAME}}<br />{{RESEARCH_GROUP_NAME}}<br />Technische Universität München<br /><a href=\"mailto:{{ PROFESSOR_EMAIL }}\">{{ PROFESSOR_EMAIL }}</a><br /><a href=\"{{RESEARCH_GROUP_WEBSITE}}\" target=\"_blank\">{{RESEARCH_GROUP_WEBSITE}}</a></p><br />"
   }

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -38,6 +38,14 @@
     "selectReason": "Select a reason...",
 
     "closeJobAndRejectAll": "Close job and reject all other applications",
+    "notifyApplicant": "Notify Applicant",
+
+    "rejectReasons": {
+      "jobFilled": "Job already filled",
+      "jobOutdated": "Job outdated",
+      "failedRequirements": "Failed requirements",
+      "otherReason": "Other reason"
+    },
 
     "defaultAcceptMessage": "<p>Dear {{APPLICANT_FIRST_NAME}},</p><br /><p>I am pleased to inform you that you have been accepted for the <b>{{JOB_NAME}}</b> position at our research group. We were impressed by your background, motivation, and potential for contributing to our academic and applied research efforts.</p><br /><p>As a candidate, you will take responsibility for managing your research project, including defining your research direction, publishing your results, and contributing to ongoing team activities. This position requires a high level of commitment, independence, and communication.</p><br /><p>We are confident in your ability to succeed in this role and look forward to seeing your impact on the group and the broader academic community.</p><br /><p><b>Please confirm acceptance of this offer as soon as possible and contact me at <a href=\"mailto:{{ PROFESSOR_EMAIL }}\">{{ PROFESSOR_EMAIL }}</a> to discuss the next steps.</b></p><br /><br /><p>Best regards,<br /><br />{{PROFESSOR_FIRST_NAME}}<br /><br />{{PROFESSOR_FIRST_NAME}} {{PROFESSOR_LAST_NAME}}<br />{{RESEARCH_GROUP_NAME}}<br />Technical University of Munich<br /><a href=\"mailto:{{ PROFESSOR_EMAIL }}\">{{ PROFESSOR_EMAIL }}</a><br /><a href=\"{{RESEARCH_GROUP_WEBSITE}}\" target=\"_blank\">{{RESEARCH_GROUP_WEBSITE}}</a></p><br />"
   }


### PR DESCRIPTION
#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

When rejecting an application, the dropdown options with the reject reason were not adapted to translation yet.

I also re-added the check box to control whether the applicant should be notified when the application was accepted/rejected

### Description

Add translation keys and adapted dropdown to it.


### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1


### Screenshots

<img width="1633" height="811" alt="grafik" src="https://github.com/user-attachments/assets/c2f4d41c-ab2c-49ab-8da6-ab959cc5c77a" />

<img width="1624" height="795" alt="grafik" src="https://github.com/user-attachments/assets/83f715fd-29da-474e-ba6b-7bd5624d3fae" />

