### PR TITLE
`General`: Fix my members page api access bug

### DIFF
--- a/src/main/java/de/tum/cit/aet/usermanagement/web/ResearchGroupResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/ResearchGroupResource.java
@@ -53,7 +53,7 @@ public class ResearchGroupResource {
      * @return paginated list of members
      */
     @GetMapping("/members")
-    @Admin
+    @ProfessorOrAdmin
     public ResponseEntity<PageResponseDTO<UserShortDTO>> getResearchGroupMembers(@ParameterObject @Valid @ModelAttribute PageDTO pageDTO) {
         log.info("GET /api/research-groups/members?pageNumber={}&pageSize={}", pageDTO.pageNumber(), pageDTO.pageSize());
         PageResponseDTO<UserShortDTO> members = researchGroupService.getResearchGroupMembers(pageDTO);


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

- my members page throws an error whenever a professor tries to access it

### Description

- changed access to ProfessorOrAdmin

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Professor
2. Go to My Members Page
3. Should not display a toast message but show the members table

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1
