### PR TITLE
`Development`: Shorten tooltip messages for evaluation status badges

### DIFF
--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -34,10 +34,10 @@
       "IN_REVIEW": "In Bearbeitung",
 
       "tooltips": {
-        "SENT": "Die Bewerbung wurde eingereicht, aber noch nicht geöffnet",
+        "SENT": "Die Bewerbung wurde noch nicht geöffnet",
         "ACCEPTED": "Die Bewerbung wurde angenommen",
         "REJECTED": "Die Bewerbung wurde abgelehnt",
-        "IN_REVIEW": "Die Bewerbung wurde geöffnet und befindet sich noch in Bearbeitung"
+        "IN_REVIEW": "Die Bewerbung wurde geöffnet"
       }
     },
     "noApplicationsFound": "Keine Bewerbungen gefunden.",

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -34,10 +34,10 @@
       "IN_REVIEW": "In Review",
 
       "tooltips": {
-        "SENT": "The application has been submitted but not yet opened",
+        "SENT": "The application has not been opened yet",
         "ACCEPTED": "The application has been accepted",
         "REJECTED": "The application has been rejected",
-        "IN_REVIEW": "The application has been opened and is still under review"
+        "IN_REVIEW": "The application has been opened"
       }
     },
     "noApplicationsFound": "No applications found.",


### PR DESCRIPTION
### Motivation and Context

The tooltip texts for status badges in the evaluation module were overly long, resulting in oversized tooltips. This PR streamlines the messages to concise, minimal wording for improved readability and usability.

### Steps for Testing

Prerequisites:

1. Log in as a professor and go the the evaluation module

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Hover over a status badge and see the new shorter text

### Screenshots

<img width="421" height="222" alt="grafik" src="https://github.com/user-attachments/assets/6776c944-fae5-4916-8793-4e1d929832a0" />

<img width="410" height="214" alt="grafik" src="https://github.com/user-attachments/assets/c2bbfcb6-fd1e-4114-a21b-91b83dbac208" />

