### PR TITLE
`General`: Allow setting initial datepicker view

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
@@ -93,6 +93,7 @@
         (selectedDateChange)="setDateOfBirth($event)"
         [minDate]="minDate"
         [maxDate]="maxDate"
+        [defaultDate]="defaultBirthDate"
       />
     </div>
   </div>

--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
@@ -103,6 +103,7 @@ export default class ApplicationCreationPage1Component {
     const today = new Date();
     return new Date(today.getFullYear() - 18, today.getMonth(), today.getDate());
   })(); // ensures minimum age of 18
+  readonly defaultBirthDate = new Date(2000, 0, 1);
 
   selectGenderLocal = selectGender;
   selectLanguageLocal = selectLanguage;

--- a/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.html
+++ b/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.html
@@ -31,6 +31,7 @@
     [disabled]="disabled()"
     [minDate]="effectiveMinDate()"
     [maxDate]="maxDate()"
+    [defaultDate]="defaultDate()"
     [showButtonBar]="true"
     [style]="{ width: width() }"
     class="custom-datepicker"

--- a/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.ts
@@ -44,6 +44,11 @@ export class DatePickerComponent {
   maxDate = input<Date | undefined>(undefined);
 
   /**
+   * Default date to show in calendar when opening (does not set the value, just the view)
+   */
+  defaultDate = input<Date | null>(null);
+
+  /**
    * Emits ISO date string ('YYYY-MM-DD') when user selects a date
    */
   selectedDateChange = output<string | undefined>();


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

When selecting dates far in the past (for example, a user’s birthdate), the calendar always opens on the current month.
This requires many clicks to navigate backward through months and years, which is inconvenient and time-consuming.

### Description

This PR:

- adds an optional `defaultDate` input to datepicker component allowing control over which date the calendar initially opens on (without setting the value)
- for birthdate: date set to 1.1.2000

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant or unauthenticated
2. Check that, if date not already filled, datepicker view opens on year 2000 for birthdate
3. Check that datepicker view opens on year 2000 after clearing date for birthdate

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1
