### PR TITLE
`General`: Fix endless login loop

### DIFF
--- a/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.html
+++ b/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.html
@@ -17,12 +17,16 @@
       />
     }
 
+    @if (submitError() && form.pristine) {
+      <p jhiTranslate="auth.login.messages.error.wrongCredentials" class="[color:var(--p-danger-color)] text-center pb-4"></p>
+    }
+
     <div class="buttons">
       <jhi-button
-        [disabled]="form.invalid || isSubmitting || (form.pristine && submitError())"
+        [disabled]="form.invalid || this.authOrchestrator.isBusy() || (form.pristine && submitError())"
         [fullWidth]="true"
         [label]="submitLabel()"
-        [loading]="isSubmitting"
+        [loading]="authOrchestrator.isBusy()"
         [shouldTranslate]="true"
         type="submit"
       />

--- a/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.ts
@@ -51,10 +51,7 @@ export class CredentialsGroupComponent {
     return 'auth.register.buttons.continue';
   });
   dividerLabel = computed(() => (this.isLogin() ? 'auth.login.texts.or' : 'auth.register.texts.or'));
-
-  isSubmitting = false;
   otpLength = environment.otp.length;
-
   form = new FormGroup({
     email: new FormControl<string>(this.authOrchestrator.email(), {
       nonNullable: true,
@@ -66,19 +63,22 @@ export class CredentialsGroupComponent {
   submitError = signal<boolean>(false);
 
   async onSubmit(): Promise<void> {
-    if (this.form.invalid) return;
-
-    this.isSubmitting = true;
+    if (this.form.invalid) {
+      return;
+    }
     const credentials = this.form.value as { email: string; password: string };
-    await this.submitHandler()(credentials.email, credentials.password).then(success => {
-      this.submitError.set(!success);
-      this.afterSubmit(success);
-    });
+    await this.submitHandler()(credentials.email, credentials.password)
+      .then(success => {
+        this.submitError.set(!success);
+        this.afterSubmit(success);
+      })
+      .catch(() => {
+        this.submitError.set(true);
+        this.form.markAsPristine();
+      });
   }
 
   private afterSubmit(success: boolean): void {
-    this.isSubmitting = false;
-
     if (success) {
       this.form.reset({}, { emitEvent: false });
       return;


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

This change fixes the endless login loop (bug #783).
The login form previously kept loading when incorrect credentials were entered, causing the UI to remain in a busy state and preventing further attempts.

### Description

- Removed the local isSubmitting flag and replaced it with the existing authOrchestrator.isBusy() signal for consistent busy-state handling.
- Displayed the “wrong credentials” error message only while the form is still pristine, so the message automatically disappears as soon as the user edits any field.
- Added proper error handling in onSubmit() to catch unexpected errors:
   - Sets submitError to true on failure.
   - Calls form.markAsPristine() to ensure the error message logic works reliably.

These adjustments unify the login busy state management and improve the user experience by clearing the error message once the user starts editing again.

### Steps for Testing

Test steps:

1. Open the login page and attempt to log in with invalid credentials. Expected: The “wrong credentials” message appears and the login button is re-enabled
3. Modify the email or password field. Expected: The error message disappears immediately.
5. Enter valid credentials and log in. Expected: Login succeeds without any endless loop and the busy indicator works correctly.


### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1