### PR TITLE
`General`: Fix double creation in user research group roles

### DIFF
--- a/src/main/java/de/tum/cit/aet/usermanagement/repository/UserResearchGroupRoleRepository.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/repository/UserResearchGroupRoleRepository.java
@@ -30,4 +30,18 @@ public interface UserResearchGroupRoleRepository extends TumApplyJpaRepository<U
     @Query("UPDATE UserResearchGroupRole urgr SET urgr.researchGroup = null WHERE urgr.user.userId = :userId")
     void removeResearchGroupFromUserRoles(@Param("userId") UUID userId);
 
+    /**
+     * Deletes a specific role entry for a user from the UserResearchGroupRole table.
+     * <p>
+     * This method removes the association between a given user and a role
+     * (e.g., APPLICANT or PROFESSOR) in the context of any research group.
+     * It does not affect other roles or the research group membership itself.
+     *
+     * @param user the user whose role should be removed
+     * @param role the specific role to remove for the user
+     */
+    @Modifying
+    @Query("DELETE FROM UserResearchGroupRole urgr WHERE urgr.user = :user AND urgr.role = :role")
+    void deleteByUserAndRole(@Param("user") User user, @Param("role") de.tum.cit.aet.usermanagement.constants.UserRole role);
+
 }

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
@@ -244,6 +244,8 @@ public class ResearchGroupService {
         headUser.setResearchGroup(saved);
         userRepository.save(headUser);
 
+        // Remove existing APPLICANT role before assigning PROFESSOR
+        userResearchGroupRoleRepository.deleteByUserAndRole(headUser, UserRole.APPLICANT);
         var existingMapping = userResearchGroupRoleRepository.findByUserAndResearchGroup(headUser, saved);
         if (existingMapping.isEmpty()) {
             UserResearchGroupRole mapping = new UserResearchGroupRole();
@@ -297,6 +299,8 @@ public class ResearchGroupService {
         }
         String roleOutcome = "unchanged";
 
+        // Remove existing APPLICANT role before assigning PROFESSOR
+        userResearchGroupRoleRepository.deleteByUserAndRole(user, UserRole.APPLICANT);
         var existing = userResearchGroupRoleRepository.findByUserAndResearchGroup(user, group);
         if (existing.isEmpty()) {
             UserResearchGroupRole mapping = new UserResearchGroupRole();
@@ -324,3 +328,4 @@ public class ResearchGroupService {
     }
 
 }
+

--- a/src/main/resources/testdata/01_users.sql
+++ b/src/main/resources/testdata/01_users.sql
@@ -64,3 +64,6 @@ VALUES
         ('11111111-0000-0000-0000-000000000028', NULL, 'claire.lambert@tumapply.local', NULL, 'Claire', 'Lambert', 'female', 'fr', '1988-08-08', '+33 1 456789', 'https://clairelambert.fr', 'https://linkedin.com/in/clairelambert123', 'en', NULL),
         ('11111111-0000-0000-0000-000000000029', NULL, 'matteo.rinaldi@tumapply.local', NULL, 'Matteo', 'Rinaldi', 'male', 'nl', '1991-07-07', '+39 02 123456', 'https://matteorinaldi.it', 'https://linkedin.com/in/matteorinaldi123', 'en', NULL),
         ('11111111-0000-0000-0000-000000000030', NULL, 'noor.ahmed@tumapply.local', NULL, 'Noor', 'Ahmed', 'female', 'fr', '1995-02-02', '+92 42 1234567', 'https://noorahmed.pk', 'https://linkedin.com/in/noorahmed123', 'en', NULL);
+
+REPLACE INTO users (user_id, research_group_id, email, avatar, first_name, last_name, gender, nationality, birthday, phone_number, website, linkedin_url, selected_language, university_id)
+VALUES ('11111111-0000-0000-0000-000000000031', NULL, 'john.beno@tumapply.local', NULL, 'John', 'Beno', 'male', 'de', '2002-04-29', '+49 12345678', 'https://beno.de', 'https://linkedin.com/in/beno', 'en', 'test07');


### PR DESCRIPTION

### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311718/Performance+Guidelines) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311877/Server+Guidelines).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context

Previously, a user could end up with multiple role assignments (e.g., both `APPLICANT` and `PROFESSOR`) for the same research group when creating a new group. This PR ensures that duplicate `user_research_group_role` entries are avoided during the creation of a research group.

### Description

- When a research group is created via the admin endpoint, the user with matching `universityId` is assigned the `PROFESSOR` role only if not already associated with that group.
- This avoids duplicate entries and resolves an inconsistency in the `user_research_group_role` table.

### Steps for Testing

1. Start the application 
2. Open Bruno and execute the saved Admin -> Create ResearchGroup request (the body is already prefilled).
3. In your local database , verify the following:
   - There is exactly onenentry in the `user_research_group_role` table for the user with `userId = 11111111-0000-0000-0000-000000000031`.
   - The role is set to `PROFESSOR`.
   - There is no duplicate entry with the same user and research group combination.

**Alternative Test (Manual):**

Prerequisites:

1. A user with a matching `universityId` must exist in the database. (Testdata)
2. Log in to TumApply as admin.

Steps:

1. Use the `POST /api/admin/research-groups` endpoint to create a new research group.
2. Confirm that only one `PROFESSOR` role entry is added for the user with the matching userId ( not universityId) in `user_research_group_roles`
3. Verify that no duplicate roles are inserted in `user_research_group_roles` (ignore already existing testdata)

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

