### PR TITLE
`Development`: Replace fullWidth with configurable searchWidth in search-filter-sort-bar

### DIFF
--- a/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
+++ b/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
@@ -95,7 +95,7 @@
       [multipleEntities]="'dependencies.dependencies' | translate"
       [filters]="filters()"
       [sortableFields]="sortableFields"
-      [fullWidth]="true"
+      searchWidth="max-w-[30%]"
       (searchOutput)="onSearchChange($event)"
       (filterOutput)="onFilterChange($event)"
       (sortOutput)="onSortChange($event)"

--- a/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
+++ b/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
@@ -95,7 +95,7 @@
       [multipleEntities]="'dependencies.dependencies' | translate"
       [filters]="filters()"
       [sortableFields]="sortableFields"
-      searchWidth="30%"
+      searchWidth="max-w-[30%]"
       (searchOutput)="onSearchChange($event)"
       (filterOutput)="onFilterChange($event)"
       (sortOutput)="onSortChange($event)"

--- a/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
+++ b/src/main/webapp/app/admin/dependencies/admin-dependencies.component.html
@@ -95,7 +95,7 @@
       [multipleEntities]="'dependencies.dependencies' | translate"
       [filters]="filters()"
       [sortableFields]="sortableFields"
-      searchWidth="max-w-[30%]"
+      searchWidth="30%"
       (searchOutput)="onSearchChange($event)"
       (filterOutput)="onFilterChange($event)"
       (sortOutput)="onSortChange($event)"

--- a/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
+++ b/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
@@ -103,7 +103,7 @@
       <div class="flex flex-col gap-3">
         <jhi-search-filter-sort-bar
           [searchText]="'researchGroup.adminView.professorSelect.searchPlaceholder' | translate"
-          searchWidth="max-w-none"
+          searchWidth="100%"
           [showRecords]="isSearchQueryLongEnough()"
           [totalRecords]="adminProfessorTotalCount()"
           [singleEntity]="'researchGroup.adminView.professorSelect.singleEntity' | translate"

--- a/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
+++ b/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
@@ -103,7 +103,7 @@
       <div class="flex flex-col gap-3">
         <jhi-search-filter-sort-bar
           [searchText]="'researchGroup.adminView.professorSelect.searchPlaceholder' | translate"
-          searchWidth="100%"
+          searchWidth="max-w-[100%]"
           [showRecords]="isSearchQueryLongEnough()"
           [totalRecords]="adminProfessorTotalCount()"
           [singleEntity]="'researchGroup.adminView.professorSelect.singleEntity' | translate"

--- a/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
+++ b/src/main/webapp/app/shared/components/molecules/research-group-creation-form/research-group-creation-form.component.html
@@ -103,7 +103,7 @@
       <div class="flex flex-col gap-3">
         <jhi-search-filter-sort-bar
           [searchText]="'researchGroup.adminView.professorSelect.searchPlaceholder' | translate"
-          [fullWidth]="true"
+          searchWidth="max-w-none"
           [showRecords]="isSearchQueryLongEnough()"
           [totalRecords]="adminProfessorTotalCount()"
           [singleEntity]="'researchGroup.adminView.professorSelect.singleEntity' | translate"

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
@@ -1,7 +1,7 @@
 <div class="search-filter-sort-bar">
   <div class="flex flex-row justify-between gap-2">
     <div class="flex flex-1 flex-row items-center gap-2 flex-wrap">
-      <p-iconfield iconPosition="left" [class]="searchFieldClass()">
+      <p-iconfield iconPosition="left" class="w-full flex-1" [class]="searchFieldClass()">
         <p-inputicon>
           <fa-icon class="icon" size="sm" [icon]="['fas', 'search']" />
         </p-inputicon>

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
@@ -1,7 +1,7 @@
-<div class="search-filter-sort-bar" [class.full-width]="fullWidth()">
+<div class="search-filter-sort-bar">
   <div class="flex flex-row justify-between gap-2">
-    <div class="flex flex-row items-center gap-2 flex-wrap" [class.flex-1]="fullWidth()">
-      <p-iconfield iconPosition="left">
+    <div class="flex flex-1 flex-row items-center gap-2 flex-wrap">
+      <p-iconfield iconPosition="left" [class]="searchFieldClass()">
         <p-inputicon>
           <fa-icon class="icon" size="sm" [icon]="['fas', 'search']" />
         </p-inputicon>

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.html
@@ -1,7 +1,7 @@
 <div class="search-filter-sort-bar">
   <div class="flex flex-row justify-between gap-2">
     <div class="flex flex-1 flex-row items-center gap-2 flex-wrap">
-      <p-iconfield iconPosition="left" class="w-full flex-1" [class]="searchFieldClass()">
+      <p-iconfield iconPosition="left" class="w-full" [class]="searchFieldClass()">
         <p-inputicon>
           <fa-icon class="icon" size="sm" [icon]="['fas', 'search']" />
         </p-inputicon>

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.scss
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.scss
@@ -4,22 +4,17 @@
   display: flex;
   flex-direction: column;
 
