### PR TITLE
`General`: Add document viewer client tests

### DIFF
--- a/src/test/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.spec.ts
+++ b/src/test/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.spec.ts
@@ -136,14 +136,6 @@ describe('DocumentViewerComponent', () => {
   });
 
   describe('documentDictionaryId input changes', () => {
-    it('should initialize document when documentDictionaryId is set', async () => {
-      cacheService.get = vi.fn().mockReturnValue(mockSafeUrl);
-      await comp.initDocument();
-
-      expect(cacheService.get).toHaveBeenCalledWith('doc-123');
-      expect(comp.sanitizedBlobUrl()).toBe(mockSafeUrl);
-    });
-
     it('should handle document with different IDs sequentially', async () => {
       const mockBlob = new ArrayBuffer(100);
       const mockDocInfo2 = createMockDocumentInfo({ id: 'doc-2' });


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines)

### Description

Client tests for the document viewer atomic component.

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

### Test Coverage

<img width="1149" height="36" alt="image" src="https://github.com/user-attachments/assets/13a91ea1-593a-45d7-9745-e0ac663e0c5e" />


