### PR TITLE
`Development`: Fix review page rating issue

### DIFF
--- a/src/main/java/de/tum/cit/aet/evaluation/service/ApplicationEvaluationService.java
+++ b/src/main/java/de/tum/cit/aet/evaluation/service/ApplicationEvaluationService.java
@@ -48,7 +48,7 @@ public class ApplicationEvaluationService {
 
     private static final Set<ApplicationState> REVIEW_STATES = Set.of(ApplicationState.SENT, ApplicationState.IN_REVIEW);
 
-    private static final Set<String> SORTABLE_FIELDS = Set.of("rating", "createdAt", "applicant.lastName");
+    private static final Set<String> SORTABLE_FIELDS = Set.of("createdAt", "applicant.lastName");
 
     /**
      * Accepts the specified application and updates its state.

--- a/src/main/webapp/app/evaluation/filterSortOptions.ts
+++ b/src/main/webapp/app/evaluation/filterSortOptions.ts
@@ -19,16 +19,6 @@ export const filterFields: FilterField[] = [
 
 export const sortOptions: SortOption[] = [
   {
-    displayName: 'Rating (Worst to Best)',
-    field: 'rating',
-    direction: 'ASC',
-  },
-  {
-    displayName: 'Rating (Best to Worst)',
-    field: 'rating',
-    direction: 'DESC',
-  },
-  {
     displayName: 'Applied at (Oldest to Newest)',
     field: 'createdAt',
     direction: 'ASC',


### PR DESCRIPTION
#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

**PR Summary**
This PR fixes a bug where professors navigating directly to an application’s detail page triggered an invalid sort on the removed `rating` field. Since `rating` is no longer part of the application model, the field was removed from both the server (`ApplicationEvaluationService`) and client (`filterSortOptions.ts`) sorting options.


### Steps for Testing

Prerequisites:

1. Log in to as a professor


#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Go directly to review page -> no exception should be shown, and data is visible
