### PR TITLE
`Usability`: Make landing pages consistent

### DIFF
--- a/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.scss
+++ b/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.scss
@@ -9,7 +9,7 @@
 }
 
 .image-container img {
-  max-width: 32rem;
+  max-width: 36rem;
   aspect-ratio: 5 / 3;
   border-radius: 1.25rem;
 }

--- a/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.scss
+++ b/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.scss
@@ -3,19 +3,19 @@
   display: flex;
   flex-direction: row;
   gap: 2rem;
-  padding: 0.75rem;
+  padding: 2rem;
   align-items: center;
   justify-content: center;
 }
 
 .image-container img {
   max-width: 32rem;
+  aspect-ratio: 5 / 3;
   border-radius: 1.25rem;
 }
 
 .text-container {
   display: flex;
-  padding: 2.5rem;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/src/main/webapp/app/shared/pages/landing-page/hero-section/hero-section.component.html
+++ b/src/main/webapp/app/shared/pages/landing-page/hero-section/hero-section.component.html
@@ -1,18 +1,24 @@
-<p-carousel
-  styleClass="hero-carousel"
-  [autoplayInterval]="8000"
-  [circular]="true"
-  [numVisible]="1"
-  [showNavigators]="false"
-  [value]="imagesWithBackgroundClass"
->
-  <ng-template #item let-image>
-    <div [class]="image.backgroundClass" class="hero-container">
-      <div class="hero-content">
-        <h1 class="title" jhiTranslate="landingPage.hero.headline"></h1>
-        <p class="subtitle" jhiTranslate="landingPage.hero.subline"></p>
+<div class="hero-wrap">
+  <p-carousel
+    styleClass="hero-carousel"
+    [autoplayInterval]="8000"
+    [circular]="true"
+    [numVisible]="1"
+    [showNavigators]="false"
+    [value]="imagesWithBackgroundClass"
+  >
+    <ng-template #item let-image>
+      <div class="hero-slide" [class]="image.backgroundClass" class="hero-container"></div>
+    </ng-template>
+  </p-carousel>
+
+  <div class="hero-overlay">
+    <div class="hero-content">
+      <h1 class="title" jhiTranslate="landingPage.hero.headline"></h1>
+      <p class="subtitle" jhiTranslate="landingPage.hero.subline"></p>
+      <div class="pointer-event-button">
         <jhi-button (click)="navigateToJobOverview()" label="{{ 'landingPage.hero.button' | translate }}" severity="primary" />
       </div>
     </div>
-  </ng-template>
-</p-carousel>
+  </div>
+</div>

--- a/src/main/webapp/app/shared/pages/landing-page/hero-section/hero-section.component.scss
+++ b/src/main/webapp/app/shared/pages/landing-page/hero-section/hero-section.component.scss
@@ -1,4 +1,9 @@
 @use '../../../../../content/scss/breakpoints' as bp;
+
+.hero-wrap {
+  position: relative;
+}
+
 .hero-container {
   position: relative;
   display: flex;

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-benefits-section/professor-benefits-section.component.scss
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-benefits-section/professor-benefits-section.component.scss
@@ -10,7 +10,7 @@
 }
 
 .image-container img {
-  max-width: 32rem;
+  max-width: 36rem;
   aspect-ratio: 5 / 3;
   border-radius: 1.25rem;
 }

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-benefits-section/professor-benefits-section.component.scss
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-benefits-section/professor-benefits-section.component.scss
@@ -4,19 +4,19 @@
   display: flex;
   flex-direction: row;
   gap: 2rem;
-  padding: 0.75rem;
+  padding: 2rem;
   align-items: center;
   justify-content: center;
 }
 
 .image-container img {
   max-width: 32rem;
+  aspect-ratio: 5 / 3;
   border-radius: 1.25rem;
 }
 
 .text-container {
   display: flex;
-  padding: 2.5rem;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-hero-section/professor-hero-section.component.html
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-hero-section/professor-hero-section.component.html
@@ -1,18 +1,24 @@
-<p-carousel
-  styleClass="hero-carousel"
-  [autoplayInterval]="8000"
-  [circular]="true"
-  [numVisible]="1"
-  [showNavigators]="false"
-  [value]="imagesWithBackgroundClass"
->
-  <ng-template #item let-image>
-    <div [class]="image.backgroundClass" class="hero-container">
-      <div class="hero-content">
-        <h1 class="title" jhiTranslate="professorLandingPage.hero.headline"></h1>
-        <p class="subtitle" jhiTranslate="professorLandingPage.hero.subline"></p>
+<div class="hero-wrap">
+  <p-carousel
+    styleClass="hero-carousel"
+    [autoplayInterval]="8000"
+    [circular]="true"
+    [numVisible]="1"
+    [showNavigators]="false"
+    [value]="imagesWithBackgroundClass"
+  >
+    <ng-template #item let-image>
+      <div [class]="image.backgroundClass" class="hero-container"></div>
+    </ng-template>
+  </p-carousel>
+
+  <div class="hero-overlay">
+    <div class="hero-content">
+      <h1 class="title" jhiTranslate="professorLandingPage.hero.headline"></h1>
+      <p class="subtitle" jhiTranslate="professorLandingPage.hero.subline"></p>
+      <div class="pointer-event-button">
         <jhi-button (click)="navigateToGetStarted()" label="{{ 'professorLandingPage.hero.button' | translate }}" severity="primary" />
       </div>
     </div>
-  </ng-template>
-</p-carousel>
+  </div>
+</div>

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-hero-section/professor-hero-section.component.scss
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-hero-section/professor-hero-section.component.scss
@@ -1,5 +1,9 @@
 @use '../../../../../content/scss/breakpoints' as bp;
 
+.hero-wrap {
+  position: relative;
+}
+
 .hero-container {
   position: relative;
   display: flex;

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -402,6 +402,20 @@
   border-radius: 50%;
 }
 
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 2;
+  pointer-events: none; // Disable pointer events for the carousel indicators
+
+  .pointer-event-button {
+    pointer-events: auto; // Enable pointer events for the button
+  }
+}
+
 /* -------------------------------
  Style primeNg select component.
 ------------------------------- */


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

- applicant landing page and professor landing page has different paddings in the journey/benefits section due to the different text content and image size
- The text in the hero section always stays the same, the carousel movement makes it look less smooth
- 
### Description

- Adds aspect ratio to images for consistenty
- Adjusts padding of sections
- Adds text area as overlay to make it "static"

### Steps for Testing

Prerequisites:

1. Navigate to professor/landing page
2. Check that doctoral journey section and professor benefits section has the same padding and image size
3. Check that the text in the hero section doesn't move with the images

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<img width="1469" height="443" alt="Screenshot 2025-09-24 at 21 37 07" src="https://github.com/user-attachments/assets/26f06f3f-d1b1-4cc0-919b-b66bcd37ee88" />
<img width="1470" height="445" alt="Screenshot 2025-09-24 at 21 37 18" src="https://github.com/user-attachments/assets/4e3bfca6-cdbf-4a1e-86c6-3402ceadc539" />

