### PR TITLE
`Development`: Adjust settings panel width and do not show admin AI settings

### DIFF
--- a/src/main/webapp/app/shared/settings/settings.component.html
+++ b/src/main/webapp/app/shared/settings/settings.component.html
@@ -7,7 +7,7 @@
     [tabs]="tabs()"
     [activeTabId]="activeTab()"
     [lazyLoad]="true"
-    [tabPanelsClass]="'px-4 xl:px-32 2xl:px-64'"
+    [tabPanelsClass]="'w-full max-w-4xl mx-auto px-4 sm:px-5 md:px-6 lg:px-8 xl:px-10'"
     (tabChange)="onTabChange($event)"
   >
     <ng-template jhiTabPanel="general">
@@ -24,8 +24,10 @@
         <jhi-select [items]="themeOptions" [selected]="selectedTheme()" (selectedChange)="onThemeChange($event)" [translateItems]="true" />
       </div>
 
-      <p-divider class="my-6" layout="horizontal" />
-      <jhi-ai-consent-settings [currentRole]="role()" />
+      @if (role() !== UserShortDTORolesEnum.Admin) {
+        <p-divider class="my-6" layout="horizontal" />
+        <jhi-ai-consent-settings [currentRole]="role()" />
+      }
     </ng-template>
 
     <ng-template jhiTabPanel="notifications">

--- a/src/main/webapp/app/shared/settings/settings.component.ts
+++ b/src/main/webapp/app/shared/settings/settings.component.ts
@@ -74,6 +74,7 @@ export class SettingsComponent {
   exportInProgress = signal<boolean>(false);
   exportButtonDisabled = computed(() => this.exportCooldownRemaining() > 0 || this.exportInProgress());
 
+  protected readonly UserShortDTORolesEnum = UserShortDTORolesEnum;
   protected readonly themeService = inject(ThemeService);
   protected readonly accountService = inject(AccountService);
   private readonly destroyRef = inject(DestroyRef);


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #2296 

### Description

<!-- Describe your changes in detail -->
* Updated the `tabPanelsClass` property in `settings.component.html` to use the same sizes as application creation form
* Modified the template to show the `jhi-ai-consent-settings` component only for users who are not admins

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to TUMApply as admin
2. Go to the Settings page -> see that the AI settings are not shown anymore
3. Log in to TUMApply as applicant
4. Go to the Settings page -> see that the tabs are narrower and match the application creation form width

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
<img width="2234" height="1211" alt="image" src="https://github.com/user-attachments/assets/34ae072a-c473-44f8-b049-ceb54c42232d" />

After:
<img width="2234" height="1211" alt="image" src="https://github.com/user-attachments/assets/9bbc74de-3302-42d5-9c78-92fc925e0031" />

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| settings.component.ts | 93.02% | 99 | 35 | 35.4 |

_Last updated: 2026-04-12 21:40:59 UTC_

