### PR TITLE
`Documentation`: Add guideline to avoid spread operator in client code

### DIFF
--- a/docs/docs/developer/client-guidelines/client-development.mdx
+++ b/docs/docs/developer/client-guidelines/client-development.mdx
@@ -345,6 +345,28 @@ async processApplication(applicationId: string): Promise<void> {
 - Split complex functions into multiple helper functions — the parent function should be easy to understand at a glance
 - Format with **Prettier**, validate with **ESLint**
 
+### Avoid the Spread Operator (`...`)
+
+Do not use the spread operator for objects or arrays. It obscures what is actually being copied or merged, makes debugging harder, and can introduce subtle bugs with nested references. Write out the operation explicitly instead.
+
+```typescript
+// ✅ GOOD — Explicit object construction
+const updated: UserDTO = {
+  id: user.id,
+  name: newName,
+  email: user.email,
+};
+
+// ✅ GOOD — Explicit array operations
+const combined = firstArray.concat(secondArray);
+const withNewItem = items.concat(newItem);
+
+// ❌ AVOID — Spread operator hides what is being copied
+const updated = { ...user, name: newName };
+const combined = [...firstArray, ...secondArray];
+const withNewItem = [...items, newItem];
+```
+
 ---
 
 ## Memory Leak Prevention


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

Developers should avoid using the spread operator (`...`) for objects and arrays in client code. It obscures what is actually being copied or merged, makes debugging harder, and can introduce subtle bugs with nested references. This adds a clear guideline with examples to the client development documentation.

### Description

Added a new "Avoid the Spread Operator" subsection under the **Code Style** section in `client-development.mdx`. The subsection includes:
- A clear rule explaining why the spread operator should be avoided
- ✅ GOOD examples showing explicit object construction and array operations (`concat`)
- ❌ AVOID examples showing the spread operator patterns to avoid

### Steps for Testing

Prerequisites:

1. Open the Docusaurus documentation locally or review the changed file
2. Navigate to Developer > Client Guidelines > Client Development > Code Style
3. Verify the new "Avoid the Spread Operator" subsection renders correctly with code examples

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1