### PR TITLE
`General`: Fix home navigation as Professor

### DIFF
--- a/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.ts
@@ -100,7 +100,7 @@ export class SidebarComponent {
         {
           title: 'sidebar.manage.manage',
           buttons: [
-            { icon: 'home', text: 'sidebar.manage.home', link: '/' },
+            { icon: 'home', text: 'sidebar.manage.home', link: '/professor' },
             { icon: 'list', text: 'sidebar.manage.mypositions', link: '/my-positions' },
             { icon: 'plus', text: 'sidebar.manage.createposition', link: '/job/create' },
           ],


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).


### Motivation and Context

Professors still navigate to the applicant landing page when logged in when clicking on the home sidebar button

### Description

Changed navigation for home button as Professor to /professor

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Professor
2. Click on Home Button on the sidebar
3. Should navigate to /professor instead of /

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [ ] Test 1
