### PR TITLE
`General`: Fix job card button

### DIFF
--- a/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.scss
+++ b/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.scss
@@ -5,10 +5,12 @@
   padding: 1rem 5rem;
   justify-content: center;
 }
+
 .job-card-grid > * {
   flex: 0 0 auto;
-  width: clamp(15rem, 20vw, 20rem);
+  width: clamp(16.5rem, 20vw, 20rem);
 }
+
 .no-jobs-text {
   text-align: center;
   padding: 2rem;

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -106,7 +106,6 @@
             label="jobActionButton.viewApplication"
             severity="secondary"
             variant="outlined"
-            icon="file-circle-check"
           />
         }
       }

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.scss
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.scss
@@ -1,0 +1,3 @@
+.apply-button {
+  white-space: nowrap;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).


#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

After submitting an application, when the screen is too small, the View Application button doesn’t fit the German translation, causing it to become larger than the other buttons, which breaks the overall page design.

### Description

<!-- Describe your changes in detail -->

- Removed the icon from the button to accommodate the German translation without having to increase the job card width too much.
- Increased the job card minimum width from 15 rem to 16.5 rem.
- Prevented line breaks in the apply buttons.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to TumApply as an applicant
2. Navigate to the job overview
3. Navigate to a job you have applied for
4. Verify that all buttons remain on a single line and do not wrap, even when the window is small

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage

<!-- Please add the test coverages for all changed files modified in this PR here. -->
<!-- You can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="1433" height="690" alt="Screenshot 2025-09-11 at 23 31 42" src="https://github.com/user-attachments/assets/ffccec41-0630-48fb-84d9-254d1d582d74" />
<img width="494" height="689" alt="Screenshot 2025-09-11 at 23 32 11" src="https://github.com/user-attachments/assets/87d2812e-ecdf-420d-bda4-1762aa1ea209" />

