### PR TITLE
`General`: Make openapi workflow deterministic

### DIFF
--- a/src/main/webapp/app/generated/api/profOnboardingResourceApi.service.ts
+++ b/src/main/webapp/app/generated/api/profOnboardingResourceApi.service.ts
@@ -134,6 +134,54 @@ export class ProfOnboardingResourceApiService extends BaseService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
+    public getOnboardingStatus(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<ProfOnboardingDTO>;
+    public getOnboardingStatus(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<ProfOnboardingDTO>>;
+    public getOnboardingStatus(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<ProfOnboardingDTO>>;
+    public getOnboardingStatus(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'application/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/me/prof-onboarding/status`;
+        return this.httpClient.request<ProfOnboardingDTO>('get', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
     public remindLater(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<any>;
     public remindLater(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
     public remindLater(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined, context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;

--- a/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.html
+++ b/src/main/webapp/app/shared/pages/landing-page/doctoral-journey-section/doctoral-journey-section.component.html
@@ -4,7 +4,15 @@
   </div>
   <div class="text-container">
     <h2 class="title" jhiTranslate="landingPage.doctoralJourney.headline"></h2>
-    <p class="text" jhiTranslate="landingPage.doctoralJourney.text"></p>
+    <p
+      class="text"
+      jhiTranslate="landingPage.doctoralJourney.text"
+      [translateValues]="{
+        startLink:
+          '<a class=&quot;text-primary&quot; href=&quot;https://www.gs.tum.de/en/gs/doctorate-at-tum/&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot;>',
+        endLink: '</a>',
+      }"
+    ></p>
     <jhi-button-group [data]="buttons()" />
   </div>
 </div>

--- a/src/main/webapp/i18n/de/landingPage.json
+++ b/src/main/webapp/i18n/de/landingPage.json
@@ -1,15 +1,15 @@
 {
   "landingPage": {
     "hero": {
-      "headline": "Beginne deine Promotion an der TUM",
-      "subline": "Die TUM bietet ein weltweit führendes Umfeld für deine Promotion.",
-      "button": "Offene Stellen"
+      "headline": "Bewirb dich für deine Promotion an der TUM CIT",
+      "subline": "TUMapply ist dein Zugang zur Promotion an der School of Computation, Information and Technology",
+      "button": "Stellen durchsuchen"
     },
     "doctoralJourney": {
-      "headline": "Deine Promotionsreise an der TUM",
-      "text": "Die Technische Universität München (TUM) ist fest davon überzeugt, dass Talent die Grundlage für exzellente akademische Ausbildung in der Promotion ist. Die TUM blickt auf eine lange Tradition in der Förderung von exzellenten Promovierenden zurück, die sich der Lösung gesellschaftlicher Herausforderungen widmen. Unterstützt von führenden Forschenden investiert die TUM umfassend in die Förderung junger Wissenschaftler, um selbstständig arbeiten und ihre Karriere starten zu können.",
+      "headline": "Starte deine Promotionsreise an der TUM CIT",
+      "text": "TUMapply ist dein Einstiegspunkt in die Promotion an der Technischen Universität München. Hier kannst du offene Stellen in allen Fachbereichen der TUM School of Computation, Information and Technology entdecken, passende Möglichkeiten finden und deine Bewerbung direkt online einreichen. <br> Fragst du dich, warum die TUM der richtige Ort für deine Promotion ist? Mit unserem lebendigen Forschungsumfeld, globalen Netzwerken und starken Unterstützungsstrukturen bietet die TUM ideale Bedingungen, um deine akademischen Ziele zu verfolgen. Die {{startLink}}TUM Graduate School{{endLink}} begleitet dich während des gesamten Prozesses – von den Voraussetzungen und Anforderungen bis hin zur Entwicklung deines Forschungsprofils.",
       "button1": "Warum TUM?",
-      "button2": "Mehr erfahren"
+      "button2": "Promotion an der TUM"
     },
     "applicationSteps": {
       "headline": "Deine Bewerbung in 5 Schritten",

--- a/src/main/webapp/i18n/en/landingPage.json
+++ b/src/main/webapp/i18n/en/landingPage.json
@@ -1,15 +1,15 @@
 {
   "landingPage": {
     "hero": {
-      "headline": "Start Your Doctorate at TUM",
-      "subline": "TUM offers a world-class environment for your doctoral journey.",
+      "headline": "Apply for your Doctorate at TUM CIT",
+      "subline": "TUMapply is your gateway to doctoral research at the School of Computation, Information and Technology",
       "button": "Browse Positions"
     },
     "doctoralJourney": {
-      "headline": "Start Your Doctoral Journey at TUM",
-      "text": "The Technical University of Munich (TUM) is firmly grounded in the belief that talent is our asset to cultivating academic excellence in doctoral education. TUM boasts a long and proud tradition of fostering world-class doctoral candidates committed to finding solutions to the diverse challenges of our time. Supported by prominent researchers in their fields, TUM invests substantial resources in helping early-stage scientists to work independently and kick-start their careers.",
+      "headline": "Start your Doctoral Journey at TUM CIT",
+      "text": "TUMApply is your entry point to doctoral research at the Technical University of Munich. Here you can explore open positions across all departments of the TUM School of Computation, Information and Technology, discover opportunities that fit your interests, and submit your application directly online. <br> Wondering what makes TUM the right place for your doctorate? With our vibrant research environment, global networks, and strong support structures, TUM offers the ideal conditions to pursue your academic goals. The {{startLink}}TUM Graduate School{{endLink}} accompanies you throughout the process. From meeting prerequisites and navigating requirements to developing your research profile.",
       "button1": "Why TUM?",
-      "button2": "Find out more"
+      "button2": "Doctorate at TUM"
     },
     "applicationSteps": {
       "headline": "Your Application in 5 Steps",


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

#1025 
Previously, after adding the "-f" option for the OpenAPI workflow, it sometimes ended in an endless loop (see issue). This PR tries to fix this by sorting the properties in schemas.

### Description

- Added `sortComponentsAndPaths()` call in `pruneOpenApiSpec` task to ensure deterministic YAML generation
- Extended `sortComponentsAndPaths()` function to sort schema properties alphabetically, not just top-level schema names
- Added new `sortSchemaProperties()` helper function to recursively sort properties within each schema definition

### Steps for Testing

Prerequisites:

1. Create a draft pull request
2. Add a test endpoint or just make a small change in an pre-existent one.
3. Check that no other files are generated except the one regarding the modified endpoint.
4. Check that openAPI workflow does not end in an endless loop by commiting changes again and again (only changing the order of properties)

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1