### PR TITLE
`General`: Add margin to lists in application detail page

### DIFF
--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -352,6 +352,7 @@
 .description-text ul,
 .text-card ol,
 .text-card ul,
+.detail-card ol,
 .detail-card ul {
   margin-left: 2rem;
   list-style: initial;


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

This PR fixes a bug that there is not enough left-margin for ordered lists in the Application Detail Page and it does not look coherent with the remaining text.

### Description

Added left-margin to the ordered lists in the detail-card class.

### Steps for Testing

1. Login as an applicant
2. FIll out the application creation form
3. Add an ordered list to an editor field in the form
4. Go to the Summary Page
5. confirm that there is a sufficient left-margin between the field and the ordered list

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Test Coverage

### Screenshots

Before:
<img width="359" height="218" alt="image" src="https://github.com/user-attachments/assets/0ece26db-48ed-4336-8833-2f652004a809" />

After:
<img width="386" height="257" alt="image" src="https://github.com/user-attachments/assets/783bc1f0-47c5-4ae6-91d0-e3b7f5aeae7e" />