### PR TITLE
`General`: Fix undefined application page 3 after otp registration/login

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -107,7 +107,12 @@ export default class ApplicationCreationFormComponent {
     masterGrade: undefined,
   });
 
-  page3 = signal<ApplicationCreationPage3Data | undefined>(undefined);
+  page3 = signal<ApplicationCreationPage3Data>({
+    desiredStartDate: '',
+    motivation: '',
+    skills: '',
+    experiences: '',
+  });
 
   previewData = computed(() => this.mapPagesToDTO() as ApplicationDetailDTO);
 
@@ -657,10 +662,10 @@ export default class ApplicationCreationFormComponent {
         masterGrade: p2.masterGrade,
         masterGradingScale: p2.masterGradingScale.value,
       },
-      motivation: p3?.motivation ?? '',
-      specialSkills: p3?.skills ?? '',
-      desiredDate: p3?.desiredStartDate ?? '',
-      projects: p3?.experiences,
+      motivation: p3.motivation,
+      specialSkills: p3.skills,
+      desiredDate: p3.desiredStartDate,
+      projects: p3.experiences,
       jobTitle: this.title(),
     };
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Application page 3 is undefined after registration/login while in the application form which causes the application page 3 not to load.

### Description

Initialise application page 3 before data is fetched

### Steps for Testing

Prerequisites:

1. Navigate to Job Overview and click on Apply
2. Enter data, click on Next and enter otp
3. Continue until Page 3 and check if page 3 is visible
4. Check if all data is stored/application can be edited

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1