### PR TITLE
`Development`: Rename Group name in sidebar

### DIFF
--- a/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.ts
@@ -113,7 +113,7 @@ export class SidebarComponent {
           ],
         },
         {
-          title: 'sidebar.researchgroup.emailtemplates',
+          title: 'sidebar.researchgroup.researchgroup',
           buttons: [{ icon: 'envelope-open-text', text: 'sidebar.researchgroup.emailtemplates', link: '/research-group/templates' }],
         },
       ],


### PR DESCRIPTION
#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Accidentally changed the group header in the sidebar, this pr is to revert the change 

### Description

- Changes header label in the sidebar

### Steps for Testing


Prerequisites:

1. Log in to TumApply as Professor
2. Check that sidebar header is "Research Group"

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1
