### PR TITLE
feat: added more error messages, display the same error message on ap…

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -392,7 +392,7 @@ export default class ApplicationCreationFormComponent {
         this.updateDocumentInformation();
       } catch (error: unknown) {
         const httpError = error as HttpErrorResponse;
-        this.showInitErrorMessage(`${applyflow}.initLoadFailed`);
+        this.showInitErrorMessage(`${applyflow}.loadFailed`);
         throw new Error(`Init failed with HTTP ${httpError.status} ${httpError.statusText}: ${httpError.message}`);
       }
     }
@@ -455,6 +455,7 @@ export default class ApplicationCreationFormComponent {
         this.savingState.set(SavingStates.SAVED);
       } else {
         this.savingState.set(SavingStates.FAILED);
+        this.toastService.showErrorKey(`${applyflow}.saveFailed`);
       }
     }
   }
@@ -462,10 +463,7 @@ export default class ApplicationCreationFormComponent {
   onConfirmSend(): void {
     this.submitAttempted.set(true);
     if (!this.privacyAcceptedSignal()) {
-      this.toastService.showError({
-        summary: this.translateService.instant('privacy.privacyConsent.toastError.summary'),
-        detail: this.translateService.instant('privacy.privacyConsent.toastError.detail'),
-      });
+      this.toastService.showErrorKey('privacy.privacyConsent.toastError');
       return;
     }
     void this.sendCreateApplicationData('SENT', true);
@@ -497,9 +495,7 @@ export default class ApplicationCreationFormComponent {
         this.toastService.showSuccessKey(`${applyflow}.submitted`);
         await this.router.navigate(['/application/overview']);
       }
-    } catch (err) {
-      const httpError = err as HttpErrorResponse;
-      this.toastService.showErrorKey(`${applyflow}.saveFailedWithStatus`, { status: httpError.statusText });
+    } catch {
       return false;
     }
     return true;
@@ -550,11 +546,8 @@ export default class ApplicationCreationFormComponent {
         this.applicantId.set(this.accountService.loadedUser()?.id ?? '');
         void this.migrateDraftIfNeeded();
         this.progressStepper()?.goToStep(2);
-      } catch (err) {
-        this.toastService.showError({
-          summary: 'Error',
-          detail: (err as Error).message || 'Email verification failed. Please try again.',
-        });
+      } catch {
+        this.toastService.showErrorKey(`${applyflow}.otpVerificationFailed`);
       }
     })();
   }
@@ -563,17 +556,17 @@ export default class ApplicationCreationFormComponent {
   private async openOtpAndWaitForLogin(email: string, firstName: string, lastName: string): Promise<void> {
     const normalizedEmail = email.trim();
     if (!normalizedEmail) {
-      this.toastService.showError({ summary: 'Error', detail: 'Please provide a valid email address.' });
+      this.toastService.showErrorKey(`${applyflow}.invalidEmail`);
       return;
     }
     const normalizedFirstName = firstName.trim();
     if (!normalizedFirstName) {
-      this.toastService.showError({ summary: 'Error', detail: 'Please provide a valid first name.' });
+      this.toastService.showErrorKey(`${applyflow}.invalidFirstName`);
       return;
     }
     const normalizedLastName = lastName.trim();
     if (!normalizedLastName) {
-      this.toastService.showError({ summary: 'Error', detail: 'Please provide a valid last name.' });
+      this.toastService.showErrorKey(`${applyflow}.invalidLastName`);
       return;
     }
 
@@ -627,7 +620,7 @@ export default class ApplicationCreationFormComponent {
       await this.sendCreateApplicationData(this.applicationState(), false);
       // TODO: remove application from local storage
     } catch {
-      this.toastService.showError({ summary: 'Error', detail: 'Failed to migrate local draft to server.' });
+      this.toastService.showErrorKey(`${applyflow}.migrationFailed`);
     }
   }
 

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -397,10 +397,6 @@
           "summary": "Ungültiger Seitenlink",
           "detail": "Dieser Bewerbungslink ist nicht gültig. Bitte öffne die Seite über die Übersicht und versuche es erneut."
         },
