### PR TITLE
`General`: Fix styling in onboarding dialog

### DIFF
--- a/src/main/webapp/app/shared/components/molecules/onboarding-dialog/employee-request-access-form/employee-request-access-form.component.html
+++ b/src/main/webapp/app/shared/components/molecules/onboarding-dialog/employee-request-access-form/employee-request-access-form.component.html
@@ -12,7 +12,7 @@
 
 <form [formGroup]="employeeForm" (ngSubmit)="onSubmit()" novalidate class="flex flex-col gap-4 py-4">
   <!-- Information Notice -->
-  <div class="flex items-start gap-3 p-2 bg-blue-50 border-l-4 border-[var(--p-primary-color)] rounded-r-lg">
+  <div class="flex items-start gap-3 p-2 bg-background-surface border-l-4 border-primary-default rounded-r-lg">
     <div class="flex-1">
       <p class="m-0 text-sm" jhiTranslate="onboarding.employeeRequest.notice"></p>
     </div>
@@ -32,7 +32,7 @@
   </div>
 
   <!-- Form Actions -->
-  <div class="flex justify-between gap-4 mt-6 pt-4 border-t border-gray-200">
+  <div class="flex justify-between gap-4 mt-6 pt-4 border-t border-border-default">
     <jhi-button
       type="button"
       (click)="onBack()"

--- a/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
+++ b/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
@@ -36,7 +36,7 @@
   @if (mode() === 'professor') {
     <div class="flex flex-col gap-4">
       <h3
-        class="m-0 mb-2 text-xl font-semibold text-gray-700 border-b-2 border-gray-200 pb-2"
+        class="m-0 mb-2 text-xl font-semibold text-text-primary border-b-2 border-border-default pb-2"
         jhiTranslate="onboarding.professorRequest.sections.personalInfo"
       ></h3>
 
@@ -93,7 +93,7 @@
   <!-- Research Group Information -->
   <div class="flex flex-col gap-4">
     <h3
-      class="m-0 mb-2 text-xl font-semibold text-gray-700 border-b-2 border-gray-200 pb-2"
+      class="m-0 mb-2 text-xl font-semibold text-text-primary border-b-2 border-border-default pb-2"
       jhiTranslate="onboarding.professorRequest.sections.researchGroupInfo"
     ></h3>
 
@@ -160,7 +160,7 @@
   <!-- Optional Information -->
   <div class="flex flex-col gap-4">
     <h3
-      class="m-0 mb-2 text-xl font-semibold text-gray-700 border-b-2 border-gray-200 pb-2"
+      class="m-0 mb-2 text-xl font-semibold text-text-primary border-b-2 border-border-default pb-2"
       jhiTranslate="onboarding.professorRequest.sections.optionalInfo"
     ></h3>
     <p class="text-sm text-gray-500 m-0 italic" jhiTranslate="onboarding.professorRequest.optionalHint"></p>
@@ -220,7 +220,7 @@
 
     <!-- Address Section -->
     <div class="flex flex-col gap-4">
-      <h4 class="m-0 text-lg font-medium text-gray-700" jhiTranslate="onboarding.professorRequest.sections.address"></h4>
+      <h4 class="m-0 text-lg font-medium text-text-primary" jhiTranslate="onboarding.professorRequest.sections.address"></h4>
 
       <div>
         <jhi-string-input
@@ -269,7 +269,7 @@
   </div>
 
   <!-- Form Actions -->
-  <div class="flex justify-end gap-4 mt-8 pt-4 border-t border-gray-200">
+  <div class="flex justify-end gap-4 mt-8 pt-4 border-t border-border-default">
     <jhi-button
       type="button"
       (click)="onCancel()"

--- a/src/main/webapp/app/shared/constants/onboarding-dialog.constants.ts
+++ b/src/main/webapp/app/shared/constants/onboarding-dialog.constants.ts
@@ -8,7 +8,7 @@ export const ONBOARDING_FORM_DIALOG_CONFIG = {
   width: '56.25rem',
   style: {
     'max-width': '95vw',
-    'background-color': 'white',
+    'background-color': 'var(--p-background-default)',
     'border-radius': '0.5rem',
   },
   focusOnShow: false,


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Onboarding dialog is not darkmode conform

### Description

This PR adjusts the colors for the onboarding dialog

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant on Professor Page
2. Open onboarding dialog and check styling

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots
<img width="1069" height="775" alt="image" src="https://github.com/user-attachments/assets/69d217ed-e5dc-48c7-8137-3730d9a9035e" />
<img width="1037" height="519" alt="image" src="https://github.com/user-attachments/assets/2a79ecc5-9583-407c-9876-0520c85e5467" />
