### PR TITLE
`General`: Adjust login card styling in job detail view 

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/confirm-dialog/confirm-dialog.scss
+++ b/src/main/webapp/app/shared/components/atoms/confirm-dialog/confirm-dialog.scss
@@ -29,5 +29,4 @@
   box-shadow: none;
   border: none;
   max-width: 45rem;
-  width: 100%;
 }

--- a/src/main/webapp/app/shared/components/templates/auth-card/auth-card.component.scss
+++ b/src/main/webapp/app/shared/components/templates/auth-card/auth-card.component.scss
@@ -1,4 +1,5 @@
 .login-card {
+  position: relative;
   border-radius: 0.75rem;
   background: var(--p-background-surface);
   width: auto;


### PR DESCRIPTION

<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).


#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The login card in the job detail view was disproportionately large and did not match the styling of the auth card on the homepage. Additionally, the login button was misaligned due to incorrect positioning.

Fixes: https://github.com/ls1intum/tum-apply/issues/1343

### Description

<!-- Describe your changes in detail -->
I reduced the overall card size by removing the width: 100% property from p.dialog, which previously caused the login card to appear oversized. I also corrected the card alignment by changing its positioning to relative, ensuring the login card is now properly centered and visually consistent with the auth card on the homepage.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Navigate to Job-detail view in TUMApply
2. Log in 
3. Verify that the login card matches the appearance and layout of the auth card on the homepage.
4. Verify that other p-dialog pages are not affected or visually broken by the changes. 

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before
<img width="1706" height="745" alt="Bildschirmfoto 2025-11-25 um 11 28 11" src="https://github.com/user-attachments/assets/c0c32fd8-f14f-4cc8-b921-9462dd9f5379" />
After 
<img width="1702" height="791" alt="Bildschirmfoto 2025-11-25 um 12 45 24" src="https://github.com/user-attachments/assets/b2d064b9-bde1-4930-b1f4-689446466e29" />

