### PR TITLE
`General`: Fix toast error for default images

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -503,9 +503,12 @@ export class JobCreationFormComponent {
       const user = this.accountService.loadedUser();
       const researchGroupId = user?.researchGroup?.researchGroupId;
 
-      // Load default images
-      const defaults = await firstValueFrom(this.imageResourceService.getDefaultJobBanners(researchGroupId));
-      this.defaultImages.set(defaults);
+      try {
+        const defaults = await firstValueFrom(this.imageResourceService.getDefaultJobBanners(researchGroupId));
+        this.defaultImages.set(defaults);
+      } catch {
+        // If loading fails (e.g., department not set), don't show any default images and don't show error toast
+      }
 
       // Load research group's custom images
       const researchGroupImages = await firstValueFrom(this.imageResourceService.getResearchGroupJobBanners());

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -211,17 +211,6 @@ describe('JobCreationFormComponent', () => {
       expect(calls).toContainEqual([['/my-positions']]);
       fixture2.destroy();
     });
-
-    it('should handle init error by showing toast and navigating', async () => {
-      mockActivatedRoute.setUrl([new UrlSegment('job', {}), new UrlSegment('create', {})]);
-      imageService.getDefaultJobBanners.mockReturnValueOnce(throwError(() => new Error('fail')));
-
-      const fixture2 = TestBed.createComponent(JobCreationFormComponent);
-      fixture2.detectChanges();
-      await fixture2.whenStable();
-
-      expect(mockToastService.showErrorKey).toHaveBeenCalledWith('jobCreationForm.imageSection.loadImagesFailed');
-    });
   });
 
   describe('Mode and Page Title', () => {
@@ -619,12 +608,6 @@ describe('JobCreationFormComponent', () => {
       imageService.getResearchGroupJobBanners.mockReturnValueOnce(of([]));
       await component.loadImages();
       expect(imageService.getDefaultJobBanners).toHaveBeenCalledWith('rg123');
-    });
-
-    it('should handle error when loading images fails', async () => {
-      imageService.getDefaultJobBanners.mockReturnValueOnce(throwError(() => new Error('Load failed')));
-      await component.loadImages();
-      expect(mockToastService.showErrorKey).toHaveBeenCalledWith('jobCreationForm.imageSection.loadImagesFailed');
     });
   });
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

The toast error images failed loading is shown whenever a research group is not assigned to a department. This might confuse the user since it is shown immediately when opening the creation form.
To avoid the confusion, simply no toast error should be shown since we already display the "no default images" message.

### Description

This PR:
- removes the toast error for default images

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Professor
2. Delete the department of the research group
3. Navigate to Job Creation
4. No toast error should be shown

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [ ] Test 1