### PR TITLE
`General`: Use tooltip as fallback for button arialabel

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/button/button.component.html
+++ b/src/main/webapp/app/shared/components/atoms/button/button.component.html
@@ -9,7 +9,7 @@
 </div>
 <ng-template #button>
   <p-button
-    [ariaLabel]="label() === undefined ? icon() : undefined"
+    [ariaLabel]="label() === undefined ? tooltip() : undefined"
     [disabled]="disabled()"
     [loading]="loading()"
     [severity]="severity()"


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Buttons currently use icon name as fallback for arialabels. This should be changed as icon names are not very descriptive (e.g. eye, xmark). Since all only icon buttons should have a tooltip, we can use the tooltip as the arialabel instead.

### Description

Change fallback to tooltip instead of icon

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Professor/Applicant
2. Check buttons have ariaLabel by either checking accessibility tree or enabling voice over

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1