-  .p-iconfield {
+  .p-inputtext {
     width: 100%;
-    flex: 1;
+    border: var(--p-border-default) solid 0.1rem;
+    border-radius: var(--border-radius-md);
 
-    .p-inputtext {
-      width: 100%;
-      border: var(--p-border-default) solid 0.1rem;
-      border-radius: var(--border-radius-md);
+    &::placeholder {
+      color: var(--p-text-tertiary);
+    }
 
-      &::placeholder {
-        color: var(--p-text-tertiary);
-      }
-
-      &:hover {
-        border-color: var(--color-border-hover);
-      }
+    &:hover {
+      border-color: var(--color-border-hover);
     }
   }
 }

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.scss
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.scss
@@ -4,17 +4,8 @@
   display: flex;
   flex-direction: column;
 
-  &.full-width {
-    .p-iconfield {
-      max-width: none;
-      min-width: 0;
-    }
-  }
-
   .p-iconfield {
     width: 100%;
-    max-width: 18rem;
-    min-width: 12rem;
     flex: 1;
 
     .p-inputtext {

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
@@ -35,7 +35,7 @@ export class SearchFilterSortBar {
   totalRecords = input<number>(0);
   showRecords = input<boolean>(true);
   searchText = input<string | undefined>(undefined);
-  fullWidth = input<boolean>(false);
+  searchWidth = input<string | undefined>(undefined);
 
   // list of filters to be displayed
   filters = input<Filter[]>([]);
@@ -60,6 +60,7 @@ export class SearchFilterSortBar {
   selectedSortField = signal<string | undefined>(undefined);
   selectedSortDirection = signal<SortDirection>('DESC');
 
+  readonly searchFieldClass = computed(() => (this.searchWidth() ? this.searchWidth() + ' min-w-0' : 'max-w-[18rem] min-w-[12rem]'));
   readonly hasMobileActions = computed(() => this.filters().length || (this.sortableFields()?.length ?? 0));
   readonly hasActiveFilters = computed(() => Object.values(this.selectedFiltersById()).some(values => values.length));
 

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
@@ -60,7 +60,13 @@ export class SearchFilterSortBar {
   selectedSortField = signal<string | undefined>(undefined);
   selectedSortDirection = signal<SortDirection>('DESC');
 
-  readonly searchFieldClass = computed(() => (this.searchWidth() ? this.searchWidth() + ' min-w-0' : 'max-w-[18rem] min-w-[12rem]'));
+  readonly searchFieldClass = computed(() => {
+    const width = this.searchWidth();
+    if (!width) {
+      return 'max-w-[18rem] min-w-[12rem]';
+    }
+    return `max-w-[${width}] min-w-0`;
+  });
   readonly hasMobileActions = computed(() => this.filters().length || (this.sortableFields()?.length ?? 0));
   readonly hasActiveFilters = computed(() => Object.values(this.selectedFiltersById()).some(values => values.length));
 

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
@@ -60,7 +60,7 @@ export class SearchFilterSortBar {
   selectedSortField = signal<string | undefined>(undefined);
   selectedSortDirection = signal<SortDirection>('DESC');
 
-  readonly searchFieldClass = computed(() => (this.searchWidth() ? `${this.searchWidth()} min-w-0` : 'max-w-[18rem] min-w-[12rem]'));
+  readonly searchFieldClass = computed(() => this.searchWidth() ?? 'max-w-[18rem]');
   readonly hasMobileActions = computed(() => this.filters().length || (this.sortableFields()?.length ?? 0));
   readonly hasActiveFilters = computed(() => Object.values(this.selectedFiltersById()).some(values => values.length));
 

--- a/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
+++ b/src/main/webapp/app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar.ts
@@ -60,13 +60,7 @@ export class SearchFilterSortBar {
   selectedSortField = signal<string | undefined>(undefined);
   selectedSortDirection = signal<SortDirection>('DESC');
 
-  readonly searchFieldClass = computed(() => {
-    const width = this.searchWidth();
-    if (!width) {
-      return 'max-w-[18rem] min-w-[12rem]';
-    }
-    return `max-w-[${width}] min-w-0`;
-  });
+  readonly searchFieldClass = computed(() => (this.searchWidth() ? `${this.searchWidth()} min-w-0` : 'max-w-[18rem] min-w-[12rem]'));
   readonly hasMobileActions = computed(() => this.filters().length || (this.sortableFields()?.length ?? 0));
   readonly hasActiveFilters = computed(() => Object.values(this.selectedFiltersById()).some(values => values.length));
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Resolves #2294

The search bar on the admin software dependencies page was too wide, causing poor visual separation between the search input and the filter dropdowns. The existing `fullWidth` boolean on `search-filter-sort-bar` was too coarse — it either constrained the search to `18rem` or removed all constraints entirely.

### Description

- Replaced the `fullWidth` boolean input with a flexible `searchWidth` string input that accepts any CSS width value (e.g. `"30%"`, `"100%"`)
- Used CSS custom properties (`--search-max-width`, `--search-min-width`) set on the host element and referenced in SCSS, avoiding inline style bindings on template elements per client styling guidelines
- Set the admin dependencies page search bar to `searchWidth="30%"` for a smaller, better-separated search input
- Updated the research-group-creation-form caller to `searchWidth="100%"` (functionally equivalent to the old `fullWidth="true"`)
- Removed the `.full-width` SCSS class in favor of CSS variable fallbacks (`var(--search-max-width, 18rem)`)

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as an admin
2. Navigate to the Software Dependencies page (Admin > Dependencies)
3. Verify the search bar is narrower (~30% width) with clear visual separation from the filter dropdowns
4. Verify search and filter functionality still works correctly
5. Navigate to Research Group creation form (Admin > Research Groups > Create)
6. Verify the professor search bar still spans the full width (equivalent to previous `fullWidth` behavior)

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<!-- Screenshots to be added after visual verification -->
Before:
<img width="1584" height="373" alt="image" src="https://github.com/user-attachments/assets/424db12e-31f7-4912-84fc-d319aaa0878e" />

After:
<img width="1584" height="373" alt="image" src="https://github.com/user-attachments/assets/4cc0d81a-cc04-4db4-8000-3b7fbe929c70" />
