### PR TITLE
`General`: Fix chevron remains in wrong state after item click

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/menu/menu.component.html
+++ b/src/main/webapp/app/shared/components/atoms/menu/menu.component.html
@@ -1,5 +1,5 @@
 <div class="jhi-menu">
-  <p-menu #menu [model]="menuModel()" [popup]="popup()" [appendTo]="appendTo()">
+  <p-menu #menu [model]="menuModel()" [popup]="popup()" [appendTo]="appendTo()" (onShow)="onShow()" (onHide)="onHide()">
     <ng-template pTemplate="item" let-item>
       <div class="p-menu-item-content">
         <a class="p-menu-item-link" [ngClass]="item.styleClass">

--- a/src/main/webapp/app/shared/components/atoms/menu/menu.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/menu/menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, viewChild } from '@angular/core';
+import { Component, computed, inject, input, output, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NavigationStart, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
@@ -46,6 +46,11 @@ export class MenuComponent {
    */
   shouldTranslate = input<boolean>(false);
 
+  /**
+   * Emits whenever the popup visibility changes. true = opened, false = closed
+   */
+  visibleChange = output<boolean>();
+
   menu = viewChild.required<Menu>('menu');
 
   // Computed property to convert JhiMenuItem to PrimeNG MenuItem format
@@ -79,6 +84,7 @@ export class MenuComponent {
     // This fixes PrimeNG 21 issue where popups don't close on navigation
     this.router.events.pipe(filter(event => event instanceof NavigationStart)).subscribe(() => {
       this.clearMenuPopups();
+      this.visibleChange.emit(false);
     });
   }
 
@@ -93,9 +99,18 @@ export class MenuComponent {
   hide(): void {
     this.menu().hide();
   }
+  onShow(): void {
+    this.visibleChange.emit(true);
+  }
+
+  onHide(): void {
+    this.visibleChange.emit(false);
+  }
 
   private handleCommand(item: JhiMenuItem): void {
     item.command?.();
+    this.visibleChange.emit(false);
+
     // Clean up immediately in case navigation occurs
     this.clearMenuPopups();
   }

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.html
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.html
@@ -86,7 +86,7 @@
         />
       </button>
       <div class="absolute right-0 top-full mt-1 z-30">
-        <jhi-menu #profileMenu [items]="profileMenuItems()" [shouldTranslate]="true" />
+        <jhi-menu #profileMenu [items]="profileMenuItems()" [shouldTranslate]="true" (visibleChange)="isProfileMenuOpen.set($event)" />
       </div>
     }
   </div>

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.ts
@@ -215,7 +215,6 @@ export class HeaderComponent {
   }
 
   toggleProfileMenu(event: Event): void {
-    this.isProfileMenuOpen.update(state => !state);
     this.profileMenu()?.toggle(event);
   }
 

--- a/src/test/webapp/app/application/application-creation-form/application-creation-page1.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation-form/application-creation-page1.component.spec.ts
@@ -142,7 +142,7 @@ describe('ApplicationPage1Component', () => {
 
     const page1 = getPage1FromApplication(fakeApp);
     expect(page1.firstName).toBe('John');
-    expect(page1.gender).toEqual(selectGender.find((g: any) => g.value === 'male'));
+    expect(page1.gender).toEqual(selectGender.find(g => g.value === 'male'));
     expect(page1.country?.value).toBe('us');
   });
 

--- a/src/test/webapp/app/shared/components/atoms/menu/menu.component.spec.ts
+++ b/src/test/webapp/app/shared/components/atoms/menu/menu.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { By } from '@angular/platform-browser';
 import { Router, NavigationStart } from '@angular/router';
 import { Subject } from 'rxjs';
 

--- a/src/test/webapp/app/shared/components/organisms/header/header.component.spec.ts
+++ b/src/test/webapp/app/shared/components/organisms/header/header.component.spec.ts
@@ -203,24 +203,6 @@ describe('HeaderComponent', () => {
   });
 
   describe('toggleProfileMenu', () => {
-    it('should toggle isProfileMenuOpen signal from false to true', () => {
-      component.isProfileMenuOpen.set(false);
-      const mockEvent = new MouseEvent('click');
-
-      component.toggleProfileMenu(mockEvent);
-
-      expect(component.isProfileMenuOpen()).toBe(true);
-    });
-
-    it('should toggle isProfileMenuOpen signal from true to false', () => {
-      component.isProfileMenuOpen.set(true);
-      const mockEvent = new MouseEvent('click');
-
-      component.toggleProfileMenu(mockEvent);
-
-      expect(component.isProfileMenuOpen()).toBe(false);
-    });
-
     it('should call profileMenu toggle method with event', () => {
       accountService.user.set({ id: '1', email: 'test@example.com', name: 'testuser' } satisfies User);
       fixture.detectChanges();
@@ -234,12 +216,24 @@ describe('HeaderComponent', () => {
       expect(toggleSpy).toHaveBeenCalledWith(mockEvent);
     });
 
-    it('should not throw error when profileMenu is undefined', () => {
+    it('should not throw error when profileMenu is undefined and should not change isProfileMenuOpen', () => {
       component.isProfileMenuOpen.set(false);
       const mockEvent = new MouseEvent('click');
 
+      vi.spyOn(component as any, 'profileMenu').mockReturnValue(undefined);
+
       expect(() => component.toggleProfileMenu(mockEvent)).not.toThrow();
+      expect(component.isProfileMenuOpen()).toBe(false);
+    });
+
+    it('should reflect menu visibility changes in isProfileMenuOpen (simulating visibleChange)', () => {
+      component.isProfileMenuOpen.set(false);
+
+      component.isProfileMenuOpen.set(true);
       expect(component.isProfileMenuOpen()).toBe(true);
+
+      component.isProfileMenuOpen.set(false);
+      expect(component.isProfileMenuOpen()).toBe(false);
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

After clicking on an item, the chevron icon remains in the wrong visual state. The chevron indicates a collapsed state even though the section is not collapsed.

### Description

This PR makes the chevron return to initial state after click

### Steps for Testing


1. Log in
2. Click on the profile menu in the header and check if the chevron changes its state into open
3. Click on any item within the expanded section or outside the menu
4. Check if the menu collapses and the chevron also changes back into the collapsed state 

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Client tests failed. Coverage could not be fully measured. Please check the [workflow logs](https://github.com/ls1intum/tum-apply/actions/runs/21545404519).

_Last updated: 2026-01-31 13:48:18 UTC_


### Screenshots

<img width="342" height="117" alt="image" src="https://github.com/user-attachments/assets/300f15d5-a741-4fd1-8224-c27098f3f979" />
<img width="341" height="148" alt="image" src="https://github.com/user-attachments/assets/1cb0ae8e-c3e6-4b96-aac6-cb439af8c649" />
