### PR TITLE
`General`: Fix error in translation key for onboarding form

### DIFF
--- a/src/main/webapp/app/service/onboarding-orchestrator.service.ts
+++ b/src/main/webapp/app/service/onboarding-orchestrator.service.ts
@@ -5,6 +5,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { filter, map, startWith, switchMap, take } from 'rxjs/operators';
 import { NavigationEnd, Router } from '@angular/router';
+import { ONBOARDING_FORM_DIALOG_CONFIG } from 'app/shared/constants/onboarding-dialog.constants';
 
 import { OnboardingDialog } from '../shared/components/molecules/onboarding-dialog/onboarding-dialog';
 import { AccountService } from '../core/auth/account.service';
@@ -70,10 +71,8 @@ export class OnboardingOrchestratorService {
         this.opened = true;
 
         this.dialog.open(OnboardingDialog, {
+          ...ONBOARDING_FORM_DIALOG_CONFIG,
           header: this.translate.instant('onboarding.title'),
-          modal: true,
-          closable: true,
-          width: '80vw',
         });
       },
       { injector: this.injector },

--- a/src/main/webapp/app/shared/components/molecules/onboarding-dialog/employee-request-access-form/employee-request-access-form.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/onboarding-dialog/employee-request-access-form/employee-request-access-form.component.ts
@@ -11,6 +11,7 @@ import TranslateDirective from 'app/shared/language/translate.directive';
 import { ToastService } from 'app/service/toast-service';
 import { ResearchGroupResourceApiService } from 'app/generated/api/researchGroupResourceApi.service';
 import { ProfOnboardingResourceApiService } from 'app/generated/api/profOnboardingResourceApi.service';
+import { ONBOARDING_FORM_DIALOG_CONFIG } from 'app/shared/constants/onboarding-dialog.constants';
 
 import { OnboardingDialog } from '../onboarding-dialog';
 
@@ -63,17 +64,8 @@ export class EmployeeRequestAccessFormComponent {
 
     // Reopen the main onboarding dialog
     this.dialogService.open(OnboardingDialog, {
-      header: this.translate.instant('onboarding.dialog.title'),
-      modal: true,
-      closable: true,
-      dismissableMask: false,
-      width: '56.25rem',
-      style: {
-        'max-width': '95vw',
-        'background-color': 'white',
-        'border-radius': '0.5rem',
-      },
-      focusOnShow: false,
+      ...ONBOARDING_FORM_DIALOG_CONFIG,
+      header: this.translate.instant('onboarding.title'),
     });
   }
 

--- a/src/main/webapp/app/shared/components/molecules/onboarding-dialog/onboarding-dialog.ts
+++ b/src/main/webapp/app/shared/components/molecules/onboarding-dialog/onboarding-dialog.ts
@@ -6,6 +6,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MessageModule } from 'primeng/message';
 import { firstValueFrom } from 'rxjs';
 import { DialogService } from 'primeng/dynamicdialog';
+import { ONBOARDING_FORM_DIALOG_CONFIG } from 'app/shared/constants/onboarding-dialog.constants';
 
 import { ButtonComponent } from '../../atoms/button/button.component';
 import TranslateDirective from '../../../language/translate.directive';
@@ -35,17 +36,8 @@ export class OnboardingDialog {
       this.ref?.close();
 
       this.dialogService.open(ProfessorRequestAccessFormComponent, {
+        ...ONBOARDING_FORM_DIALOG_CONFIG,
         header: this.translate.instant('onboarding.professorRequest.dialogTitle'),
-        modal: true,
-        closable: true,
-        dismissableMask: false,
-        width: '56.25rem',
-        style: {
-          'max-width': '95vw',
-          'background-color': 'white',
-          'border-radius': '0.5rem',
-        },
-        focusOnShow: false,
       });
     } else {
       void firstValueFrom(this.api.confirmOnboarding()).catch();
@@ -57,17 +49,8 @@ export class OnboardingDialog {
     this.ref?.close();
 
     this.dialogService.open(EmployeeRequestAccessFormComponent, {
+      ...ONBOARDING_FORM_DIALOG_CONFIG,
       header: this.translate.instant('onboarding.employeeRequest.dialogTitle'),
-      modal: true,
-      closable: true,
-      dismissableMask: false,
-      width: '56.25rem',
-      style: {
-        'max-width': '95vw',
-        'background-color': 'white',
-        'border-radius': '0.5rem',
-      },
-      focusOnShow: false,
     });
   }
 }

--- a/src/main/webapp/app/shared/constants/onboarding-dialog.constants.ts
+++ b/src/main/webapp/app/shared/constants/onboarding-dialog.constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared configuration constants for onboarding dialogs.
+ */
+export const ONBOARDING_FORM_DIALOG_CONFIG = {
+  modal: true,
+  closable: true,
+  dismissableMask: false,
+  width: '56.25rem',
+  style: {
+    'max-width': '95vw',
+    'background-color': 'white',
+    'border-radius': '0.5rem',
+  },
+  focusOnShow: false,
+} as const;


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).

### Motivation and Context

Solves #1087 

### Description

- Fixed translation key error: Changed 'onboarding.dialog.title' to 'onboarding.title' in employee request access form to match existing translation keys
- Centralized dialog configuration: Created ONBOARDING_FORM_DIALOG_CONFIG constant

### Steps for Testing

Prerequisites:

1. Go to TumApply professor landing page
2. Log in as applicant
3. In onboarding form, press button 'I am an employee'
4. Press 'back' button
5. Translation key for the form title should show up

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

