### PR TITLE
`Development`: Granular renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,31 +3,151 @@
   "extends": [
     "config:recommended"
   ],
-  "prConcurrentLimit": 2,
-  "prHourlyLimit": 1,
   "schedule": [
     "every weekend"
   ],
+  "minimumReleaseAge": "3 days",
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [
-      "security fix"
+      "security fix",
+      "ready for review"
     ]
   },
   "packageRules": [
     {
-      "groupName": "Weekly Dependency Updates",
-      "groupSlug": "weekly-updates",
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "digest",
-        "pin",
-        "lockFileMaintenance"
+      "matchManagers": [
+        "github-actions"
       ],
-      "schedule": [
-        "every weekend"
+      "groupName": "ci: GitHub Actions",
+      "automerge": true,
+      "automergeType": "pr",
+      "prPriority": 10,
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchSourceUrlPrefixes": [
+        "https://github.com/FasterXML/"
+      ],
+      "groupName": "vendor: Jackson FasterXML",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchSourceUrlPrefixes": [
+        "https://github.com/keycloak/"
+      ],
+      "groupName": "vendor: Keycloak",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ]
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "groupName": "vendor: PrimeTek / PrimeUIX",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackageNames": [
+        "primeng",
+        "primeicons",
+        "tailwindcss-primeui"
+      ],
+      "matchPackagePrefixes": [
+        "@primeuix/"
+      ]
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "groupName": "vendor: ngx-translate",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePrefixes": [
+        "@ngx-translate/"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "vendor: JHipster",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^tech\\.jhipster:"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "vendor: Caffeine",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^com\\.github\\.ben-manes\\.caffeine:"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "vendor: Lombok",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^org\\.projectlombok:lombok$"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "vendor: ArchUnit",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^com\\.tngtech\\.archunit:"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "vendor: Testcontainers",
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^org\\.testcontainers:"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "schedule": [
     "every weekend"
   ],
+  "timezone": "Europe/Berlin",
   "minimumReleaseAge": "3 days",
   "vulnerabilityAlerts": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -45,13 +45,13 @@
       "matchManagers": [
         "gradle"
       ],
-      "matchSourceUrlPrefixes": [
-        "https://github.com/keycloak/"
-      ],
       "groupName": "vendor: Keycloak",
       "labels": [
         "dependencies",
         "ready for review"
+      ],
+      "matchPackagePatterns": [
+        "^org\\.keycloak:"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,23 @@
     "enabled": true,
     "labels": [
       "security fix",
+      "dependencies",
       "ready for review"
     ]
   },
   "packageRules": [
+    {
+      "matchManagers": [
+        "npm",
+        "gradle",
+        "maven",
+        "github-actions"
+      ],
+      "labels": [
+        "dependencies",
+        "ready for review"
+      ]
+    },
     {
       "matchManagers": [
         "github-actions"
@@ -22,23 +35,15 @@
       "groupName": "ci: GitHub Actions",
       "automerge": true,
       "automergeType": "pr",
-      "prPriority": 10,
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ]
+      "prPriority": 10
     },
     {
       "matchManagers": [
         "gradle"
       ],
+      "groupName": "vendor: Jackson FasterXML",
       "matchSourceUrlPrefixes": [
         "https://github.com/FasterXML/"
-      ],
-      "groupName": "vendor: Jackson FasterXML",
-      "labels": [
-        "dependencies",
-        "ready for review"
       ]
     },
     {
@@ -46,10 +51,6 @@
         "gradle"
       ],
       "groupName": "vendor: Keycloak",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^org\\.keycloak:"
       ]
@@ -59,10 +60,6 @@
         "npm"
       ],
       "groupName": "vendor: PrimeTek / PrimeUIX",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackageNames": [
         "primeng",
         "primeicons",
@@ -77,10 +74,6 @@
         "npm"
       ],
       "groupName": "vendor: ngx-translate",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePrefixes": [
         "@ngx-translate/"
       ]
@@ -90,10 +83,6 @@
         "gradle"
       ],
       "groupName": "vendor: JHipster",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^tech\\.jhipster:"
       ]
@@ -103,10 +92,6 @@
         "gradle"
       ],
       "groupName": "vendor: Caffeine",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^com\\.github\\.ben-manes\\.caffeine:"
       ]
@@ -116,10 +101,6 @@
         "gradle"
       ],
       "groupName": "vendor: Lombok",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^org\\.projectlombok:lombok$"
       ]
@@ -129,10 +110,6 @@
         "gradle"
       ],
       "groupName": "vendor: ArchUnit",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^com\\.tngtech\\.archunit:"
       ]
@@ -142,10 +119,6 @@
         "gradle"
       ],
       "groupName": "vendor: Testcontainers",
-      "labels": [
-        "dependencies",
-        "ready for review"
-      ],
       "matchPackagePatterns": [
         "^org\\.testcontainers:"
       ]


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Renovate was previously configured with a single “Weekly Dependency Updates” group. This led to large and less transparent PRs that combined unrelated dependencies.
To improve maintainability, traceability, and reviewability, the configuration has been restructured for granular vendor-based grouping.

### Description

- Removed the generic Weekly Dependency Updates group.
- Introduced vendor-specific rules for both server (Gradle) and client (npm):
   - GitHub Actions → separate group, auto-merge enabled.
   - Jackson FasterXML (Gradle) → grouped by source.
   - Keycloak (Gradle) → grouped by source.
   - PrimeTek / PrimeUIX (npm) → primeng, primeicons, @primeuix/*, tailwindcss-primeui.
   - ngx-translate (npm) → all @ngx-translate packages.
   - JHipster (Gradle) → tech.jhipster:*
   - Caffeine (Gradle) → com.github.ben-manes.caffeine:*
   - Lombok (Gradle) → org.projectlombok:lombok
   - ArchUnit (Gradle, test scope) → com.tngtech.archunit:*
   - Testcontainers (Gradle, test scope) → org.testcontainers:*
- Added minimumReleaseAge: "3 days" to avoid too-early adoption of unstable releases.
- Added consistent labels (dependencies, ready for review) to all dependency PRs.

### Review Progress

#### Code Review

- [x] Code Review 1