### PR TITLE
`General`: Fix professor onboarding dialog scroll state

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/button/button.component.html
+++ b/src/main/webapp/app/shared/components/atoms/button/button.component.html
@@ -17,6 +17,7 @@
     [styleClass]="buttonClass()"
     [type]="type()"
     [variant]="variant()"
+    [buttonProps]="{ autofocus: autofocus() }"
   >
     @if (icon() !== undefined) {
       <fa-icon [icon]="[iconPrefix(), icon() ?? '']" />

--- a/src/main/webapp/app/shared/components/atoms/button/button.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/button/button.component.ts
@@ -45,6 +45,7 @@ export class ButtonComponent {
   fullWidth = input<boolean>(false);
   type = input<'button' | 'submit' | 'reset'>('button');
   loading = input<boolean>(false);
+  autofocus = input<boolean>(false);
   size = input<ButtonSize>('lg');
 
   readonly faArrowUpRightFromSquare = faArrowUpRightFromSquare;


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

- When opening the onboarding dialog form for professors, the content immediately scrolls to the bottom

### Description

- Disable autofocus for buttons and propagate to primeng focus

### Steps for Testing

Prerequisites:

1. Navigate to professor landing page and login as applicant (e.g. external@uni.de)
2. Open research group form
3. Content should stay at top and not scroll to bottom

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1