### PR TITLE
`General`: Add client tests for interviewee assessment

### DIFF
--- a/src/test/webapp/app/interview/interviewee-assessment/interviewee-assessment.component.spec.ts
+++ b/src/test/webapp/app/interview/interviewee-assessment/interviewee-assessment.component.spec.ts
@@ -1,8 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { IntervieweeAssessmentComponent } from 'app/interview/interviewee-assessment/interviewee-assessment.component';
 import { InterviewResourceApiService } from 'app/generated';
@@ -66,11 +65,13 @@ describe('IntervieweeAssessmentComponent', () => {
   let toastMock: ToastServiceMock;
   let routerMock: RouterMock;
   let activatedRouteMock: ActivatedRouteMock;
-  let queryParamsSubject: BehaviorSubject<Record<string, string>>;
 
-  function configureTestBed(queryParams: Record<string, string> = {}): Promise<void> {
-    queryParamsSubject = new BehaviorSubject<Record<string, string>>(queryParams);
+  function createComponent(): void {
+    fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
+    component = fixture.componentInstance;
+  }
 
+  function configureTestBed(): Promise<void> {
     return TestBed.configureTestingModule({
       imports: [IntervieweeAssessmentComponent],
       providers: [
@@ -82,23 +83,7 @@ describe('IntervieweeAssessmentComponent', () => {
         { provide: InterviewResourceApiService, useValue: mockInterviewService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideProvider(ActivatedRoute, {
-        useValue: {
-          paramMap: activatedRouteMock.paramMapSubject.asObservable(),
-          queryParamMap: activatedRouteMock.queryParamMapSubject.asObservable(),
-          queryParams: queryParamsSubject.asObservable(),
-          url: activatedRouteMock.urlSubject.asObservable(),
-          get snapshot() {
-            return {
-              paramMap: activatedRouteMock.paramMapSubject.value,
-              queryParamMap: activatedRouteMock.queryParamMapSubject.value,
-              url: activatedRouteMock.urlSubject.value,
-            };
-          },
-        },
-      })
-      .compileComponents();
+    }).compileComponents();
   }
 
   beforeEach(async () => {
@@ -111,6 +96,8 @@ describe('IntervieweeAssessmentComponent', () => {
     activatedRouteMock = createActivatedRouteMock({ processId: 'proc-1', intervieweeId: 'iee-1' });
 
     await configureTestBed();
+    createComponent();
+    await fixture.whenStable();
   });
 
   afterEach(() => {
@@ -118,11 +105,7 @@ describe('IntervieweeAssessmentComponent', () => {
   });
 
   describe('Data Loading', () => {
-    it('should load interviewee details on init', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
+    it('should load interviewee details on init', () => {
       expect(mockInterviewService.getIntervieweeDetails).toHaveBeenCalledOnce();
       expect(mockInterviewService.getIntervieweeDetails).toHaveBeenCalledWith('proc-1', 'iee-1');
       expect(component['loading']()).toBe(false);
@@ -132,8 +115,7 @@ describe('IntervieweeAssessmentComponent', () => {
     it('should set error signal on 404', async () => {
       (mockInterviewService.getIntervieweeDetails as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => ({ status: 404 })));
 
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      createComponent();
       await fixture.whenStable();
 
       expect(component['error']()).toBe('interview.assessment.error.notFound');
@@ -143,8 +125,7 @@ describe('IntervieweeAssessmentComponent', () => {
     it('should show error toast and navigate to overview on 403', async () => {
       (mockInterviewService.getIntervieweeDetails as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => ({ status: 403 })));
 
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      createComponent();
       await fixture.whenStable();
 
       expect(toastMock.showErrorKey).toHaveBeenCalledWith('interview.assessment.error.loadFailed');
@@ -154,8 +135,7 @@ describe('IntervieweeAssessmentComponent', () => {
     it('should set error signal and show toast on generic error', async () => {
       (mockInterviewService.getIntervieweeDetails as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => ({ status: 500 })));
 
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      createComponent();
       await fixture.whenStable();
 
       expect(component['error']()).toBe('interview.assessment.error.loadFailed');
@@ -164,83 +144,35 @@ describe('IntervieweeAssessmentComponent', () => {
   });
 
   describe('Computed Properties', () => {
-    it('should compute applicantName from user', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
+    it.each([
+      { property: 'applicantAvatar', expected: '/img/alice.jpg' },
+      { property: 'degreeName', expected: 'Computer Science' },
+      { property: 'universityName', expected: 'TU Munich' },
+      { property: 'motivation', expected: 'I love this role' },
+      { property: 'skills', expected: 'Angular, TypeScript' },
+      { property: 'interests', expected: 'Built a CMS' },
+      { property: 'applicationId', expected: 'app-1' },
+    ])('should compute $property correctly', ({ property, expected }) => {
+      expect(component[property as keyof typeof component]()).toBe(expected);
+    });
 
+    it('should compute applicantName from user', () => {
       expect(component['applicantName']()).toContain('Alice');
       expect(component['applicantName']()).toContain('Mueller');
     });
 
-    it('should compute applicantAvatar from user', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['applicantAvatar']()).toBe('/img/alice.jpg');
-    });
-
-    it('should compute degreeName from application', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['degreeName']()).toBe('Computer Science');
-    });
-
-    it('should compute universityName from application', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['universityName']()).toBe('TU Munich');
-    });
-
-    it('should compute motivation from application', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['motivation']()).toBe('I love this role');
-    });
-
-    it('should compute skills from application', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['skills']()).toBe('Angular, TypeScript');
-    });
-
-    it('should compute interests from application', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['interests']()).toBe('Built a CMS');
-    });
-
-    it('should compute slotInfo from interviewee', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
+    it('should compute slotInfo from interviewee', () => {
       expect(component['slotInfo']()?.location).toBe('Room 303');
-    });
-
-    it('should compute applicationId as string', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
-      expect(component['applicationId']()).toBe('app-1');
     });
   });
 
   describe('Computed Properties with missing data', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       (mockInterviewService.getIntervieweeDetails as ReturnType<typeof vi.fn>).mockReturnValue(of(intervieweeWithoutOptionals));
+      TestBed.resetTestingModule();
+      await configureTestBed();
+      createComponent();
+      await fixture.whenStable();
     });
 
     it.each([
@@ -252,21 +184,13 @@ describe('IntervieweeAssessmentComponent', () => {
       { property: 'skills', expected: '' },
       { property: 'interests', expected: '' },
       { property: 'savedNotes', expected: '' },
-    ])('should return "$expected" for $property when data is missing', async ({ property, expected }) => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
+    ])('should return "$expected" for $property when data is missing', ({ property, expected }) => {
       expect(component[property as keyof typeof component]()).toBe(expected);
     });
   });
 
   describe('Save Notes', () => {
     it('should save notes and show success toast', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
       component['notesControl'].setValue('Updated notes');
       await component.saveNotes();
 
@@ -279,10 +203,6 @@ describe('IntervieweeAssessmentComponent', () => {
     it('should show error toast when saving notes fails', async () => {
       (mockInterviewService.updateAssessment as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('fail')));
 
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
       component['notesControl'].setValue('New notes');
       await component.saveNotes();
 
@@ -292,10 +212,9 @@ describe('IntervieweeAssessmentComponent', () => {
 
     it('should not save when processId is empty', async () => {
       activatedRouteMock = createActivatedRouteMock({ processId: '', intervieweeId: '' });
+      TestBed.resetTestingModule();
       await configureTestBed();
-
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      createComponent();
       await fixture.whenStable();
 
       await component.saveNotes();
@@ -305,11 +224,7 @@ describe('IntervieweeAssessmentComponent', () => {
   });
 
   describe('Navigation', () => {
-    it('should navigate to process detail page on goBack', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
+    it('should navigate to process detail page on goBack', () => {
       component.goBack();
 
       expect(routerMock.navigate).toHaveBeenCalledOnce();
@@ -317,10 +232,10 @@ describe('IntervieweeAssessmentComponent', () => {
     });
 
     it('should navigate to overview when from=overview query param is set', async () => {
-      await configureTestBed({ from: 'overview' });
-
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      activatedRouteMock = createActivatedRouteMock({ processId: 'proc-1', intervieweeId: 'iee-1' }, { from: 'overview' });
+      TestBed.resetTestingModule();
+      await configureTestBed();
+      createComponent();
       await fixture.whenStable();
 
       component.goBack();
@@ -331,10 +246,9 @@ describe('IntervieweeAssessmentComponent', () => {
 
     it('should navigate to overview when processId is empty', async () => {
       activatedRouteMock = createActivatedRouteMock({ processId: '', intervieweeId: 'iee-1' });
+      TestBed.resetTestingModule();
       await configureTestBed();
-
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
+      createComponent();
       await fixture.whenStable();
 
       component.goBack();
@@ -344,19 +258,11 @@ describe('IntervieweeAssessmentComponent', () => {
   });
 
   describe('Rating', () => {
-    it('should initialize rating from loaded data', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
+    it('should initialize rating from loaded data', () => {
       expect(component['rating']()).toBe(4);
     });
 
     it('should show error toast and revert rating when save fails', async () => {
-      fixture = TestBed.createComponent(IntervieweeAssessmentComponent);
-      component = fixture.componentInstance;
-      await fixture.whenStable();
-
       (mockInterviewService.updateAssessment as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('fail')));
 
       component['rating'].set(2);

--- a/src/test/webapp/util/activated-route.mock.ts
+++ b/src/test/webapp/util/activated-route.mock.ts
@@ -8,6 +8,7 @@ import { Provider } from '@angular/core';
 export interface ActivatedRouteMock {
   paramMapSubject: BehaviorSubject<ParamMap>;
   queryParamMapSubject: BehaviorSubject<ParamMap>;
+  queryParamsSubject: BehaviorSubject<Record<string, string>>;
   urlSubject: BehaviorSubject<UrlSegment[]>;
   setParams: (params: Record<string, string>) => void;
   setQueryParams: (params: Record<string, string>) => void;
@@ -24,6 +25,7 @@ export function createActivatedRouteMock(
 ): ActivatedRouteMock {
   const paramMapSubject = new BehaviorSubject<ParamMap>(convertToParamMap(initialParams));
   const queryParamMapSubject = new BehaviorSubject<ParamMap>(convertToParamMap(initialQueryParams));
+  const queryParamsSubject = new BehaviorSubject<Record<string, string>>(initialQueryParams);
   const urlSubject = new BehaviorSubject<UrlSegment[]>(initialUrlSegments);
 
   const setParams = (params: Record<string, string>) => {
@@ -32,13 +34,14 @@ export function createActivatedRouteMock(
 
   const setQueryParams = (params: Record<string, string>) => {
     queryParamMapSubject.next(convertToParamMap(params));
+    queryParamsSubject.next(params);
   };
 
   const setUrl = (segments: UrlSegment[]) => {
     urlSubject.next(segments);
   };
 
-  return { paramMapSubject, queryParamMapSubject, urlSubject, setParams, setQueryParams, setUrl };
+  return { paramMapSubject, queryParamMapSubject, queryParamsSubject, urlSubject, setParams, setQueryParams, setUrl };
 }
 
 /**
@@ -50,6 +53,7 @@ export function provideActivatedRouteMock(mock: ActivatedRouteMock): Provider {
     useValue: {
       paramMap: mock.paramMapSubject.asObservable(),
       queryParamMap: mock.queryParamMapSubject.asObservable(),
+      queryParams: mock.queryParamsSubject.asObservable(),
       url: mock.urlSubject.asObservable(),
       get snapshot() {
         return {


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/AP/pages/257786006/Language+Guidelines+Client).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).
#### Client
- [x] I **strictly** followed the [client coding and design guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311716/Client+Guidelines).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311925/Client+Test+Guidelines).

### Motivation and Context
The interviewee assessment component had no client-side test coverage. This PR adds comprehensive Vitest integration tests to ensure correctness of data loading, computed properties, error handling, save operations, navigation, and rating behavior.



### Description

Added 30 Vitest integration tests for the IntervieweeAssessmentComponent:

**Data Loading (4 tests):** Loads interviewee details from route params, handles 404 (sets error signal), 403 (toast + redirect to overview), and generic errors (error signal + toast)
**Computed Properties (10 tests):** Uses it.each for 8 simple computed properties (applicantAvatar, degreeName, universityName, motivation, skills, interests, savedNotes, applicationId), plus separate tests for applicantName (first + last name) and slotInfo (nested object)
**Computed Properties with missing data (8 tests):** Uses it.each to verify all computed properties return safe fallback values when optional data is absent
Save Notes (3 tests): Save with success toast, error toast on failure, guard against empty processId
**Navigation (3 tests):** goBack() navigates to process detail, overview when from=overview query param is set, overview when processId is empty
**Rating (2 tests):** Initializes rating from loaded data, reverts rating and shows error toast on save failure

### Steps for Testing

1. Check out this branch
2. Run npx vitest run src/test/webapp/app/interview/interviewee-assessment/ to verify all 30 tests pass
3. Review that tests use it.each for parameterized cases, toHaveBeenCalledOnce() for positive assertions, project mock utilities, and explicit mock data (no spread overrides)

### Review Progress


#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-03-15 20:55:45 UTC_

