### PR TITLE
`General`: Fix warning email for application deletions

### DIFF
--- a/src/main/java/de/tum/cit/aet/core/retention/ApplicantRetentionService.java
+++ b/src/main/java/de/tum/cit/aet/core/retention/ApplicantRetentionService.java
@@ -110,6 +110,7 @@ public class ApplicantRetentionService {
                 .to(user)
                 .language(Language.fromCode(user.getSelectedLanguage()))
                 .emailType(EmailType.APPLICANT_DATA_DELETION_WARNING)
+                .content(user)
                 .build();
 
             sender.sendAsync(email);

--- a/src/main/java/de/tum/cit/aet/notification/service/TemplateProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/notification/service/TemplateProcessingService.java
@@ -176,6 +176,7 @@ public class TemplateProcessingService {
             case ResearchGroupEmailContext ctx -> addResearchGroupContextData(dataModel, ctx);
             case Interviewee interviewee -> addIntervieweeData(dataModel, interviewee);
             case DataExportEmailContext ctx -> addDataExportContextData(dataModel, ctx);
+            case User user -> addUserData(dataModel, user);
             default -> {
                 throw new TemplateProcessingException("Unsupported content type: " + content.getClass().getName());
             }


### PR DESCRIPTION

### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

#### Server

- [x] I **strictly** followed the [server coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311877/Server+Guidelines).

### Motivation and Context

Closes #2044 

### Description

- Added `User` as a supported content type in `TemplateProcessingService.createDataModel()` so the email template variables (`USER_FIRST_NAME`, `USER_LAST_NAME`) are resolved correctly.
- Passed the `User` object as `.content(user)` in the retention warning email builder in `ApplicantRetentionService` to fix the `NullPointerException` when rendering the deletion warning email.

### Review Progress

#### Code Review

- [ ] Code Review 1

### Screenshots

![Screenshot 2026-03-10 at 13 23 53](https://github.com/user-attachments/assets/1ea90b94-c11e-4fd3-8b45-54d27c08ee41)

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Server tests failed. Coverage could not be fully measured. Please check the [workflow logs](https://github.com/ls1intum/tum-apply/actions/runs/22902424982).

_Last updated: 2026-03-10 12:33:28 UTC_

