### PR TITLE
`General`: Fix translation bug

### DIFF
--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
@@ -60,21 +60,21 @@
 
                       {
                         labelKey: 'evaluation.details.applicantGender',
-                       value: application.applicationDetailDTO.applicant?.user?.gender
-  ? ('genders.' + application.applicationDetailDTO.applicant?.user?.gender?.toLowerCase() | translate)
-  : '—'
+                        value: application.applicationDetailDTO.applicant?.user?.gender
+                          ? ('genders.' + application.applicationDetailDTO.applicant?.user?.gender?.toLowerCase() | translate)
+                          : '—',
                       },
                       {
                         labelKey: 'evaluation.details.applicantNationality',
-      value: application.applicationDetailDTO.applicant?.user?.nationality
-        ? ('nationalities.' + application.applicationDetailDTO.applicant?.user?.nationality?.toLowerCase() | translate)
-        : '—'
+                        value: application.applicationDetailDTO.applicant?.user?.nationality
+                          ? ('nationalities.' + application.applicationDetailDTO.applicant?.user?.nationality?.toLowerCase() | translate)
+                          : '—',
                       },
                       {
                         labelKey: 'evaluation.details.applicantPreferredLanguage',
-      value: application.applicationDetailDTO.applicant?.user?.preferredLanguage
-        ? ('languages.' + application.applicationDetailDTO.applicant?.user?.preferredLanguage?.toLowerCase() | translate)
-        : '—'
+                        value: application.applicationDetailDTO.applicant?.user?.preferredLanguage
+                          ? ('languages.' + application.applicationDetailDTO.applicant?.user?.preferredLanguage?.toLowerCase() | translate)
+                          : '—',
                       },
                     ]"
                   />


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I strictly followed the principle of **data economy** for all client-server REST calls.
- [x] I strictly followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.



### Motivation and Context

Currently, when certain applicant fields (e.g. gender, nationality, preferred language) are not provided, the application detail view shows raw translation keys.  
This PR adds safe fallback rendering (`—`) for missing values, improving the user experience and ensuring a cleaner display for incomplete applications.



### Description

Added fallback display (—) for optional applicant fields in the application-detail.component.html view (e.g. gender, nationality, preferred language), to avoid showing broken translations or empty values.



### Steps for Testing

Prerequisites:

1. Log in to TumApply as a Professor
2. Navigate to the **Review Applications** page
3. Select an application with missing `gender`, `nationality` or `preferredLanguage`
4. Verify that those fields now show `—` instead of a broken translation key or empty space




### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [x] Test 1



### Screenshots
<img width="592" height="222" alt="image" src="https://github.com/user-attachments/assets/d0bb0607-d684-438b-9c41-cd162a5a8715" />
