### PR TITLE
`General`: Remove ring effect input bar

### DIFF
--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
@@ -4,7 +4,7 @@
       <p-inputicon>
         <fa-icon class="icon" [icon]="['fas', 'search']" />
       </p-inputicon>
-      <input type="text" pInputText [placeholder]="searchText()" [(ngModel)]="inputText" (input)="onSearch()" />
+      <input class="focus:ring-0" type="text" pInputText [placeholder]="searchText()" [(ngModel)]="inputText" (input)="onSearch()" />
     </p-iconfield>
     <div class="filter-sort flex items-center flex-wrap gap-4">
       @if (filters().length > 0) {


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Solves #1176.

### Description

- Removes ring effect keeping highlight for search filter sort bar consistent

### Steps for Testing

Prerequisites:

1. Go to "Find positions"
2. Click on search field
3. Check that no big highlight/ring effects shows up anymore

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage

### Screenshots

<img width="773" height="197" alt="Screenshot 2025-11-07 at 16 31 00" src="https://github.com/user-attachments/assets/9ae0b9bd-86fc-4ee7-aca9-aba290f4b553" />

<img width="652" height="148" alt="Screenshot 2025-11-07 at 16 31 07" src="https://github.com/user-attachments/assets/eec44366-9788-4f57-9011-916ea6898483" />

