### PR TITLE
`Bugfix`: Fix PR naming of renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
   "timezone": "Europe/Berlin",
   "minimumReleaseAge": "14 days",
   "semanticCommits": "disabled",
-  "prTitle": "`General`: Update {{depName}} to {{newVersion}}",
+  "commitMessageAction": "`General`: Update",
+  "commitMessageTopic": "{{{depName}}}",
+  "commitMessageExtra": "to {{newVersion}}",
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": [


### PR DESCRIPTION
<!-- Thanks for contributing to TumApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I chose a title conforming to the [naming conventions for pull requests](https://confluence.aet.cit.tum.de/spaces/AP/pages/256311714/PR+Guidelines).

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #2202 

### Description

<!-- Describe your changes in detail -->
Disabled semantic commit messages by setting `"semanticCommits": "disabled"` in `renovate.json`, so Renovate will no longer use semantic prefixes in its commit messages.

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1