### PR TITLE
`Development`: Add professor login

### DIFF
--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -16,6 +16,13 @@ const routes: Routes = [
     title: 'landingPage.title',
   },
   {
+    path: 'professor',
+    canActivate: [UserRouteAccessService],
+    data: { authorities: [] },
+    loadComponent: () => import('./shared/pages/landing-page/landing-page.component').then(m => m.LandingPageComponent),
+    title: 'landingPage.title',
+  },
+  {
     path: '',
     canActivate: [UserRouteAccessService],
     data: { authorities: [] },

--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -52,11 +52,7 @@ export class AuthFacadeService {
   async loginWithEmail(email: string, password: string, redirectUri?: string): Promise<boolean> {
     try {
       await this.emailAuthenticationService.login(email, password);
-
-      // If a redirect URI is provided, navigate to it
-      if (redirectUri !== undefined) {
-        window.location.href = redirectUri.startsWith('http') ? redirectUri : window.location.origin + redirectUri;
-      }
+      this.redirectToPage(redirectUri);
       return true;
     } catch {
       return false;
@@ -81,15 +77,16 @@ export class AuthFacadeService {
   }
 
   // Logout the user from both email and Keycloak sessions.
-  async logout(): Promise<void> {
+  async logout(redirectUri?: string): Promise<void> {
     // Email-Logout
     try {
       await this.emailAuthenticationService.logout();
+      this.redirectToPage(redirectUri);
     } catch {}
 
     // Keycloak-Logout
     try {
-      await this.keycloakService.logout();
+      await this.keycloakService.logout(redirectUri);
     } catch {}
 
     // reset account state
@@ -105,5 +102,12 @@ export class AuthFacadeService {
    */
   private async loadUser(): Promise<void> {
     await this.accountService.loadUser();
+  }
+
+  private redirectToPage(redirectUri?: string): void {
+    // If a redirect URI is provided, navigate to it
+    if (redirectUri !== undefined) {
+      window.location.href = redirectUri.startsWith('http') ? redirectUri : window.location.origin + redirectUri;
+    }
   }
 }

--- a/src/main/webapp/app/core/auth/keycloak.service.ts
+++ b/src/main/webapp/app/core/auth/keycloak.service.ts
@@ -20,13 +20,12 @@ export interface UserProfile {
 @Injectable({ providedIn: 'root' })
 export class KeycloakService {
   profile: UserProfile | undefined;
-  private refreshIntervalId: any;
-
   private readonly keycloak = new Keycloak({
     url: environment.keycloak.url,
     realm: environment.keycloak.realm,
     clientId: environment.keycloak.clientId,
   });
+  private refreshIntervalId: any;
 
   /**
    * Initializes the Keycloak client and determines login status.
@@ -107,7 +106,7 @@ export class KeycloakService {
         this.refreshIntervalId = undefined;
       }
       await this.keycloak.logout({
-        redirectUri: redirectUri ?? window.location.origin + '/',
+        redirectUri: redirectUri?.startsWith('http') ? redirectUri : window.location.origin + (redirectUri ?? '/'),
       });
     } catch (err) {
       console.error('Logout failed:', err);

--- a/src/main/webapp/app/shared/components/organisms/auth-card/auth-card.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/auth-card/auth-card.component.ts
@@ -72,10 +72,6 @@ export class AuthCardComponent {
     ],
   }));
 
-  onTUMSSOLogin(): void {
-    this.authFacadeService.loginWithTUM(this.redirectUri());
-  }
-
   onEmailLogin = async (credentials: { email: string; password: string }): Promise<boolean> => {
     const response = await this.authFacadeService.loginWithEmail(credentials.email, credentials.password, this.redirectUri());
     if (!response) {

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.html
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.html
@@ -2,6 +2,9 @@
   <div (click)="navigateToHome()" class="logo-section">
     <img alt="TUM Logo" class="tum-logo" src="content/images/tum-logo/tum-logo-blue.svg" />
     <span class="app-name">Apply</span>
+    @if (isProfessorPage()) {
+      <span class="professor" jhiTranslate="header.professorTitle"></span>
+    }
   </div>
 
   <div class="actions-section">

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.html
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.html
@@ -24,6 +24,23 @@
 			/>-->
 
     @if (user() === undefined) {
+      @if (isProfessorPage()) {
+        <jhi-button
+          class="fixed-width-button"
+          (click)="redirectToApplicantLandingPage()"
+          label="{{ 'header.applicant' | translate }}"
+          severity="primary"
+          variant="outlined"
+        />
+      } @else {
+        <jhi-button
+          class="fixed-width-button"
+          (click)="redirectToProfessorLandingPage()"
+          label="{{ 'header.professor' | translate }}"
+          severity="primary"
+          variant="outlined"
+        />
+      }
       <jhi-button class="fixed-width-button" (click)="openLoginDialog()" label="{{ 'header.login' | translate }}" severity="primary" />
     } @else {
       <div class="profile">

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.html
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.html
@@ -41,7 +41,7 @@
           variant="outlined"
         />
       }
-      <jhi-button class="fixed-width-button" (click)="openLoginDialog()" label="{{ 'header.login' | translate }}" severity="primary" />
+      <jhi-button class="fixed-width-button" (click)="login()" label="{{ 'header.login' | translate }}" severity="primary" />
     } @else {
       <div class="profile">
         <fa-icon class="profile-icon" icon="user" />

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.scss
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.scss
@@ -24,6 +24,11 @@
     .tum-logo {
       height: 1.5rem;
     }
+
+    .professor {
+      color: var(--p-secondary-color);
+      font-weight: 300;
+    }
   }
 
   .actions-section {

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.ts
@@ -12,11 +12,12 @@ import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dy
 import { ButtonComponent } from '../../atoms/button/button.component';
 import { AuthCardComponent } from '../auth-card/auth-card.component';
 import { AuthFacadeService } from '../../../../core/auth/auth-facade.service';
+import TranslateDirective from '../../../language/translate.directive';
 
 @Component({
   selector: 'jhi-header',
   standalone: true,
-  imports: [CommonModule, ButtonComponent, FontAwesomeModule, TranslateModule, DynamicDialogModule],
+  imports: [CommonModule, ButtonComponent, FontAwesomeModule, TranslateModule, DynamicDialogModule, TranslateDirective],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
   encapsulation: ViewEncapsulation.None,

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.ts
@@ -49,6 +49,14 @@ export class HeaderComponent {
     void this.router.navigate(['/']);
   }
 
+  async login(): Promise<void> {
+    if (this.isProfessorPage()) {
+      await this.onTUMSSOLogin();
+    } else {
+      this.openLoginDialog();
+    }
+  }
+
   openLoginDialog(): void {
     this.ref = this.dialogService.open(AuthCardComponent, {
       style: {
@@ -57,7 +65,10 @@ export class HeaderComponent {
         background: 'transparent',
         boxShadow: 'none',
       },
-      data: { mode: 'login', redirectUri: this.router.url },
+      data: {
+        professor: this.isProfessorPage(),
+        redirectUri: this.router.url,
+      },
       modal: true,
       contentStyle: {
         padding: '0',
@@ -74,6 +85,10 @@ export class HeaderComponent {
 
   redirectToApplicantLandingPage(): void {
     void this.router.navigate(['/']);
+  }
+
+  async onTUMSSOLogin(): Promise<void> {
+    await this.authFacadeService.loginWithTUM(this.router.url);
   }
 
   logout(): void {

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.ts
@@ -38,8 +38,10 @@ export class HeaderComponent {
   accountService = inject(AccountService);
   user: WritableSignal<User | undefined> = this.accountService.user;
   ref: DynamicDialogRef | undefined;
-
-  private router = inject(Router);
+  router = inject(Router);
+  isProfessorPage = toSignal(this.router.events.pipe(map(() => this.router.url === '/professor')), {
+    initialValue: this.router.url === '/professor',
+  });
   private dialogService = inject(DialogService);
   private authFacadeService = inject(AuthFacadeService);
 
@@ -64,6 +66,14 @@ export class HeaderComponent {
       closeOnEscape: true,
       showHeader: false,
     });
+  }
+
+  redirectToProfessorLandingPage(): void {
+    void this.router.navigate(['/professor']);
+  }
+
+  redirectToApplicantLandingPage(): void {
+    void this.router.navigate(['/']);
   }
 
   logout(): void {

--- a/src/main/webapp/i18n/de/header.json
+++ b/src/main/webapp/i18n/de/header.json
@@ -1,6 +1,8 @@
 {
   "header": {
     "login": "Anmelden",
+    "professor": "Sind Sie Professor:in?",
+    "applicant": "Sind Sie Bewerber:in?",
     "logout": "Abmelden"
   }
 }

--- a/src/main/webapp/i18n/de/header.json
+++ b/src/main/webapp/i18n/de/header.json
@@ -1,6 +1,7 @@
 {
   "header": {
     "login": "Anmelden",
+    "professorTitle": "Professor:in",
     "professor": "Sind Sie Professor:in?",
     "applicant": "Sind Sie Bewerber:in?",
     "logout": "Abmelden"

--- a/src/main/webapp/i18n/en/header.json
+++ b/src/main/webapp/i18n/en/header.json
@@ -1,6 +1,7 @@
 {
   "header": {
     "login": "Login",
+    "professorTitle": "Professor",
     "professor": "Are you a professor?",
     "applicant": "Are you an applicant?",
     "logout": "Logout"

--- a/src/main/webapp/i18n/en/header.json
+++ b/src/main/webapp/i18n/en/header.json
@@ -1,6 +1,8 @@
 {
   "header": {
     "login": "Login",
+    "professor": "Are you a professor?",
+    "applicant": "Are you an applicant?",
     "logout": "Logout"
   }
 }


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

This PR introduces the initial differentiation between applicant and professor login flows.
Until now, both shared the same entry points. With this change:
- Professors are redirected directly to the Keycloak SSO login.
- Applicants continue to use the standard login form.

⚠️ Disclaimer:
The Landing page itself is still identical for applicants and professors (only the header and navigation links differ).
A dedicated professor landing page will be implemented in Feature #504

### Description

- Updated header and navigation links depending on role (professor vs. applicant).
- Adjusted login handling:
 - Professor entry → redirect directly to Keycloak TUM login.
 - Applicant entry → show standard TUMApply login dialog.
- Ensured routing and guards work consistently.

### Steps for Testing

Steps:

1. Navigate to / (home page) as not-logged-in user.
2. Verify the header and links are applicant-specific (see screenshot below; default header, as known from before)
3. Click Login → the standard TUMApply login form appears.
4. Navigate to /professor (either via URL or via Button "Are you a professor?" as not-logged-in user.
5. Verify the header and links are professor-specific (see screenshot below; Professor text and different button text).
6. Click Login → you are redirected to the Keycloak login page.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<img width="1465" height="58" alt="image" src="https://github.com/user-attachments/assets/eb04b740-b7d1-4a24-926b-e9135436edd9" />

<img width="1465" height="58" alt="image" src="https://github.com/user-attachments/assets/377fc753-1e22-462f-bc13-411d745909bc" />
