### PR TITLE
`General`: Fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [
-      "security"
+      "security fix"
     ]
   },
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
   "schedule": [
     "every weekend"
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ]
+  },
   "packageRules": [
     {
       "groupName": "Weekly Dependency Updates",
@@ -22,26 +28,6 @@
       ],
       "schedule": [
         "every weekend"
-      ]
-    },
-    {
-      "groupName": "Security Updates",
-      "groupSlug": "security-updates",
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
-      "matchConfidenceLevels": [
-        "high"
-      ],
-      "labels": [
-        "security"
-      ],
-      "prPriority": 10,
-      "separateMultipleMajor": false,
-      "schedule": [
-        "at any time"
       ]
     }
   ]


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Renovate was failing to run due to invalid configuration options. The properties
matchConfidenceLevels and separateMultipleMajor are no longer supported, which caused Renovate validation errors and prevented dependency updates.

This PR cleans up the configuration and replaces the legacy Security Updates rule with the modern vulnerabilityAlerts configuration to ensure security-related updates are still detected and labeled correctly.

### Description

- Removed outdated packageRules block for "Security Updates" (which included deprecated properties such as matchConfidenceLevels and separateMultipleMajor).
- Added a new top-level [vulnerabilityAlerts configuration](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts):
   - Enables Renovate’s built-in vulnerability alerts
   - Labels all security-related PRs with "security"
- Kept the existing Weekly Dependency Updates rule for all regular updates.

### Review Progress

#### Code Review

- [x] Code Review 1