### PR TITLE
`General`: Fix section detail card rendered text styling

### DIFF
--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -341,7 +341,8 @@
 .link,
 .description-text a,
 .text-card a,
-.detail-card a {
+.detail-card a,
+.section-detail-card a {
   color: var(--p-primary-color);
 
   &:hover {
@@ -366,7 +367,9 @@
 .text-card ol,
 .text-card ul,
 .detail-card ol,
-.detail-card ul {
+.detail-card ul,
+.section-detail-card ul,
+.section-detail-card ol {
   margin-left: 2rem;
   list-style: initial;
 }


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

### Motivation and Context

Text rendered from the editor with section-detail-card css class on detail pages fails to apply the expected formatting styles (for example, bullet points are not displayed correctly).

### Description

This PR:

- adds section-detail-card to the global scss styling classes

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant or Professor and view the job/application detail page with styled editor text (bullet points)

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots
<img width="830" height="738" alt="Screenshot 2025-11-11 at 16 28 08" src="https://github.com/user-attachments/assets/fd36640d-8970-4875-b037-2918ac419d9d" />

