### PR TITLE
`General`: Fix error text for pre-filled editor fields

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
@@ -66,15 +66,11 @@ export class EditorComponent extends BaseInputDirective<string> {
   private htmlValue = signal('');
   private hasFormControl = computed(() => this.control() !== undefined);
 
-  constructor() {
-    super();
-
-    // Effect to sync htmlValue when editorValue changes (e.g., from form patching)
-    effect(() => {
-      const currentEditorValue = this.editorValue();
-      this.htmlValue.set(currentEditorValue);
-    });
-  }
+  // Effect to sync htmlValue when editorValue changes (e.g., from form patching)
+  private syncHtmlValueEffect = effect(() => {
+    const currentEditorValue = this.editorValue();
+    this.htmlValue.set(currentEditorValue);
+  });
 
   textChanged(event: ContentChange): void {
     const { source, oldDelta, editor } = event;

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, effect, input, signal } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { TranslateModule } from '@ngx-translate/core';
 import { TooltipModule } from 'primeng/tooltip';
@@ -22,7 +22,6 @@ export class EditorComponent extends BaseInputDirective<string> {
   characterLimit = input<number | undefined>(STANDARD_CHARACTER_LIMIT); // Optionally set maximum character limit
   helperText = input<string | undefined>(undefined); // Optional helper text to display below the editor field
   // Check if error message should be displayed
-  isTouched = signal(false);
   isOverCharLimit = computed(() => {
     const count = this.characterCount();
     const limit = this.characterLimit() ?? STANDARD_CHARACTER_LIMIT;
@@ -65,12 +64,16 @@ export class EditorComponent extends BaseInputDirective<string> {
   });
 
   private htmlValue = signal('');
-  private hasFormControl = computed(() => !!this.formControl());
+  private hasFormControl = computed(() => this.control() !== undefined);
 
   constructor() {
     super();
 
-    this.htmlValue.set(this.editorValue());
+    // Effect to sync htmlValue when editorValue changes (e.g., from form patching)
+    effect(() => {
+      const currentEditorValue = this.editorValue();
+      this.htmlValue.set(currentEditorValue);
+    });
   }
 
   textChanged(event: ContentChange): void {


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

The error text should only be shown if the editor component is empty. However, when pre-filling the job and application creation forms, when touching the editor field and clicking anywhere else on the screen afterwards, the error text is still displayed, even though the editor field is not empty.

### Description

- Added effect that updates the htmlValue of the editor component (side effect due to e.g. patch)

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant/Professor
2. Navigate to Job Creation/Application Creation
3. Check that character count changes accordingly when typing
4. Check that character count is visible for pre-filled editor components

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1