### PR TITLE
`General`: Fix title not displayed in application creation when not logged in

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -421,7 +421,9 @@ export default class ApplicationCreationFormComponent {
             this.title.set(jobDetails.title);
           }
         })
-        .catch(() => {});
+        .catch(() => {
+          // Silently ignore errors when fetching job title - this is non-critical for the application flow
+        });
     } else {
       this.showInitErrorMessage(`${applyflow}.missingJobIdUnauthenticated`);
     }


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

- When not logged in, the title in the application form is not visible

### Description

- Fetch job title regardless

### Steps for Testing

Prerequisites:

1. Navigate to Find Jobs and click on apply
2. Title should be visible to the user 
3. Check that title is also visible when logged in

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1