### PR TITLE
`Development`: Add tooltips to badge and adapt evaluation pages

### DIFF
--- a/src/main/webapp/app/evaluation/application-overview/application-overview.component.html
+++ b/src/main/webapp/app/evaluation/application-overview/application-overview.component.html
@@ -29,6 +29,7 @@
       <jhi-tag
         [text]="'evaluation.statusBadge.' + (application.state || '') | translate"
         [color]="stateSeverityMap()[application.state] || 'info'"
+        [tooltipText]="'evaluation.statusBadge.tooltips.' + (application.state || '')"
       />
     </ng-template>
   </div>

--- a/src/main/webapp/app/shared/components/atoms/tag/tag.component.html
+++ b/src/main/webapp/app/shared/components/atoms/tag/tag.component.html
@@ -1,4 +1,10 @@
-<p-tag [severity]="color()" [rounded]="round()" class="custom-tag">
+<p-tag
+  class="custom-tag"
+  [severity]="color()"
+  [rounded]="round()"
+  [pTooltip]="tooltipKey() ? (tooltipKey() | translate) : null"
+  tooltipPosition="top"
+>
   @if (icon() && !iconRight()) {
     <fa-icon [icon]="iconProp()" class="icon left" />
   }

--- a/src/main/webapp/app/shared/components/atoms/tag/tag.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/tag/tag.component.ts
@@ -1,10 +1,12 @@
 import { Component, computed, input } from '@angular/core';
 import { Tag } from 'primeng/tag';
 import { FontAwesomeModule, IconDefinition } from '@fortawesome/angular-fontawesome';
+import { TooltipModule } from 'primeng/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'jhi-tag',
-  imports: [Tag, FontAwesomeModule],
+  imports: [Tag, FontAwesomeModule, TooltipModule, TranslateModule],
   templateUrl: './tag.component.html',
   styleUrl: './tag.component.scss',
   standalone: true,
@@ -15,6 +17,8 @@ export class TagComponent {
   icon = input<IconDefinition | undefined>(undefined);
   round = input<boolean>(false);
   iconRight = input<boolean>(false);
+  tooltipText = input<string | undefined>(undefined);
 
   readonly iconProp = computed(() => this.icon() as IconDefinition);
+  readonly tooltipKey = computed(() => this.tooltipText() ?? '');
 }

--- a/src/main/webapp/app/shared/components/molecules/application-card/application-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/application-card/application-card.component.html
@@ -6,6 +6,7 @@
       <jhi-tag
         [text]="'evaluation.statusBadge.' + (applicationDetails()?.applicationState || '') | translate"
         [color]="stateSeverityMap[applicationDetails()?.applicationState!] || 'info'"
+        [tooltipText]="'evaluation.statusBadge.tooltips.' + (applicationDetails()?.applicationState || '')"
       />
     </div>
 

--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -27,7 +27,14 @@
       "SENT": "Ungelesen",
       "ACCEPTED": "Angenommen",
       "REJECTED": "Abgelehnt",
-      "IN_REVIEW": "In Bearbeitung"
+      "IN_REVIEW": "In Bearbeitung",
+
+      "tooltips": {
+        "SENT": "Die Bewerbung wurde eingereicht, aber noch nicht geöffnet",
+        "ACCEPTED": "Die Bewerbung wurde angenommen",
+        "REJECTED": "Die Bewerbung wurde abgelehnt",
+        "IN_REVIEW": "Die Bewerbung wurde geöffnet und befindet sich noch in Bearbeitung"
+      }
     },
     "noApplicationsFound": "Keine Bewerbungen gefunden.",
     "filterOptions": {

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -27,7 +27,14 @@
       "SENT": "Unopened",
       "ACCEPTED": "Approved",
       "REJECTED": "Rejected",
-      "IN_REVIEW": "In Review"
+      "IN_REVIEW": "In Review",
+
+      "tooltips": {
+        "SENT": "The application has been submitted but not yet opened",
+        "ACCEPTED": "The application has been accepted",
+        "REJECTED": "The application has been rejected",
+        "IN_REVIEW": "The application has been opened and is still under review"
+      }
     },
     "noApplicationsFound": "No applications found.",
     "filterOptions": {


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Status labels alone were not clear enough for professors and applicants to understand the exact meaning of each state. To improve usability and reduce confusion, tooltips were added that provide short explanations of the status.

### Description

This PR enhances the `jhi-tag` component by adding an optional tooltip input and integrating PrimeNG’s tooltip with translations. Tooltips are now displayed for application status badges in the application overview and application card components, with localized texts provided in both German and English.

### Steps for Testing

- Open the application overview and hover over the status badge of an application → verify that a tooltip appears with the correct localized explanation.
- Switch the app language between English and German → confirm that the tooltip text updates accordingly.

Prerequisites:

1. Log in as Professor
2. Go to application evaluation overview & detail page

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1


### Screenshots

<img width="1114" height="110" alt="grafik" src="https://github.com/user-attachments/assets/275e14b4-725f-469e-af8c-fd754423c093" />

<img width="415" height="227" alt="grafik" src="https://github.com/user-attachments/assets/f0e19a2a-1e13-4c8a-bee4-eb5785c9e241" />

