### PR TITLE
`General`: Improve date slot card UI 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ profile=dev
 node_version=24.7.0
 npm_version=11.5.1
 # Dependency versions
-jhipsterDependenciesVersion=8.11.0
+jhipsterDependenciesVersion=8.12.0
 springBootVersion=3.5.9
 lombokVersion=1.18.42
 archunitJunit5Version=1.4.1
-junitVersion=6.0.1
+junitVersion=6.0.2
 jacksonDatabindNullableVersion=0.2.8
 logbackVersion=1.5.16
 mysqlVersion=9.5.0

--- a/src/main/java/de/tum/cit/aet/usermanagement/repository/DepartmentRepository.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/repository/DepartmentRepository.java
@@ -44,7 +44,7 @@ public interface DepartmentRepository extends TumApplyJpaRepository<Department, 
                    LOWER(s.name) LIKE LOWER(CONCAT('%', :searchQuery, '%')) OR
                    LOWER(s.abbreviation) LIKE LOWER(CONCAT('%', :searchQuery, '%'))
             )
-            AND (:schoolNames IS NULL OR s.name IN :schoolNames)
+            AND (:schoolNames IS NULL OR LOWER(s.name) IN :schoolNames)
         """
     )
     Page<DepartmentDTO> findAllForAdmin(

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/DepartmentService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/DepartmentService.java
@@ -14,6 +14,8 @@ import de.tum.cit.aet.usermanagement.dto.DepartmentCreationDTO;
 import de.tum.cit.aet.usermanagement.dto.DepartmentDTO;
 import de.tum.cit.aet.usermanagement.repository.DepartmentRepository;
 import de.tum.cit.aet.usermanagement.repository.SchoolRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -92,9 +94,19 @@ public class DepartmentService {
      * @param pageDTO the paging parameters
      * @param filterDTO the filter parameters (searchQuery, schoolNames)
      * @param sortDTO the sorting parameters
+     * @param request the HTTP servlet request to extract schoolNames
      * @return a paged response of DepartmentDTOs
      */
-    public PageResponseDTO<DepartmentDTO> getDepartmentsForAdmin(PageDTO pageDTO, AdminDepartmentFilterDTO filterDTO, SortDTO sortDTO) {
+    public PageResponseDTO<DepartmentDTO> getDepartmentsForAdmin(
+        PageDTO pageDTO,
+        AdminDepartmentFilterDTO filterDTO,
+        SortDTO sortDTO,
+        HttpServletRequest request
+    ) {
+        String[] schoolNames = request.getParameterValues("schoolNames");
+        if (schoolNames != null) {
+            filterDTO.setSchoolNames(Arrays.asList(schoolNames));
+        }
         PageRequest pageable = PageUtil.createPageRequest(pageDTO, sortDTO, PageUtil.ColumnMapping.DEPARTMENTS_ADMIN, true);
         String normalizedSearch = StringUtil.normalizeSearchQuery(filterDTO.getSearchQuery());
 

--- a/src/main/java/de/tum/cit/aet/usermanagement/web/DepartmentResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/DepartmentResource.java
@@ -9,6 +9,7 @@ import de.tum.cit.aet.usermanagement.dto.AdminDepartmentFilterDTO;
 import de.tum.cit.aet.usermanagement.dto.DepartmentCreationDTO;
 import de.tum.cit.aet.usermanagement.dto.DepartmentDTO;
 import de.tum.cit.aet.usermanagement.service.DepartmentService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -70,6 +71,7 @@ public class DepartmentResource {
      * @param pageDTO paging params
      * @param filterDTO filter params (searchQuery, schoolNames)
      * @param sortDTO sorting params
+     * @param request HTTP servlet request to extract parameters
      * @return paginated departments
      */
     @Admin
@@ -77,7 +79,8 @@ public class DepartmentResource {
     public ResponseEntity<PageResponseDTO<DepartmentDTO>> getDepartmentsForAdmin(
         @ParameterObject @Valid @ModelAttribute PageDTO pageDTO,
         @ParameterObject @Valid @ModelAttribute AdminDepartmentFilterDTO filterDTO,
-        @ParameterObject @Valid @ModelAttribute SortDTO sortDTO
+        @ParameterObject @Valid @ModelAttribute SortDTO sortDTO,
+        HttpServletRequest request
     ) {
         log.info(
             "GET /api/departments/admin/search - Fetching departments for admin with page={}, filter={}, sort={}",
@@ -85,7 +88,7 @@ public class DepartmentResource {
             filterDTO,
             sortDTO
         );
-        PageResponseDTO<DepartmentDTO> response = departmentService.getDepartmentsForAdmin(pageDTO, filterDTO, sortDTO);
+        PageResponseDTO<DepartmentDTO> response = departmentService.getDepartmentsForAdmin(pageDTO, filterDTO, sortDTO, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/webapp/app/interview/interviewee-assessment/interviewee-assessment.component.html
+++ b/src/main/webapp/app/interview/interviewee-assessment/interviewee-assessment.component.html
@@ -22,10 +22,9 @@
   @if (!loading() && !error() && interviewee()) {
     <div class="flex flex-col gap-6">
       <!-- Header -->
-      <div class="flex items-center gap-4">
-        <div class="flex flex-col gap-1">
-          <h1 class="text-3xl font-bold text-text-primary" jhiTranslate="interview.assessment.title">Interview Assessment</h1>
-        </div>
+      <div class="page-header flex flex-row items-center">
+        <jhi-button [icon]="'arrow-left'" variant="text" severity="secondary" (click)="goBack()" />
+        <h1 class="h1-text" jhiTranslate="interview.assessment.title">Interview Assessment</h1>
       </div>
 
       <div class="flex flex-col xl:flex-row gap-8">
@@ -125,20 +124,6 @@
           </jhi-section>
         </div>
       </div>
-    </div>
-
-    <!-- Sticky Footer -->
-    <div
-      class="sticky-footer sticky bottom-0 mt-auto py-3 bg-background-default transition-all duration-300 z-[1000] ease-in-out -mx-4 px-4 w-[calc(100%+2rem)] md:-mx-16 md:px-16 md:w-[calc(100%+8rem)] border-t border-border-default"
-    >
-      <jhi-button
-        [label]="'button.back'"
-        [shouldTranslate]="true"
-        icon="arrow-left"
-        variant="outlined"
-        [severity]="'info'"
-        (click)="goBack()"
-      />
     </div>
   }
 </div>


### PR DESCRIPTION
### Checklist

#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).
#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The Date Slot Creation UI required visual refinements to improve usability, prevent layout glitches (e.g., overlapping borders in conflict state)

### Description

**Usability Improvements:**

- Replaced inline helper text with a structured Info Icon (i) tooltips in the slot header.
- Improved visual hierarchy for "Single Slot" vs. "Time Range" labels.
- Replaced generic "X" buttons with clear Trash icons for deletion.
- Added persistent dividers between slot items for better readability.

**Bug Fixes:**

- Fixed layout issues where inputs overlapped the red error border in conflict states.
- Fixed visual artifacts in the collapsed state (prevented double borders, ensured dividers remain visible).

### Steps for Testing

Prerequisites:

1. Log in to TumApply as a professor
2. Go to `/interviews/overview`
3. Choose a process
4. Click on Add slots 


**Slot Management:**
- Add a Single Slot and a Time Range.
- Verify that the "Trash" icon deletes the slot correctly.
- Hover over the (i) info icon in the slot header and check if the tooltip appears correctly.

**Conflict State:**
- Create two colliding slots (same time for same day).
- Verify the red error border wraps the content properly without overlapping the input fields.

**Collapsed State:**
- Collapse a Date Card.
- Verify the header's bottom border disappears (no double border).
- Verify the vertical separator in the header remains visible.


### Review Progress


#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-01-24 13:18:42 UTC_


### Screenshots

Before: 
<img width="644" height="504" alt="image" src="https://github.com/user-attachments/assets/a1d19d26-8c0f-4085-ac96-392487a52fdc" />

After: 
<img width="635" height="508" alt="image" src="https://github.com/user-attachments/assets/fe6dce9d-72d5-49e2-920c-e015fc397a84" />



