### PR TITLE
`Test`: Add client tests for profile picture settings

### DIFF
--- a/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
+++ b/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
@@ -1,0 +1,236 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageCropperComponent } from 'ngx-image-cropper';
+
+import { AccountService } from 'app/core/auth/account.service';
+import { ImageResourceApi } from 'app/generated/api/image-resource-api';
+import { UserResourceApi } from 'app/generated/api/user-resource-api';
+import { ToastService } from 'app/service/toast-service';
+import { ButtonComponent } from 'app/shared/components/atoms/button/button.component';
+import { ProfilePictureSettingsComponent } from 'app/shared/settings/profile-picture-settings/profile-picture-settings.component';
+import { createAccountServiceMock } from 'util/account.service.mock';
+import { provideFontAwesomeTesting } from 'util/fontawesome.testing';
+import { provideThemeServiceMock } from 'util/theme.service.mock';
+import { createToastServiceMock } from 'util/toast-service.mock';
+import { provideTranslateMock } from 'util/translate.mock';
+
+type AccountServiceTestMock = ReturnType<typeof createAccountServiceMock> & {
+  setAvatar: ReturnType<typeof vi.fn>;
+};
+
+type ImageCropperTestDouble = Pick<ImageCropperComponent, 'crop'>;
+
+describe('ProfilePictureSettingsComponent', () => {
+  let fixture: ComponentFixture<ProfilePictureSettingsComponent>;
+  let component: ProfilePictureSettingsComponent;
+  let accountServiceMock: AccountServiceTestMock;
+  let imageApiMock: { uploadProfilePicture: ReturnType<typeof vi.fn> };
+  let userApiMock: { updateAvatar: ReturnType<typeof vi.fn> };
+  let toastServiceMock: ReturnType<typeof createToastServiceMock>;
+
+  const createMockFile = (name: string, type: string, size: number): File => {
+    const file = new File(['profile-picture'], name, { type });
+    Object.defineProperty(file, 'size', { value: size });
+    return file;
+  };
+
+  const createFileSelectionEvent = (file: File, value: string): Event => {
+    const input = document.createElement('input');
+    Object.defineProperty(input, 'files', {
+      value: [file],
+    });
+    input.value = value;
+
+    const event = new Event('change');
+    Object.defineProperty(event, 'target', {
+      value: input,
+    });
+
+    return event;
+  };
+
+  const defaultTransform = {
+    scale: 1,
+    rotate: 0,
+    translateH: 0,
+    translateV: 0,
+    translateUnit: 'px',
+  };
+
+  const getButtons = () => fixture.debugElement.queryAll(By.directive(ButtonComponent));
+  const setImageCropper = (cropper: ImageCropperTestDouble | undefined): void => {
+    Object.assign(component, {
+      imageCropper: () => cropper,
+    });
+  };
+
+  beforeEach(async () => {
+    accountServiceMock = createAccountServiceMock() as AccountServiceTestMock;
+    accountServiceMock.user.set({
+      id: 'user-1',
+      name: ' Ada Lovelace ',
+      email: 'ada@example.com',
+      avatar: '/images/original-avatar.jpg',
+      authorities: [],
+    });
+    accountServiceMock.setAvatar = vi.fn((avatarUrl: string | undefined) => {
+      accountServiceMock.user.update(currentUser => (currentUser ? Object.assign({}, currentUser, { avatar: avatarUrl }) : currentUser));
+    });
+
+    imageApiMock = { uploadProfilePicture: vi.fn() };
+    userApiMock = { updateAvatar: vi.fn() };
+    toastServiceMock = createToastServiceMock();
+
+    await TestBed.configureTestingModule({
+      imports: [ProfilePictureSettingsComponent],
+      providers: [
+        { provide: AccountService, useValue: accountServiceMock },
+        { provide: ImageResourceApi, useValue: imageApiMock },
+        { provide: UserResourceApi, useValue: userApiMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        provideTranslateMock(),
+        provideFontAwesomeTesting(),
+        provideThemeServiceMock(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfilePictureSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create and normalize the current user data', () => {
+    expect(component).toBeTruthy();
+    expect(component.fullName()).toBe('Ada Lovelace');
+    expect(component.currentProfilePictureUrl()).toBe('/images/original-avatar.jpg');
+
+    accountServiceMock.user.update(currentUser =>
+      currentUser ? Object.assign({}, currentUser, { name: '   ', avatar: '   ' }) : currentUser,
+    );
+    fixture.detectChanges();
+
+    expect(component.fullName()).toBeUndefined();
+    expect(component.currentProfilePictureUrl()).toBeNull();
+  });
+
+  it('should open the file picker and disable remove when no avatar exists', () => {
+    const fileInput = fixture.nativeElement.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click');
+
+    (getButtons()[0].nativeElement as HTMLElement).click();
+    expect(clickSpy).toHaveBeenCalledOnce();
+
+    accountServiceMock.user.update(currentUser => (currentUser ? Object.assign({}, currentUser, { avatar: undefined }) : currentUser));
+    fixture.detectChanges();
+
+    const removeButton = getButtons()[1].componentInstance as ButtonComponent;
+    expect(removeButton.disabled()).toBe(true);
+  });
+
+  it('should validate file selection and open the crop dialog only for valid images', () => {
+    component.onFileSelected(createFileSelectionEvent(createMockFile('avatar.gif', 'image/gif', 1024), 'invalid'));
+
+    component.onFileSelected(createFileSelectionEvent(createMockFile('large.jpg', 'image/jpeg', 5 * 1024 * 1024 + 1), 'large'));
+
+    const validFile = createMockFile('avatar.png', 'image/png', 1024);
+    const validEvent = createFileSelectionEvent(validFile, 'valid');
+    component.onFileSelected(validEvent);
+
+    expect(toastServiceMock.showErrorKey).toHaveBeenNthCalledWith(1, 'settings.profilePicture.invalidFileType');
+    expect(toastServiceMock.showErrorKey).toHaveBeenNthCalledWith(2, 'settings.profilePicture.fileTooLarge');
+    expect(component.selectedFile()).toBe(validFile);
+    expect(component.cropDialogVisible()).toBe(true);
+    expect(component.cropTransform).toEqual(defaultTransform);
+    expect((validEvent.target as HTMLInputElement).value).toBe('');
+  });
+
+  it('should update crop state and reset on image load failure', () => {
+    component.onImageLoaded();
+    component.onTransformChange({
+      scale: 2,
+      rotate: 90,
+      flipH: true,
+      flipV: false,
+      translateH: 8,
+      translateV: 12,
+      translateUnit: '%',
+    });
+    component.selectedFile.set(createMockFile('avatar.jpg', 'image/jpeg', 1024));
+    component.cropDialogVisible.set(true);
+
+    component.onLoadImageFailed();
+
+    expect(component.imageLoaded()).toBe(false);
+    expect(component.selectedFile()).toBeUndefined();
+    expect(component.cropDialogVisible()).toBe(false);
+    expect(component.cropTransform).toEqual(defaultTransform);
+    expect(toastServiceMock.showErrorKey).toHaveBeenCalledWith('settings.profilePicture.invalidFileType');
+  });
+
+  it('should save the cropped picture and reset the dialog', async () => {
+    const blob = new Blob(['cropped'], { type: 'image/jpeg' });
+    component.selectedFile.set(createMockFile('avatar.jpg', 'image/jpeg', 1024));
+    component.cropDialogVisible.set(true);
+    component.imageLoaded.set(true);
+    setImageCropper({
+      crop: vi.fn().mockResolvedValue({ blob }),
+    });
+    imageApiMock.uploadProfilePicture.mockReturnValue(of({ imageId: 'img-1', url: '/images/uploaded-avatar.jpg' }));
+
+    await component.onSave();
+
+    expect(imageApiMock.uploadProfilePicture).toHaveBeenCalledOnce();
+    expect(accountServiceMock.setAvatar).toHaveBeenCalledWith('/images/uploaded-avatar.jpg');
+    expect(toastServiceMock.showSuccessKey).toHaveBeenCalledWith('settings.profilePicture.saved');
+    expect(component.selectedFile()).toBeUndefined();
+    expect(component.cropDialogVisible()).toBe(false);
+    expect(component.imageLoaded()).toBe(false);
+  });
+
+  it('should not upload without a cropped blob and should show an error when upload fails', async () => {
+    setImageCropper(undefined);
+    await component.onSave();
+
+    setImageCropper({
+      crop: vi.fn().mockResolvedValue({ blob: undefined }),
+    });
+    await component.onSave();
+
+    const blob = new Blob(['cropped'], { type: 'image/jpeg' });
+    setImageCropper({
+      crop: vi.fn().mockResolvedValue({ blob }),
+    });
+    imageApiMock.uploadProfilePicture.mockReturnValue(throwError(() => new Error('upload failed')));
+
+    await component.onSave();
+
+    expect(imageApiMock.uploadProfilePicture).toHaveBeenCalledOnce();
+    expect(accountServiceMock.setAvatar).not.toHaveBeenCalled();
+    expect(toastServiceMock.showErrorKey).toHaveBeenCalledWith('settings.profilePicture.saveFailed');
+  });
+
+  it('should remove the current profile picture', async () => {
+    userApiMock.updateAvatar.mockReturnValue(of(undefined));
+
+    await component.onResetPicture();
+
+    expect(userApiMock.updateAvatar).toHaveBeenCalledWith({});
+    expect(accountServiceMock.setAvatar).toHaveBeenCalledWith(undefined);
+    expect(toastServiceMock.showSuccessKey).toHaveBeenCalledWith('settings.profilePicture.deleted');
+  });
+
+  it('should show an error when removing the profile picture fails', async () => {
+    userApiMock.updateAvatar.mockReturnValue(throwError(() => new Error('delete failed')));
+
+    await component.onResetPicture();
+
+    expect(accountServiceMock.setAvatar).not.toHaveBeenCalled();
+    expect(toastServiceMock.showErrorKey).toHaveBeenCalledWith('settings.profilePicture.deleteFailed');
+  });
+});

--- a/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
+++ b/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
@@ -36,10 +36,10 @@ describe('ProfilePictureSettingsComponent', () => {
     return file;
   };
 
-  const createFileSelectionEvent = (file: File, value: string): Event => {
+  const createFileSelectionEvent = (file: File | undefined, value: string): Event => {
     const input = document.createElement('input');
     Object.defineProperty(input, 'files', {
-      value: [file],
+      value: file ? [file] : [],
     });
     input.value = value;
 
@@ -59,7 +59,11 @@ describe('ProfilePictureSettingsComponent', () => {
     translateUnit: 'px',
   };
 
-  const getButtons = () => fixture.debugElement.queryAll(By.directive(ButtonComponent));
+  const getButtonByIcon = (icon: string) =>
+    fixture.debugElement
+      .queryAll(By.directive(ButtonComponent))
+      .find(debugElement => (debugElement.componentInstance as ButtonComponent).icon() === icon);
+
   const setImageCropper = (cropper: ImageCropperTestDouble | undefined): void => {
     Object.assign(component, {
       imageCropper: () => cropper,
@@ -123,13 +127,19 @@ describe('ProfilePictureSettingsComponent', () => {
     const fileInput = fixture.nativeElement.querySelector('input[type="file"]') as HTMLInputElement;
     const clickSpy = vi.spyOn(fileInput, 'click');
 
-    (getButtons()[0].nativeElement as HTMLElement).click();
+    const editButton = getButtonByIcon('pen');
+    expect(editButton).not.toBeUndefined();
+
+    (editButton!.nativeElement as HTMLElement).click();
     expect(clickSpy).toHaveBeenCalledOnce();
 
     accountServiceMock.user.update(currentUser => (currentUser ? Object.assign({}, currentUser, { avatar: undefined }) : currentUser));
     fixture.detectChanges();
 
-    const removeButton = getButtons()[1].componentInstance as ButtonComponent;
+    const removeButtonDebugElement = getButtonByIcon('trash');
+    expect(removeButtonDebugElement).not.toBeUndefined();
+
+    const removeButton = removeButtonDebugElement!.componentInstance as ButtonComponent;
     expect(removeButton.disabled()).toBe(true);
   });
 
@@ -148,6 +158,34 @@ describe('ProfilePictureSettingsComponent', () => {
     expect(component.cropDialogVisible()).toBe(true);
     expect(component.cropTransform).toEqual(defaultTransform);
     expect((validEvent.target as HTMLInputElement).value).toBe('');
+  });
+
+  it('should ignore empty file selection and reset the crop dialog on cancel', () => {
+    const selectedFile = createMockFile('avatar.jpg', 'image/jpeg', 1024);
+    component.selectedFile.set(selectedFile);
+    component.cropDialogVisible.set(true);
+    component.imageLoaded.set(true);
+    component.onTransformChange({
+      scale: 2,
+      rotate: 90,
+      flipH: true,
+      flipV: false,
+      translateH: 8,
+      translateV: 12,
+      translateUnit: '%',
+    });
+
+    component.onFileSelected(createFileSelectionEvent(undefined, ''));
+
+    expect(component.selectedFile()).toBe(selectedFile);
+    expect(component.cropDialogVisible()).toBe(true);
+
+    component.onCancel();
+
+    expect(component.selectedFile()).toBeUndefined();
+    expect(component.cropDialogVisible()).toBe(false);
+    expect(component.imageLoaded()).toBe(false);
+    expect(component.cropTransform).toEqual(defaultTransform);
   });
 
   it('should update crop state and reset on image load failure', () => {
@@ -198,6 +236,11 @@ describe('ProfilePictureSettingsComponent', () => {
     await component.onSave();
 
     setImageCropper({
+      crop: vi.fn().mockResolvedValue(undefined),
+    });
+    await component.onSave();
+
+    setImageCropper({
       crop: vi.fn().mockResolvedValue({ blob: undefined }),
     });
     await component.onSave();
@@ -206,13 +249,18 @@ describe('ProfilePictureSettingsComponent', () => {
     setImageCropper({
       crop: vi.fn().mockResolvedValue({ blob }),
     });
+    imageApiMock.uploadProfilePicture.mockReturnValue(of({ imageId: 'img-1', url: '   ' }));
+
+    await component.onSave();
+
     imageApiMock.uploadProfilePicture.mockReturnValue(throwError(() => new Error('upload failed')));
 
     await component.onSave();
 
-    expect(imageApiMock.uploadProfilePicture).toHaveBeenCalledOnce();
+    expect(imageApiMock.uploadProfilePicture).toHaveBeenCalledTimes(2);
     expect(accountServiceMock.setAvatar).not.toHaveBeenCalled();
-    expect(toastServiceMock.showErrorKey).toHaveBeenCalledWith('settings.profilePicture.saveFailed');
+    expect(toastServiceMock.showErrorKey).toHaveBeenNthCalledWith(1, 'settings.profilePicture.saveFailed');
+    expect(toastServiceMock.showErrorKey).toHaveBeenNthCalledWith(2, 'settings.profilePicture.saveFailed');
   });
 
   it('should remove the current profile picture', async () => {

--- a/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
+++ b/src/test/webapp/app/shared/settings/profile-picture-settings/profile-picture-settings.component.spec.ts
@@ -4,13 +4,12 @@ import { of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ImageCropperComponent } from 'ngx-image-cropper';
 
-import { AccountService } from 'app/core/auth/account.service';
 import { ImageResourceApi } from 'app/generated/api/image-resource-api';
 import { UserResourceApi } from 'app/generated/api/user-resource-api';
 import { ToastService } from 'app/service/toast-service';
 import { ButtonComponent } from 'app/shared/components/atoms/button/button.component';
 import { ProfilePictureSettingsComponent } from 'app/shared/settings/profile-picture-settings/profile-picture-settings.component';
-import { createAccountServiceMock } from 'util/account.service.mock';
+import { createAccountServiceMock, provideAccountServiceMock } from 'util/account.service.mock';
 import { provideFontAwesomeTesting } from 'util/fontawesome.testing';
 import { provideThemeServiceMock } from 'util/theme.service.mock';
 import { createToastServiceMock } from 'util/toast-service.mock';
@@ -90,7 +89,7 @@ describe('ProfilePictureSettingsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [ProfilePictureSettingsComponent],
       providers: [
-        { provide: AccountService, useValue: accountServiceMock },
+        provideAccountServiceMock(accountServiceMock),
         { provide: ImageResourceApi, useValue: imageApiMock },
         { provide: UserResourceApi, useValue: userApiMock },
         { provide: ToastService, useValue: toastServiceMock },


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2008 

### Description

This PR adds Client Tests for the profile picture settings component

### Steps for Testing

1. Run npm run test:ci

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| profile-picture-settings.component.ts | 100.00% | 147 | 41 | 27.9 |

_Last updated: 2026-04-16 10:24:36 UTC_

