### PR TITLE
`Development`: OpenAPI exclude actuator endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,8 +136,8 @@ openApi {
     customBootRun {
         jvmArgs = [
                 "-Dspring.profiles.active=dev,no-liquibase",
-                "-Dspringdoc.packages-to-scan=de.tum.cit.aet.application.web, de.tum.cit.aet.evaluation.web, de.tum.cit.aet." +
-                        "job.web, de.tum.cit.aet.usermanagement.web, de.tum.cit.aet.core.web",
+                "-Dspringdoc.packages-to-scan=de.tum.cit.aet", // all packages inside of de.tum.cit.aet will be scanned
+                "-Dspringdoc.paths-to-match=/api/**", // paths must start with '/api' to be scanned
                 "-Dspring.docker.compose.enabled=false",
                 "-Dspring.docker.compose.lifecycle-management=none"
         ]

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2046,19 +2046,13 @@
       "PageCreatedJobDTO": {
         "type": "object",
         "properties": {
-          "totalElements": {
-            "type": "integer",
-            "format": "int64"
-          },
           "totalPages": {
             "type": "integer",
             "format": "int32"
           },
-          "first": {
-            "type": "boolean"
-          },
-          "last": {
-            "type": "boolean"
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
           },
           "size": {
             "type": "integer",
@@ -2084,6 +2078,12 @@
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
           },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
           "empty": {
             "type": "boolean"
           }
@@ -2099,19 +2099,19 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "unpaged": {
-            "type": "boolean"
-          },
-          "paged": {
-            "type": "boolean"
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
           },
           "pageNumber": {
             "type": "integer",
             "format": "int32"
           },
-          "pageSize": {
-            "type": "integer",
-            "format": "int32"
+          "unpaged": {
+            "type": "boolean"
+          },
+          "paged": {
+            "type": "boolean"
           }
         }
       },
@@ -2734,19 +2734,13 @@
       "PageJobCardDTO": {
         "type": "object",
         "properties": {
-          "totalElements": {
-            "type": "integer",
-            "format": "int64"
-          },
           "totalPages": {
             "type": "integer",
             "format": "int32"
           },
-          "first": {
-            "type": "boolean"
-          },
-          "last": {
-            "type": "boolean"
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
           },
           "size": {
             "type": "integer",
@@ -2771,6 +2765,12 @@
           },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
           },
           "empty": {
             "type": "boolean"


### PR DESCRIPTION
Excludes the actuator endpoints from being scanned by openAPI, so no openAPI is generated for these endpoints.