### PR TITLE
`General`: Add margin bottom to select component label

### DIFF
--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -66,6 +66,7 @@
 }
 
 .custom-label {
+  margin-bottom: 0.25rem;
   color: var(--p-text-primary);
 }
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

The select component labels currently do not have a margin bottom like other form input fields

### Description

Add margin-bottom to select component labels

### Steps for Testing

Prerequisites:

1. Log in to TumApply as Applicant
2. Apply to a Job and check all form fields

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<img width="1073" height="618" alt="image" src="https://github.com/user-attachments/assets/02f05f6b-7393-4f62-b95a-570507f41acb" />