### PR TITLE
`General`: Fix sign in after keycloak session logout

### DIFF
--- a/src/main/webapp/app/shared/components/organisms/header/header.component.ts
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.ts
@@ -90,11 +90,17 @@ export class HeaderComponent {
   );
   isProfessorPage = computed(() => {
     const auths = this.routeAuthorities();
-    return (
-      (this.router.url === '/professor' && !this.accountService.hasAnyAuthority(['APPLICANT'])) ||
-      this.accountService.hasAnyAuthority(['PROFESSOR']) ||
-      (Array.isArray(auths) && auths.includes(UserShortDTO.RolesEnum.Professor))
-    );
+    const user = this.accountService.user();
+
+    // When user is signed in, check their authorities
+    if (user) {
+      return (
+        this.accountService.hasAnyAuthority(['PROFESSOR']) || (Array.isArray(auths) && auths.includes(UserShortDTO.RolesEnum.Professor))
+      );
+    }
+
+    // When not signed in, check if we're on professor page and not explicitly an applicant route
+    return this.router.url === '/professor';
   });
 
   readonly headerButtonClass =


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

Currently, when users log out from a keycloak based session, clicking on the sign in button does nothing.

### Description

This PR adds an automatic reload to after the user logs out from a keycloak session to clear fully clear all keycloak state.

### Steps for Testing

Prerequisites:

1. Log in to TumApply with keycloak
2. Sign out and check reload happens automatically

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1