### PR TITLE
`Bugfix`: Prevent full page refresh during navigation to settings

### DIFF
--- a/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
@@ -66,7 +66,7 @@
 />
 @if (canManageSubjectAreaSubscriptions()) {
   <p class="mx-auto mt-5 mb-8 max-w-3xl text-center text-sm text-text-secondary">
-    <span>{{ 'jobOverviewPage.notificationsCta.text' | translate }}</span>
+    <span>{{ 'jobOverviewPage.notificationsCta.textPrefix' | translate }}</span>
     <a
       class="font-medium text-primary hover:underline"
       data-testid="notifications-settings-link"
@@ -75,5 +75,6 @@
     >
       {{ 'jobOverviewPage.notificationsCta.link' | translate }}
     </a>
+    <span>{{ 'jobOverviewPage.notificationsCta.textSuffix' | translate }}</span>
   </p>
 }

--- a/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
@@ -65,9 +65,15 @@
   [tableStyle]="{ width: '100%' }"
 />
 @if (canManageSubjectAreaSubscriptions()) {
-  <div
-    class="mx-auto mt-5 mb-8 max-w-3xl text-center text-sm text-text-secondary"
-    jhiTranslate="jobOverviewPage.notificationsCta.text"
-    [translateValues]="notificationsCtaTranslateValues()"
-  ></div>
+  <p class="mx-auto mt-5 mb-8 max-w-3xl text-center text-sm text-text-secondary">
+    <span>{{ 'jobOverviewPage.notificationsCta.text' | translate }}</span>
+    <a
+      class="font-medium text-primary hover:underline"
+      data-testid="notifications-settings-link"
+      [routerLink]="['/settings']"
+      [queryParams]="{ tab: 'notifications' }"
+    >
+      {{ 'jobOverviewPage.notificationsCta.link' | translate }}
+    </a>
+  </p>
 }

