### PR TITLE
`Usability`: Show empty string instead of undefined

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/string-input/string-input.component.html
+++ b/src/main/webapp/app/shared/components/atoms/string-input/string-input.component.html
@@ -46,7 +46,7 @@
           [id]="id()"
           [ngModel]="model()"
           [pAutoFocus]="autofocus()"
-          [placeholder]="shouldTranslate() && placeholder() ? (placeholder() ?? '' | translate) : placeholder()"
+          [placeholder]="shouldTranslate() && placeholder() ? (placeholder() ?? '' | translate) : (placeholder() ?? '')"
           [required]="required()"
           [style]="{ width: width() }"
           autocomplete="off"


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Input fields are showing undefined if the field is empty.

### Description

- added empty string if placeholder is null

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots
<img width="1230" height="723" alt="Screenshot 2025-09-11 at 17 25 36" src="https://github.com/user-attachments/assets/a261bc2d-9947-415e-9e29-b7b99d907335" />

