### PR TITLE
`Development`: Global document caching

### DIFF
--- a/src/main/webapp/app/service/document-cache.service.ts
+++ b/src/main/webapp/app/service/document-cache.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, inject } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+
+export interface CachedDoc {
+  safeUrl: SafeResourceUrl;
+  rawUrl: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DocumentCacheService {
+  private cache = new Map<string, CachedDoc>();
+  private maxSize = 20;
+
+  private readonly sanitizer = inject(DomSanitizer);
+
+  get(documentId: string): SafeResourceUrl | undefined {
+    const entry = this.cache.get(documentId);
+    if (entry) {
+      // refresh LRU order
+      this.cache.delete(documentId);
+      this.cache.set(documentId, entry);
+      return entry.safeUrl;
+    }
+    return undefined;
+  }
+
+  set(documentId: string, blob: Blob): SafeResourceUrl {
+    const rawUrl = URL.createObjectURL(blob);
+    const safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(rawUrl + '#toolbar=0&navpanes=0');
+
+    // drop existing if present
+    if (this.cache.has(documentId)) {
+      this.revoke(this.cache.get(documentId)!);
+      this.cache.delete(documentId);
+    }
+
+    this.cache.set(documentId, { safeUrl, rawUrl });
+
+    // enforce size limit
+    if (this.cache.size > this.maxSize) {
+      const oldestKey = this.cache.keys().next().value;
+
+      if (oldestKey !== undefined) {
+        const oldest = this.cache.get(oldestKey);
+        if (oldest) {
+          this.revoke(oldest);
+        }
+        this.cache.delete(oldestKey);
+      }
+    }
+
+    return safeUrl;
+  }
+
+  private revoke(entry: CachedDoc): void {
+    URL.revokeObjectURL(entry.rawUrl);
+  }
+}

--- a/src/test/webapp/app/service/document-cache.service.spec.ts
+++ b/src/test/webapp/app/service/document-cache.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentCacheService } from 'app/service/document-cache.service';
+
+// Mock DomSanitizer
+const mockDomSanitizer = {
+  bypassSecurityTrustResourceUrl: vi.fn((url: string) => `safe:${url}` as SafeResourceUrl),
+};
+
+const mockCreateObjectURL = vi.fn();
+const mockRevokeObjectURL = vi.fn();
+
+const originalURL = global.URL;
+
+describe('DocumentCacheService', () => {
+  let service: DocumentCacheService;
+  let mockBlob: Blob;
+
+  beforeEach(async () => {
+    // Setup URL mocks
+    global.URL = class extends originalURL {
+      static createObjectURL = mockCreateObjectURL;
+      static revokeObjectURL = mockRevokeObjectURL;
+    } as typeof URL;
+
+    mockCreateObjectURL.mockReturnValue('blob:mock-url-123');
+
+    await TestBed.configureTestingModule({
+      providers: [DocumentCacheService, { provide: DomSanitizer, useValue: mockDomSanitizer }],
+    }).compileComponents();
+
+    service = TestBed.inject(DocumentCacheService);
+    mockBlob = new Blob(['test content'], { type: 'application/pdf' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Restore original URL
+    global.URL = originalURL;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return undefined when getting non-existent document', () => {
+    const result = service.get('non-existent-id');
+    expect(result).toBeUndefined();
+  });
+
+  it('should set and get a document', () => {
+    const documentId = 'doc-123';
+    const safeUrl = service.set(documentId, mockBlob);
+
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(mockBlob);
+    expect(mockDomSanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith('blob:mock-url-123#toolbar=0&navpanes=0');
+    expect(safeUrl).toBe('safe:blob:mock-url-123#toolbar=0&navpanes=0');
+
+    const retrievedUrl = service.get(documentId);
+    expect(retrievedUrl).toBe(safeUrl);
+  });
+
+  it('should implement LRU behavior when getting documents', () => {
+    const doc1Id = 'doc-1';
+    const doc2Id = 'doc-2';
+
+    mockCreateObjectURL.mockReturnValueOnce('blob:url-1').mockReturnValueOnce('blob:url-2');
+
+    const safeUrl1 = service.set(doc1Id, mockBlob);
+    const safeUrl2 = service.set(doc2Id, mockBlob);
+
+    // Access doc1 to make it most recently used
+    const retrieved1 = service.get(doc1Id);
+    expect(retrieved1).toBe(safeUrl1);
+
+    // Verify doc1 is now at the end (most recent) by checking internal behavior
+    const retrieved2 = service.get(doc2Id);
+    expect(retrieved2).toBe(safeUrl2);
+  });
+
+  it('should replace existing document with same ID', () => {
+    const documentId = 'doc-123';
+    mockCreateObjectURL.mockReturnValueOnce('blob:url-1').mockReturnValueOnce('blob:url-2');
+
+    // Set first document
+    const safeUrl1 = service.set(documentId, mockBlob);
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+
+    // Replace with second document
+    const safeUrl2 = service.set(documentId, mockBlob);
+
+    // Should revoke the first URL and create a new one
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:url-1');
+    expect(safeUrl2).toBe('safe:blob:url-2#toolbar=0&navpanes=0');
+
+    const retrieved = service.get(documentId);
+    expect(retrieved).toBe(safeUrl2);
+  });
+
+  it('should enforce max size limit and evict oldest entry', () => {
+    // Set maxSize to a small number for testing
+    const maxSize = 3;
+    (service as any).maxSize = maxSize;
+
+    const documentIds = ['doc-1', 'doc-2', 'doc-3', 'doc-4'];
+    const mockUrls = ['blob:url-1', 'blob:url-2', 'blob:url-3', 'blob:url-4'];
+
+    mockUrls.forEach(url => mockCreateObjectURL.mockReturnValueOnce(url));
+
+    // Fill cache to max capacity
+    documentIds.slice(0, 3).forEach((id, index) => {
+      service.set(id, mockBlob);
+    });
+
+    // Add one more document, should evict the oldest (doc-1)
+    service.set(documentIds[3], mockBlob);
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:url-1');
+
+    // doc-1 should no longer be in cache
+    expect(service.get('doc-1')).toBeUndefined();
+
+    // Other documents should still be accessible
+    expect(service.get('doc-2')).toBeDefined();
+    expect(service.get('doc-3')).toBeDefined();
+    expect(service.get('doc-4')).toBeDefined();
+  });
+
+  it('should handle cache size exactly at limit without eviction', () => {
+    const maxSize = 2;
+    (service as any).maxSize = maxSize;
+
+    mockCreateObjectURL.mockReturnValueOnce('blob:url-1').mockReturnValueOnce('blob:url-2');
+
+    service.set('doc-1', mockBlob);
+    service.set('doc-2', mockBlob);
+
+    // Should not have called revoke yet
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+
+    // Both documents should be accessible
+    expect(service.get('doc-1')).toBeDefined();
+    expect(service.get('doc-2')).toBeDefined();
+  });
+
+  it('should handle empty cache correctly during eviction', () => {
+    const maxSize = 1;
+    (service as any).maxSize = maxSize;
+
+    mockCreateObjectURL.mockReturnValue('blob:url-1');
+
+    // This should work without errors even with empty cache
+    service.set('doc-1', mockBlob);
+
+    expect(service.get('doc-1')).toBeDefined();
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('should properly handle PDF viewer parameters', () => {
+    const documentId = 'doc-123';
+    mockCreateObjectURL.mockReturnValue('blob:test-url');
+
+    service.set(documentId, mockBlob);
+
+    expect(mockDomSanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith('blob:test-url#toolbar=0&navpanes=0');
+  });
+});


### PR DESCRIPTION
#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Opening documents repeatedly in the reviewer dialog caused unnecessary downloads and slower performance. To improve responsiveness and reduce server load, a local cache with safe object URLs was introduced. The document viewer was adapted to use this cache.

### Description

`DocumentCacheService `provides an LRU-style in-memory cache for document blobs. It creates sanitized object URLs, reuses them for quick access, and revokes old ones when the cache exceeds its size limit to prevent memory leaks.

### Steps for Testing

- [ ] Create one or two test applications as an applicant and upload several documents
- [ ] Log in as a professor and open the applications in the details page
- [ ] Switch between different applications
      - [ ] Check the **Network** tab in browser dev tools. 
      - [ ] Ensure **no new request** to the server is made (document should come from cache)



#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1