### PR TITLE
`Development`: Add professor request access form (server-side)

### DIFF
--- a/docs-github/TUMApply API/Admin/Activate Research Group.bru
+++ b/docs-github/TUMApply API/Admin/Activate Research Group.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Activate Research Group
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/research-groups/e9888937-1fae-4495-bd18-17648cf9923e/activate
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/docs-github/TUMApply API/Admin/Create Research Group.bru
+++ b/docs-github/TUMApply API/Admin/Create Research Group.bru
@@ -1,7 +1,7 @@
 meta {
   name: Create Research Group
   type: http
-  seq: 1
+  seq: 4
 }
 
 post {

--- a/docs-github/TUMApply API/Admin/Deny Research Group.bru
+++ b/docs-github/TUMApply API/Admin/Deny Research Group.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Deny Research Group
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/research-groups/00000000-0000-0000-0000-000000000010/deny
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/docs-github/TUMApply API/Admin/Get Draft Research Groups.bru
+++ b/docs-github/TUMApply API/Admin/Get Draft Research Groups.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Draft Research Groups
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/research-groups/draft?pageNumber=0&pageSize=10
+  body: none
+  auth: inherit
+}
+
+params:query {
+  pageNumber: 0
+  pageSize: 10
+}
+
+settings {
+  encodeUrl: true
+}

