### PR TITLE
`General`: Fix liquibaseDropAll command

### DIFF
--- a/gradle/liquibase.gradle
+++ b/gradle/liquibase.gradle
@@ -53,10 +53,23 @@ tasks.register("liquibaseUpdateCli", JavaExec) {
   args "update"   // rely on liquibase.properties for connection settings
 }
 
+tasks.register("liquibaseDropAllCli", JavaExec) {
+  group = "liquibase"
+  description = "Liquibase dropAll via CLI"
+  classpath = sourceSets.main.runtimeClasspath + configurations.liquibaseRuntime
+  mainClass = "liquibase.integration.commandline.LiquibaseCommandLine"
+  args "dropAll"
+}
+
 // keep the public name and bypass the plugin actions
 plugins.withId("org.liquibase.gradle") {
   tasks.named("liquibaseUpdate").configure {
     dependsOn tasks.named("liquibaseUpdateCli")
+    onlyIf { false }
+  }
+
+  tasks.named("liquibaseDropAll").configure {
+    dependsOn tasks.named("liquibaseDropAllCli")
     onlyIf { false }
   }
 }


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

The new Gradle version needs some adaptation for all liquibase commands as the plugin has some open issues. LiquibaseDropAll has not beed adapated yet.

### Description

This PR fixes liquibaseDropAll command

### Steps for Testing

Prerequisites:

1. Execute the command ./gradlew liquibaseDropAll locally
2. Check if build successful

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1