### PR TITLE
`General`: Remove init call from loginWithProvider

### DIFF
--- a/src/main/webapp/app/core/auth/keycloak-authentication.service.ts
+++ b/src/main/webapp/app/core/auth/keycloak-authentication.service.ts
@@ -108,7 +108,6 @@ export class KeycloakAuthenticationService {
    * @param redirectUri Optional URI to redirect to after login. Defaults to the app root.
    */
   async loginWithProvider(provider: IdpProvider, redirectUri?: string): Promise<void> {
-    await this.init();
     try {
       await this.keycloak?.login({
         redirectUri: this.buildRedirectUri(redirectUri),


### PR DESCRIPTION

### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context
A false toast error appears when trying to log in as a professor 

### Description
Deleted one init() call 

### Steps for Testing

Prerequisites:

1. Try to log in as a Professor and verify no toast error appears 

### Review Progress
#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [x] Test 1


