### PR TITLE
`Development`: No withdraw button on rejected applications

### DIFF
--- a/src/main/webapp/app/application/application-overview-for-applicant/application-overview-for-applicant.component.html
+++ b/src/main/webapp/app/application/application-overview-for-applicant/application-overview-for-applicant.component.html
@@ -48,7 +48,7 @@
         severity="primary"
         (click)="onViewApplication(row.applicationId)"
       />
-      @if (['SENT', 'IN_REVIEW', 'REJECTED'].includes(row.applicationState)) {
+      @if (['SENT', 'IN_REVIEW'].includes(row.applicationState)) {
         <jhi-button
           [label]="'entity.applicationOverview.actions.withdraw' | translate"
           severity="danger"


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context and Description

Previously, on the application overview page for applicants, there was a "Withdraw" button displayed next to rejected applications. This PR fixes this.


### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Go to the application overview page for applicants and check whether next to rejected applications there is a 

### Screenshots

<img width="1298" height="712" alt="image" src="https://github.com/user-attachments/assets/6712a0f3-1290-4a6b-9d1a-1ff4cd8ffc3a" />