-        "saveFailedWithStatus": {
-          "summary": "Übermittlung fehlgeschlagen",
-          "detail": "Bewerbung konnte nicht übermittelt werden: {{status}}"
-        },
         "fetchDocumentIdsFailed": {
           "summary": "Dokumente nicht geladen",
           "detail": "Die Dokument-IDs für diese Bewerbung konnten nicht abgerufen werden. Bitte versuche es erneut."
@@ -415,19 +411,35 @@
         },
         "saveFailed": {
           "summary": "Speichern fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht gespeichert werden. Bitte versuche es erneut."
+          "detail": "Die Änderungen konnten nicht gespeichert werden. Bitte prüfe deine Verbindung und speichere erneut."
         },
         "loadFailed": {
           "summary": "Laden fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte aktualisiere die Seite."
-        },
-        "initLoadFailed": {
-          "summary": "Laden fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht initial geladen werden. Bitte versuche es erneut."
+          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte aktualisiere die Seite und überprüfe deine Verbindung."
         },
         "missingJobIdUnauthenticated": {
           "summary": "Job-ID fehlt",
           "detail": "Ohne Anmeldung muss eine Job-ID angegeben werden."
+        },
+        "invalidEmail": {
+          "summary": "Error",
+          "detail": "Bitte gib eine gültige E-Mail-Adresse an."
+        },
+        "invalidFirstName": {
+          "summary": "Error",
+          "detail": "Bitte gib einen gültigen Vornamen an."
+        },
+        "invalidLastName": {
+          "summary": "Error",
+          "detail": "Bitte gib einen gültigen Nachnamen an."
+        },
+        "migrationFailed": {
+          "summary": "Error",
+          "detail": "Der lokale Entwurf konnte nicht auf den Server migriert werden."
+        },
+        "otpVerificationFailed": {
+          "summary": "Error",
+          "detail": "E-Mail-Verifizierung fehlgeschlagen. Bitte versuch es erneut."
         }
       },
       "applicationOverview": {

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -397,10 +397,6 @@
           "summary": "Error",
           "detail": "This is not a valid application page link."
         },
-        "saveFailedWithStatus": {
-          "summary": "Submission failed",
-          "detail": "Failed to submit application: {{status}}"
-        },
         "fetchDocumentIdsFailed": {
           "summary": "Error",
           "detail": "Failed to fetch document IDs for this application."
@@ -414,20 +410,36 @@
           "detail": "Cannot submit application: User authentication required."
         },
         "saveFailed": {
-          "summary": "Error",
-          "detail": "Failed to save application."
+          "summary": "Save failed",
+          "detail": "Changes could not be saved. Please check your connection and save again."
         },
         "loadFailed": {
           "summary": "Error",
-          "detail": "Failed to load application."
-        },
-        "initLoadFailed": {
-          "summary": "Error",
-          "detail": "Failed to load application."
+          "detail": "Failed to load application. Please check your connection."
         },
         "missingJobIdUnauthenticated": {
           "summary": "Error",
           "detail": "Job ID must be provided when not authenticated."
+        },
+        "invalidEmail": {
+          "summary": "Error",
+          "detail": "Please provide a valid email address."
+        },
+        "invalidFirstName": {
+          "summary": "Error",
+          "detail": "Please provide a valid first name."
+        },
+        "invalidLastName": {
+          "summary": "Error",
+          "detail": "Please provide a valid last name."
+        },
+        "migrationFailed": {
+          "summary": "Error",
+          "detail": "Failed to migrate local draft to server."
+        },
+        "otpVerificationFailed": {
+          "summary": "Error",
+          "detail": "Email verification failed. Please try again."
         }
       },
       "applicationOverview": {


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [ ] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

So far, the application creation form has displayed different errors compared to the job creation form. Moreover, it used the `showError` method instead of `showErrorKey`.

### Description

- Replaced the `showError` method with the `showErrorKey` method
- Display same error message in application creation form as in job creation form for failed unsaved changes

### Steps for Testing

Prerequisites:

1. Log in to TumApply as a professor
2. Create a new application
3. Stop the server and make some changes -> Error message should appear

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<img width="1891" height="804" alt="Screenshot 2025-09-27 at 01 15 47" src="https://github.com/user-attachments/assets/fee3eb0c-1f22-4012-93ac-b040fd750f05" />

