### PR TITLE
`Bugfix`: Center arrow and add wrapping for small displays

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -130,7 +130,7 @@
                 jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.languageNote"
               ></p>
 
-              <div class="flex items-center gap-3 mt-3 mb-3">
+              <div class="flex flex-wrap items-center gap-3 mt-3 mb-3">
                 <jhi-segmented-toggle
                   [value]="segmentValueForCurrentLang()"
                   [disabled]="isGeneratingDraft()"
@@ -144,10 +144,14 @@
                 @if (isTranslating()) {
                   <div class="flex items-center gap-2 px-3 h-8 border border-border-default rounded-lg">
                     <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />
-                    <span class="text-sm font-semibold text-text-primary whitespace-nowrap">
-                      {{ 'jobCreationForm.positionDetailsSection.jobDescription.translating' | translate }}
-                      {{ translationDirectionLabel() }}
-                    </span>
+                    @if (translationDirectionLabels(); as translationDirection) {
+                      <span class="flex items-center gap-1 text-sm font-semibold text-text-primary whitespace-nowrap">
+                        <span jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.translating"></span>
+                        <span class="ml-0.5">{{ translationDirection.source }}</span>
+                        <fa-icon [icon]="['fas', 'arrow-right']" class="text-xs" />
+                        <span>{{ translationDirection.target }}</span>
+                      </span>
+                    }
                   </div>
                 }
               </div>

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -142,7 +142,7 @@
 
                 <!-- Translation indicator with direction -->
                 @if (isTranslating()) {
-                  <div class="flex items-center gap-2 px-3 h-8 border border-border-default rounded-lg">
+                  <div class="flex gap-2 px-3 h-8 border border-border-default rounded-lg">
                     <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />
                     @if (translationDirectionLabels(); as translationDirection) {
                       <span class="flex items-center gap-1 text-sm font-semibold text-text-primary whitespace-nowrap">

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -195,10 +195,13 @@ export class JobCreationFormComponent {
   );
 
   /** Computed: direction label shown during translation (e.g. "EN → DE") */
-  translationDirectionLabel = computed(() => {
+  translationDirectionLabels = computed(() => {
     const target = this.translationTargetLang();
-    if (!target) return '';
-    return target === 'de' ? 'EN → DE' : 'DE → EN';
+    if (!target) return null;
+    return {
+      source: target === 'de' ? 'EN' : 'DE',
+      target: target === 'de' ? 'DE' : 'EN',
+    };
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -194,7 +194,7 @@ export class JobCreationFormComponent {
       : 'jobCreationForm.positionDetailsSection.jobDescription.placeholderDE',
   );
 
-  /** Computed: direction label shown during translation (e.g. "EN → DE") */
+  /** Computed: direction labels shown during translation (e.g. "EN → DE") */
   translationDirectionLabels = computed(() => {
     const target = this.translationTargetLang();
     if (!target) return null;


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #2316 

### Description

<!-- Describe your changes in detail -->
* The arrow of the translation direction indicator is now vertically centered
* The container for the segmented toggle and translation indicator now uses `flex-wrap` to improve responsiveness and handle overflow better on smaller screens.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to TUMApply as professor
2. Create a job or edit an existing one
3. Write a job description
4. See the translation label

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

| Before | After |
| :---: | :---: |
| <img alt="image" src="https://github.com/user-attachments/assets/14dab9d3-fe86-4741-a83a-c698ecf01add" /> | <img alt="image" src="https://github.com/user-attachments/assets/5c617b1e-f6d5-423e-a964-8ba54f718da9" /> |
| <img alt="image" src="https://github.com/user-attachments/assets/e16d23c2-a88b-446a-aa7f-b58d8f6f6deb" /> | <img alt="image" src="https://github.com/user-attachments/assets/ce880fec-ac04-4241-a1de-d8ec84cebfca" /> |

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 64.63% | 1064 | 124 | 11.7 |

_Last updated: 2026-04-18 18:10:58 UTC_

