### PR TITLE
`General`: Fix inconsistent margin in forms

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/select/select.component.scss
+++ b/src/main/webapp/app/shared/components/atoms/select/select.component.scss
@@ -12,11 +12,6 @@
     font-size: 0.8rem;
   }
 
-  // Add styling for labels on the top of the select component
-  &.label-top .custom-label {
-    margin-bottom: 0.25rem;
-  }
-
   // Add styling for border and corners of select fields
   .custom-select {
     border: 0.1rem solid var(--p-border-default);


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

The select component has a slight margin on the bottom of the label which is inconsistent with the rest of the components (datepicker, input etc.)

### Description

This PR removes the margin-bottom applied to the select component

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant/Professor
2. Go to Application/Job Creation Form and check alignment of all fields

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage

### Screenshots
Before:
<img width="1169" height="204" alt="image" src="https://github.com/user-attachments/assets/963fae1d-4194-4b02-b5e0-ad3698c24cba" />
After:
<img width="1197" height="204" alt="image" src="https://github.com/user-attachments/assets/6dd3fbdc-81fa-4a4a-9149-1abcd5ba05ce" />