--- a/docs-github/TUMApply API/Admin/Provision Research Group.bru
+++ b/docs-github/TUMApply API/Admin/Provision Research Group.bru
@@ -1,7 +1,7 @@
 meta {
   name: Provision Research Group
   type: http
-  seq: 2
+  seq: 5
 }
 
 post {

--- a/docs-github/TUMApply API/Admin/Provision ResearchGroup – UserNotFound.bru
+++ b/docs-github/TUMApply API/Admin/Provision ResearchGroup – UserNotFound.bru
@@ -1,7 +1,7 @@
 meta {
   name: Provision ResearchGroup – UserNotFound
   type: http
-  seq: 3
+  seq: 6
 }
 
 post {

--- a/docs-github/TUMApply API/Authentication/Keycloak Token.bru
+++ b/docs-github/TUMApply API/Authentication/Keycloak Token.bru
@@ -32,6 +32,6 @@ auth:oauth2 {
 body:form-urlencoded {
   grant_type: password
   client_id: {{clientId}}
-  username: applicant1
-  password: applicant
+  username: admin1@tumapply.local
+  password: admin
 }

--- a/docs-github/TUMApply API/Research Group/Create Draft-Research Group (Professor Onboarding).bru
+++ b/docs-github/TUMApply API/Research Group/Create Draft-Research Group (Professor Onboarding).bru
@@ -1,0 +1,39 @@
+meta {
+  name: Create Draft-Research Group (Professor Onboarding)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/research-groups/professor-request
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "title": "Prof. Dr.",
+    "firstName": "Max", 
+    "lastName": "Mustermann",
+    "universityID": "ab12cde",
+    "researchGroupHead": "Prof. Dr. Max Mustermann",
+    "researchGroupName": "Advanced Software Engineering Research Group",
+    "abbreviation": "ASERG",
+    "contactEmail": "max.mustermann@tum.de", 
+    "website": "https://www.aserg.tum.de",
+    "school": "Informatics",
+    "description": "Research in software engineering methodologies and tools",
+    "defaultFieldOfStudies": "Computer Science",
+    "street": "Boltzmannstr. 3",
+    "postalCode": "85748",
+    "city": "Garching bei München"
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/main/java/de/tum/cit/aet/core/constants/ResearchGroupState.java
+++ b/src/main/java/de/tum/cit/aet/core/constants/ResearchGroupState.java
@@ -1,0 +1,7 @@
+package de.tum.cit.aet.core.constants;
+
+public enum ResearchGroupState {
+    DRAFT,
+    ACTIVE,
+    DENIED,
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/domain/ResearchGroup.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/domain/ResearchGroup.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.usermanagement.domain;
 
+import de.tum.cit.aet.core.constants.ResearchGroupState;
 import de.tum.cit.aet.core.domain.AbstractAuditingEntity;
 import jakarta.persistence.*;
 import java.util.HashSet;
@@ -60,6 +61,10 @@ public class ResearchGroup extends AbstractAuditingEntity {
 
     @Column(name = "university_id", nullable = false)
     private String universityId;
+
+    @Column(name = "state")
+    @Enumerated(EnumType.STRING)
+    private ResearchGroupState state = ResearchGroupState.DRAFT;
 
     @OneToMany(mappedBy = "researchGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserResearchGroupRole> userRoles = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/usermanagement/dto/ProfessorResearchGroupRequestDTO.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/dto/ProfessorResearchGroupRequestDTO.java
@@ -1,0 +1,30 @@
+package de.tum.cit.aet.usermanagement.dto;
+
+/**
+ * DTO for professor research group creation requests during onboarding.
+ * Contains all fields that a professor can fill in the onboarding form.
+ */
+public record ProfessorResearchGroupRequestDTO(
+    // Required Personal Information
+    String title,
+    String firstName,
+    String lastName,
+    String universityID,
+
+    // Required Research Group Information
+    String researchGroupHead,
+    String researchGroupName,
+
+    // Optional Research Group Information
+    String abbreviation,
+    String contactEmail,
+    String website,
+    String school,
+    String description,
+    String defaultFieldOfStudies,
+
+    // Optional Address Information
+    String street,
+    String postalCode,
+    String city
+) {}

--- a/src/main/java/de/tum/cit/aet/usermanagement/dto/ResearchGroupCreationDTO.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/dto/ResearchGroupCreationDTO.java
@@ -18,5 +18,6 @@ public record ResearchGroupCreationDTO(
     String defaultFieldOfStudies,
     String street,
     String postalCode,
-    String city
+    String city,
+    String state
 ) {}

--- a/src/main/java/de/tum/cit/aet/usermanagement/dto/ResearchGroupDTO.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/dto/ResearchGroupDTO.java
@@ -21,7 +21,8 @@ public record ResearchGroupDTO(
     String defaultFieldOfStudies,
     String street,
     String postalCode,
-    String city
+    String city,
+    String state
 ) {
     /**
      * @param researchGroup the ResearchGroup entity
@@ -44,7 +45,8 @@ public record ResearchGroupDTO(
             researchGroup.getDefaultFieldOfStudies(),
             researchGroup.getStreet(),
             researchGroup.getPostalCode(),
-            researchGroup.getCity()
+            researchGroup.getCity(),
+            researchGroup.getState() != null ? researchGroup.getState().name() : null
         );
     }
 }

--- a/src/main/java/de/tum/cit/aet/usermanagement/repository/ResearchGroupRepository.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/repository/ResearchGroupRepository.java
@@ -1,11 +1,15 @@
 package de.tum.cit.aet.usermanagement.repository;
 
+import de.tum.cit.aet.core.constants.ResearchGroupState;
 import de.tum.cit.aet.core.repository.TumApplyJpaRepository;
 import de.tum.cit.aet.job.domain.Job;
 import de.tum.cit.aet.usermanagement.domain.ResearchGroup;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -27,4 +31,7 @@ public interface ResearchGroupRepository extends TumApplyJpaRepository<ResearchG
 
     boolean existsByNameIgnoreCase(String name);
     Optional<ResearchGroup> findByNameIgnoreCase(String name);
+
+    List<ResearchGroup> findByState(ResearchGroupState state);
+    Page<ResearchGroup> findByState(ResearchGroupState state, Pageable pageable);
 }

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
@@ -17,7 +17,6 @@ import de.tum.cit.aet.usermanagement.repository.ResearchGroupRepository;
 import de.tum.cit.aet.usermanagement.repository.UserRepository;
 import de.tum.cit.aet.usermanagement.repository.UserResearchGroupRoleRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/ResearchGroupService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.usermanagement.service;
 
+import de.tum.cit.aet.core.constants.ResearchGroupState;
 import de.tum.cit.aet.core.dto.PageDTO;
 import de.tum.cit.aet.core.dto.PageResponseDTO;
 import de.tum.cit.aet.core.exception.AccessDeniedException;
@@ -182,6 +183,7 @@ public class ResearchGroupService {
         entity.setPostalCode(dto.postalCode());
         entity.setCity(dto.city());
         entity.setDefaultFieldOfStudies(dto.defaultFieldOfStudies());
+        entity.setState(ResearchGroupState.valueOf(dto.state()));
     }
 
     /**
@@ -200,64 +202,8 @@ public class ResearchGroupService {
         group.setAbbreviation(StringUtil.normalize(dto.abbreviation(), false));
         group.setWebsite(StringUtil.normalize(dto.website(), false));
         group.setSchool(StringUtil.normalize(dto.school(), false));
+        group.setState(ResearchGroupState.valueOf(dto.state()));
         return group;
-    }
-
-    /**
-     * Creates a research group if the current user is professor; returns existing if found.
-     *
-     * @param dto the research group creation request DTO
-     * @return the created or existing research group
-     */
-    @Transactional
-    public ResearchGroup createResearchGroup(ResearchGroupCreationDTO dto) {
-        Optional<ResearchGroup> existing = researchGroupRepository.findByUniversityId(dto.universityId());
-        if (existing.isPresent()) {
-            log.info(
-                "AUDIT research-group.create reused by={} groupId={} name={} headName={} universityId={}",
-                currentUserService.getUserId(),
-                existing.get().getResearchGroupId(),
-                dto.name(),
-                dto.headName(),
-                dto.universityId()
-            );
-            throw new ResourceAlreadyExistsException(
-                "ResearchGroup for head with universityId '" + dto.universityId() + "' already exists"
-            );
-        }
-
-        ResearchGroup newResearchGroup = buildResearchGroupFromDTO(dto);
-        ResearchGroup saved = researchGroupRepository.save(newResearchGroup);
-
-        User headUser = userRepository
-            .findByUniversityIdIgnoreCase(dto.universityId())
-            .orElseThrow(() -> new EntityNotFoundException("User with universityId '%s' not found".formatted(dto.universityId())));
-
-        headUser.setResearchGroup(saved);
-        userRepository.save(headUser);
-
-        var existingMapping = userResearchGroupRoleRepository.findByUserAndResearchGroup(headUser, saved);
-        if (existingMapping.isEmpty()) {
-            UserResearchGroupRole mapping = new UserResearchGroupRole();
-            mapping.setUser(headUser);
-            mapping.setResearchGroup(saved);
-            mapping.setRole(UserRole.PROFESSOR);
-            userResearchGroupRoleRepository.save(mapping);
-        } else if (existingMapping.get().getRole() != UserRole.PROFESSOR) {
-            existingMapping.get().setRole(UserRole.PROFESSOR);
-            userResearchGroupRoleRepository.save(existingMapping.get());
-        }
-
-        log.info(
-            "AUDIT research-group.create created by={} groupId={} name={} headName={} universityId={}",
-            currentUserService.getUserId(),
-            saved.getResearchGroupId(),
-            dto.name(),
-            dto.headName(),
-            dto.universityId()
-        );
-
-        return saved;
     }
 
     /**
@@ -315,5 +261,134 @@ public class ResearchGroupService {
         );
 
         return group;
+    }
+
+    /**
+     * Activates a DRAFT research group (admin only).
+     * Changes the state from DRAFT to ACTIVE, allowing the research group to be used.
+     * This operation can only be performed on research groups in DRAFT state.
+     *
+     * @param researchGroupId the unique identifier of the research group to activate
+     * @return the activated research group with updated state
+     * @throws EntityNotFoundException if the research group does not exist
+     * @throws IllegalStateException if the research group is not in DRAFT state
+     */
+    @Transactional
+    public ResearchGroup activateResearchGroup(UUID researchGroupId) {
+        ResearchGroup group = researchGroupRepository.findByIdElseThrow(researchGroupId);
+        if (group.getState() != ResearchGroupState.DRAFT) {
+            throw new IllegalStateException("Only DRAFT groups can be activated");
+        }
+        group.setState(ResearchGroupState.ACTIVE);
+        ResearchGroup saved = researchGroupRepository.save(group);
+
+        log.info(
+            "AUDIT research-group.activate by={} groupId={} name={}",
+            currentUserService.getUserId(),
+            researchGroupId,
+            group.getName()
+        );
+
+        return saved;
+    }
+
+    /**
+     * Denies a DRAFT research group (admin only).
+     * Changes the state from DRAFT to DENIED, preventing the research group from being used.
+     * This operation can only be performed on research groups in DRAFT state.
+     *
+     * @param researchGroupId the unique identifier of the research group to deny
+     * @return the denied research group with updated state
+     * @throws EntityNotFoundException if the research group does not exist
+     * @throws IllegalStateException if the research group is not in DRAFT state
+     */
+    @Transactional
+    public ResearchGroup denyResearchGroup(UUID researchGroupId) {
+        ResearchGroup group = researchGroupRepository.findByIdElseThrow(researchGroupId);
+        if (group.getState() != ResearchGroupState.DRAFT) {
+            throw new IllegalStateException("Only DRAFT groups can be denied");
+        }
+        group.setState(ResearchGroupState.DENIED);
+        ResearchGroup saved = researchGroupRepository.save(group);
+
+        log.info("AUDIT research-group.deny by={} groupId={} name={}", currentUserService.getUserId(), researchGroupId, group.getName());
+
+        return saved;
+    }
+
+    /**
+     * Gets all DRAFT research groups for admin review.
+     * Returns a paginated list of research groups that are waiting for admin approval.
+     * Research groups are sorted by name in ascending order.
+     *
+     * @param pageDTO pagination information including page number and page size
+     * @return paginated response containing DRAFT research groups and total count
+     */
+    public PageResponseDTO<ResearchGroupDTO> getDraftResearchGroups(PageDTO pageDTO) {
+        Pageable pageable = PageRequest.of(pageDTO.pageNumber(), pageDTO.pageSize(), Sort.by(Sort.Direction.ASC, "name"));
+        Page<ResearchGroup> page = researchGroupRepository.findByState(ResearchGroupState.DRAFT, pageable);
+        return new PageResponseDTO<>(page.get().map(ResearchGroupDTO::getFromEntity).toList(), page.getTotalElements());
+    }
+
+    /**
+     * Creates a research group request from a professor during onboarding.
+     * The research group starts in DRAFT state and needs admin approval.
+     *
+     * @param request the professor's research group request
+     * @return the created research group in DRAFT state
+     */
+    @Transactional
+    public ResearchGroup createProfessorResearchGroupRequest(ProfessorResearchGroupRequestDTO request) {
+        User currentUser = currentUserService.getUser();
+
+        if (currentUser.getResearchGroup() != null) {
+            throw new IllegalStateException("User already belongs to a research group");
+        }
+
+        if (researchGroupRepository.existsByNameIgnoreCase(request.researchGroupName())) {
+            throw new ResourceAlreadyExistsException("Research group with name '" + request.researchGroupName() + "' already exists");
+        }
+
+        // TODO: should we update existing user data with the provided info?
+        // if (request.firstName() != null) currentUser.setFirstName(request.firstName());
+        // if (request.lastName() != null) currentUser.setLastName(request.lastName());
+        // if (request.universityID() != null) currentUser.setUniversityId(request.universityID());
+
+        ResearchGroup researchGroup = new ResearchGroup();
+        researchGroup.setName(StringUtil.normalize(request.researchGroupName(), false));
+        researchGroup.setUniversityId(request.universityID());
+        researchGroup.setHead(request.researchGroupHead());
+        researchGroup.setAbbreviation(StringUtil.normalize(request.abbreviation(), false));
+        researchGroup.setEmail(request.contactEmail());
+        researchGroup.setWebsite(request.website());
+        researchGroup.setSchool(request.school());
+        researchGroup.setDescription(request.description());
+        researchGroup.setDefaultFieldOfStudies(request.defaultFieldOfStudies());
+        researchGroup.setStreet(request.street());
+        researchGroup.setPostalCode(request.postalCode());
+        researchGroup.setCity(request.city());
+        researchGroup.setState(ResearchGroupState.DRAFT);
+
+        ResearchGroup saved = researchGroupRepository.save(researchGroup);
+
+        userRepository.save(currentUser);
+
+        currentUser.setResearchGroup(saved);
+        userRepository.save(currentUser);
+
+        UserResearchGroupRole role = new UserResearchGroupRole();
+        role.setUser(currentUser);
+        role.setResearchGroup(saved);
+        role.setRole(UserRole.PROFESSOR);
+        userResearchGroupRoleRepository.save(role);
+
+        log.info(
+            "AUDIT professor-onboarding.create-research-group userId={} groupId={} name={}",
+            currentUser.getUserId(),
+            saved.getResearchGroupId(),
+            request.researchGroupName()
+        );
+
+        return saved;
     }
 }

--- a/src/main/java/de/tum/cit/aet/usermanagement/web/AdminResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/AdminResource.java
@@ -22,17 +22,6 @@ public class AdminResource {
     private final ResearchGroupService researchGroupService;
 
     /**
-     * Creates a new research group manually based on the provided data.
-     *
-     * @param request the DTO containing the information required to create a research group
-     * @return HTTP 200 OK with the created {@link ResearchGroup}
-     */
-    @PostMapping("/research-groups")
-    public ResponseEntity<ResearchGroup> createResearchGroup(@Valid @RequestBody ResearchGroupCreationDTO request) {
-        return ResponseEntity.ok(researchGroupService.createResearchGroup(request));
-    }
-
-    /**
      * Provisions a new research group, potentially including additional setup steps.
      *
      * @param request the DTO containing the information required to provision a research group

--- a/src/main/java/de/tum/cit/aet/usermanagement/web/AdminResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/AdminResource.java
@@ -1,7 +1,6 @@
 package de.tum.cit.aet.usermanagement.web;
 
 import de.tum.cit.aet.usermanagement.domain.ResearchGroup;
-import de.tum.cit.aet.usermanagement.dto.ResearchGroupCreationDTO;
 import de.tum.cit.aet.usermanagement.dto.ResearchGroupProvisionDTO;
 import de.tum.cit.aet.usermanagement.service.ResearchGroupService;
 import jakarta.validation.Valid;

--- a/src/main/resources/config/liquibase/changelog/00000000000009_add_research_group_state.xml
+++ b/src/main/resources/config/liquibase/changelog/00000000000009_add_research_group_state.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-research-group-state" author="sehmuelwagner">
+        <addColumn tableName="research_groups">
+            <column name="state" type="varchar(20)" defaultValue="DRAFT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -13,6 +13,7 @@
   <include file="changelog/00000000000006_add_user_settings.xml" relativeToChangelogFile="true"/>
   <include file="changelog/00000000000007_alter_jobs_make_location_nullable.xml" relativeToChangelogFile="true"/>
   <include file="changelog/00000000000008_add_university_id.xml" relativeToChangelogFile="true"/>
+  <include file="changelog/00000000000009_add_research_group_state.xml" relativeToChangelogFile="true"/>
 
   <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
   <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->


### PR DESCRIPTION
‼️ THIS PR INCLUDES DATABASE CHANGES. DO NOT DEPLOY TO TEST SERVER.‼️

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).


#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311718/Performance+Guidelines) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311877/Server+Guidelines).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context

his change implements the **Professor Onboarding** feature to automate the research group creation process. Previously, professors had to send research group requests via email, which were then manually processed by administrators. This PR introduces a streamlined, automated workflow where professors can directly submit their research group requests through the application, and administrators can review and approve them via the API.

The implementation adds state management to research groups (DRAFT/ACTIVE/DENIED) and provides dedicated endpoints for the professor onboarding flow, improving efficiency and reducing manual administrative work.

### Description

#### Database Changes
- Added `state` column to `research_groups` table via Liquibase migration (`00000000000009_add_research_group_state.xml`)
- Default value set to "DRAFT" for existing research groups, "ACTIVE" for new admin-created groups

#### Entity Changes
- Extended `ResearchGroup.java` with `state` field using `@Enumerated(EnumType.STRING)`
- Added `ResearchGroupState` enum with values: DRAFT, ACTIVE, DENIED

#### Service Changes
- Added `createProfessorResearchGroupRequest()` method for professor onboarding
- Added `activateResearchGroup()` method for admin approval
- Added `denyResearchGroup()` method for admin rejection
- Added `getDraftResearchGroups()` method for admin review with pagination
- All methods include proper validation, transaction management, and audit logging

#### API Changes
- `POST /api/research-groups/professor-request` - Creates research group in DRAFT state (authenticated users)
- `GET /api/research-groups/draft` - Lists all DRAFT research groups for admin review (ADMIN role required)
- `POST /api/research-groups/{id}/activate` - Activates DRAFT research group (ADMIN role required)
- `POST /api/research-groups/{id}/deny` - Denies DRAFT research group (ADMIN role required)

#### DTO Changes
- Created `ProfessorResearchGroupRequestDTO` with all professor form fields
- Extended existing DTOs to support state field where appropriate

#### Repository Changes
- Added `findByState()` and `findByState(Pageable)` methods to `ResearchGroupRepository`

### Steps for Testing

Prerequisites:

1. Checkout branch and start the server locally
2. Ensure database migrations have run
3. Open Bruno and load the collection from `docs-github/TUMApply API/`
4. Verify that for the three endpoints in the admin folder, they only **succeed** if logged in as an **admin** and fail if not. The endpoint under the Research-Group folder should work if **authenticated**, as professor should be able to send their request for a research group **before** having the **Professor** role


### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Test Coverage

<!-- Please add the test coverages for all changed files modified in this PR here. -->
<!-- You can execute the tests locally (see build.gradle and package.json) or look into the corresponding artefacts. -->
<!-- The line coverage must be above 90% for changes files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->