--- a/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.ts
+++ b/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.ts
@@ -1,10 +1,10 @@
-import { Component, Signal, computed, effect, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { TableLazyLoadEvent, TableModule } from 'primeng/table';
 import { PaginatorModule } from 'primeng/paginator';
 import { firstValueFrom, map } from 'rxjs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { SearchFilterSortBar } from 'app/shared/components/molecules/search-filter-sort-bar/search-filter-sort-bar';
 import { FilterChange } from 'app/shared/components/atoms/filter-multiselect/filter-multiselect';
 import { ToastService } from 'app/service/toast-service';
@@ -23,7 +23,7 @@ import * as DropdownOptions from '../.././dropdown-options';
 @Component({
   selector: 'jhi-job-card-list',
   standalone: true,
-  imports: [TableModule, JobCardComponent, PaginatorModule, SearchFilterSortBar, TranslateModule, TranslateDirective],
+  imports: [TableModule, JobCardComponent, PaginatorModule, SearchFilterSortBar, TranslateModule, TranslateDirective, RouterLink],
   templateUrl: './job-card-list.component.html',
 })
 export class JobCardListComponent {
@@ -44,7 +44,6 @@ export class JobCardListComponent {
   readonly selectedSubjectAreaFilters = signal<JobFormDTOSubjectAreaEnum[]>([]);
   readonly selectedLocationFilters = signal<JobFormDTOLocationEnum[]>([]);
   readonly selectedSupervisorFilters = signal<string[]>([]);
-  readonly notificationsSettingsHref: Signal<string>;
 
   readonly allSubjectAreas = this.DropdownOptions.subjectAreas.map(option => option.name);
   readonly availableLocationLabels = this.DropdownOptions.locations.map(option => option.name);
@@ -63,18 +62,10 @@ export class JobCardListComponent {
   currentLanguage = toSignal(this.translateService.onLangChange.pipe(map(event => event.lang.toUpperCase())), {
     initialValue: this.translateService.getCurrentLang() ? this.translateService.getCurrentLang().toUpperCase() : 'EN',
   });
-  readonly notificationsCtaTranslateValues = computed(() => {
-    // Recompute the translated link text when the active language changes.
-    this.currentLanguage();
-    return {
-      link: `<a class="font-medium text-primary hover:underline" href="${this.notificationsSettingsHref()}">${this.translateService.instant('jobOverviewPage.notificationsCta.link')}</a>`,
-    };
-  });
   readonly canManageSubjectAreaSubscriptions = computed(
     () => this.accountService.signedIn() && this.accountService.hasAnyAuthority([UserShortDTORolesEnum.Applicant]),
   );
 
-  private readonly router = inject(Router);
   private jobApi = inject(JobResourceApi);
   private readonly toastService = inject(ToastService);
 
@@ -91,9 +82,6 @@ export class JobCardListComponent {
   });
 
   constructor() {
-    this.notificationsSettingsHref = computed(() =>
-      this.router.serializeUrl(this.router.createUrlTree(['/settings'], { queryParams: { tab: 'notifications' } })),
-    );
     void this.loadAllFilter();
   }
 

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -300,7 +300,7 @@
     },
     "hoursPerWeek": "{{workload}} h/Woche",
     "notificationsCta": {
-      "text": "Keine passende Stelle dabei? Erhalte {{link}}.",
+      "text": "Keine passende Stelle dabei? Erhalte ",
       "link": "Benachrichtigungen"
     },
     "errors": {

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -300,8 +300,9 @@
     },
     "hoursPerWeek": "{{workload}} h/Woche",
     "notificationsCta": {
-      "text": "Keine passende Stelle dabei? Erhalte ",
-      "link": "Benachrichtigungen"
+      "textPrefix": "Keine passende Stelle dabei? Erhalte",
+      "link": "Benachrichtigungen",
+      "textSuffix": "."
     },
     "errors": {
       "loadFilter": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -300,7 +300,7 @@
     },
     "hoursPerWeek": "{{workload}} h/week",
     "notificationsCta": {
-      "text": "No suitable job? Receive {{link}}.",
+      "text": "No suitable job? Receive ",
       "link": "notifications"
     },
     "errors": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -300,8 +300,9 @@
     },
     "hoursPerWeek": "{{workload}} h/week",
     "notificationsCta": {
-      "text": "No suitable job? Receive ",
-      "link": "notifications"
+      "textPrefix": "No suitable job? Receive",
+      "link": "notifications",
+      "textSuffix": "."
     },
     "errors": {
       "loadFilter": {

--- a/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
+++ b/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of, throwError } from 'rxjs';
+import { provideRouter, Router } from '@angular/router';
 
 import { JobCardListComponent } from 'app/job/job-overview/job-card-list/job-card-list.component';
 import { JobResourceApi } from 'app/generated/api/job-resource-api';
@@ -9,13 +10,16 @@ import { provideFontAwesomeTesting } from 'src/test/webapp/util/fontawesome.test
 import { ApplicationStatusExtended, JobCardComponent } from 'app/job/job-overview/job-card/job-card.component';
 import * as DropdownOptions from 'app/job/dropdown-options';
 import { JobCardDTOLocationEnum as JobLocationEnum } from 'app/generated/model/job-card-dto';
+import { UserShortDTORolesEnum } from 'app/generated/model/user-short-dto';
 import { By } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
+import { createAccountServiceMock, provideAccountServiceMock } from 'src/test/webapp/util/account.service.mock';
 import { createToastServiceMock, provideToastServiceMock } from '../../../../util/toast-service.mock';
 
 describe('JobCardListComponent', () => {
   let fixture: ComponentFixture<JobCardListComponent>;
   let component: JobCardListComponent;
+  let accountService = createAccountServiceMock();
 
   let jobApi: {
     getAllFilters: ReturnType<typeof vi.fn>;
@@ -46,6 +50,8 @@ describe('JobCardListComponent', () => {
         }),
       ),
     };
+    accountService = createAccountServiceMock();
+    accountService.setAuthorities([UserShortDTORolesEnum.Applicant]);
 
     await TestBed.configureTestingModule({
       imports: [JobCardListComponent],
@@ -54,6 +60,8 @@ describe('JobCardListComponent', () => {
         provideTranslateMock(),
         provideFontAwesomeTesting(),
         provideToastServiceMock(mockToastService),
+        provideAccountServiceMock(accountService),
+        provideRouter([]),
       ],
     }).compileComponents();
 
@@ -336,5 +344,22 @@ describe('JobCardListComponent', () => {
     fixture2.detectChanges();
 
     expect(component2.currentLanguage()).toBe('EN');
+  });
+
+  it('should navigate to notification settings through the Angular router', async () => {
+    const router = TestBed.inject(Router);
+    const navigateByUrlSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+
+    fixture.detectChanges();
+    const link = fixture.nativeElement.querySelector('[data-testid="notifications-settings-link"]') as HTMLAnchorElement | null;
+
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toContain('/settings?tab=notifications');
+
+    link?.click();
+    await fixture.whenStable();
+
+    expect(navigateByUrlSpy).toHaveBeenCalledOnce();
+    expect(router.serializeUrl(navigateByUrlSpy.mock.calls[0][0])).toBe('/settings?tab=notifications');
   });
 });

--- a/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
+++ b/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
@@ -15,6 +15,7 @@ import { By } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { createAccountServiceMock, provideAccountServiceMock } from 'src/test/webapp/util/account.service.mock';
 import { createToastServiceMock, provideToastServiceMock } from '../../../../util/toast-service.mock';
+import { getRequiredAnchor } from 'src/test/webapp/util/utility-methods/dom-query.util';
 
 describe('JobCardListComponent', () => {
   let fixture: ComponentFixture<JobCardListComponent>;
@@ -351,12 +352,11 @@ describe('JobCardListComponent', () => {
     const navigateByUrlSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
     fixture.detectChanges();
-    const link = fixture.nativeElement.querySelector('[data-testid="notifications-settings-link"]') as HTMLAnchorElement | null;
+    const link = getRequiredAnchor(fixture.nativeElement, '[data-testid="notifications-settings-link"]');
 
-    expect(link).not.toBeNull();
-    expect(link?.getAttribute('href')).toContain('/settings?tab=notifications');
+    expect(link.getAttribute('href')).toContain('/settings?tab=notifications');
 
-    link?.click();
+    link.click();
     await fixture.whenStable();
 
     expect(navigateByUrlSpy).toHaveBeenCalledOnce();

--- a/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
+++ b/src/test/webapp/app/job/job-overview/job-card-list/job-card-list.component.spec.ts
@@ -360,6 +360,8 @@ describe('JobCardListComponent', () => {
     await fixture.whenStable();
 
     expect(navigateByUrlSpy).toHaveBeenCalledOnce();
-    expect(router.serializeUrl(navigateByUrlSpy.mock.calls[0][0])).toBe('/settings?tab=notifications');
+    const navigationTarget = navigateByUrlSpy.mock.calls[0][0];
+    const serializedTarget = typeof navigationTarget === 'string' ? navigationTarget : router.serializeUrl(navigationTarget);
+    expect(serializedTarget).toBe('/settings?tab=notifications');
   });
 });

--- a/src/test/webapp/util/utility-methods/dom-query.util.ts
+++ b/src/test/webapp/util/utility-methods/dom-query.util.ts
@@ -5,4 +5,3 @@ export const getRequiredAnchor = (root: ParentNode, selector: string): HTMLAncho
   }
   return element;
 };
-

--- a/src/test/webapp/util/utility-methods/dom-query.util.ts
+++ b/src/test/webapp/util/utility-methods/dom-query.util.ts
@@ -1,0 +1,8 @@
+export const getRequiredAnchor = (root: ParentNode, selector: string): HTMLAnchorElement => {
+  const element = root.querySelector(selector);
+  if (!(element instanceof HTMLAnchorElement)) {
+    throw new Error(`Expected anchor for selector: ${selector}`);
+  }
+  return element;
+};
+


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2277 

### Description

This PR fixes that the application triggers a full browser page refresh, when a user navigates from the Job Card Overview to the Notification settings page.

### Steps for Testing

1. Log in as an Applicant
2. Open the job overview page 
3. Scroll down
4. Click on the the link to the notification settings which you find below the page stepper
5.  Verify the navigation goes to /settings?tab=notifications
6. Verify there is no full browser refresh / no jarring reload

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-card-list.component.ts | 100.00% | 148 | 51 | 34.5 |

_Last updated: 2026-04-16 10:25:12 UTC_

