### PR TITLE
`Development`: Temporary remove editor from review dialog

### DIFF
--- a/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.html
+++ b/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.html
@@ -34,6 +34,8 @@
 <!-- ───────── Template rendered in ACCEPT mode ───────── -->
 <ng-template #acceptTemplate>
   <div>
+    <!-- TODO: Removed until editor is fixed -->
+    <!--
     <jhi-editor
       [label]="'evaluation.message' | translate"
       [placeholder]="'evaluation.writeMessage' | translate"
@@ -41,6 +43,7 @@
       (modelChange)="editorModel.set($event)"
       [required]="true"
     />
+    -->
     <ul class="review-checkboxes">
       <li>
         <p-checkbox [(ngModel)]="notifyApplicant" [binary]="true" />

--- a/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/review-dialog/review-dialog.component.ts
@@ -8,7 +8,6 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { SelectComponent, SelectOption } from '../../atoms/select/select.component';
 import { ButtonComponent } from '../../atoms/button/button.component';
-import { EditorComponent } from '../../atoms/editor/editor.component';
 import TranslateDirective from '../../../language/translate.directive';
 import { ApplicationEvaluationDetailDTO } from '../../../../generated/model/applicationEvaluationDetailDTO';
 import { AcceptDTO } from '../../../../generated/model/acceptDTO';
@@ -28,7 +27,6 @@ import ReasonEnum = RejectDTO.ReasonEnum;
     SelectComponent,
     NgTemplateOutlet,
     ButtonComponent,
-    EditorComponent,
     TranslateDirective,
   ],
   templateUrl: './review-dialog.component.html',
@@ -99,15 +97,22 @@ export class ReviewDialogComponent {
     },
   ];
 
-  constructor() {
-    // Reset state each time the dialog opens
-    effect(() => {
-      if (this.visible()) {
-        this.resetDialogState();
-        this.editorModel.set(this.translate.instant('evaluation.defaultAcceptMessage', this.translationMetaData()));
-      }
-    });
-  }
+  _defaultTextEffect = effect(() => {
+    if (this.visible()) {
+      this.resetDialogState();
+      // TODO: Removed until editor is fixed
+      // this.editorModel.set(this.translate.instant('evaluation.defaultAcceptMessage', this.translationMetaData()));
+
+      // TODO: Remove this when editor is fixed
+      // Always use english for the message
+      const value = this.translate.getParsedResult(
+        this.translate.translations['en'],
+        'evaluation.defaultAcceptMessage',
+        this.translationMetaData(),
+      );
+      this.editorModel.set(value);
+    }
+  });
 
   resetDialogState(): void {
     this.notifyApplicant.set(true);


### PR DESCRIPTION
### Motivation and Context

This PR temporarily removes the editor from the review dialog, as it was not working properly before. The editor will be re-added once it is fixed. In the meantime, Professors can not change the acceptance text, but the default text will be used.

### Description

- commented out the editor from the review dialog
- adapted the translation of the default text to always use English. This will also be reverted once teh edior is fixed

### Steps for Testing

- [ ] no editor should be shown
- [ ] validate that the default text (in English) is sent to the server which is then used for the acceptance email

Prerequisites:

1. Log in to as professor
2. Accept an application

