### PR TITLE
`Bugfix`: Fix job form autosave on language switch, description validation, and login dialog issues

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -37,6 +37,7 @@ import { ImageResourceApi } from 'app/generated/api/image-resource-api';
 import { ImageDTO } from 'app/generated/model/image-dto';
 import { ResearchGroupResourceApi } from 'app/generated/api/research-group-resource-api';
 import { extractCompleteHtmlTags, unescapeJsonString } from 'app/shared/util/util';
+import { extractTextFromHtml } from 'app/shared/util/text.util';
 import {
   ImageUploadButtonComponent,
   ImageUploadError,
@@ -324,11 +325,15 @@ export class JobCreationFormComponent {
   /** Signal that emits when positionDetailsForm status changes */
   positionDetailsChanges = toSignal(this.positionDetailsForm.statusChanges, { initialValue: this.positionDetailsForm.status });
 
-  /** Computed: true when both EN and DE job descriptions have non-empty content */
+  /** Computed: true when both EN and DE job descriptions have non-empty text content.
+   *  Uses jobDescriptionSignal for the active language (updates on every keystroke)
+   *  and the stored signal for the inactive language (synced on tab switch / save).
+   *  Strips HTML tags before checking so that empty editor markup (e.g. `<p></p>`) is treated as empty. */
   bothDescriptionsFilled = computed(() => {
-    const en = this.jobDescriptionEN().trim();
-    const de = this.jobDescriptionDE().trim();
-    return en.length > 0 && de.length > 0;
+    const currentLang = this.currentDescriptionLanguage();
+    const currentText = extractTextFromHtml(this.jobDescriptionSignal());
+    const otherText = extractTextFromHtml(currentLang === 'en' ? this.jobDescriptionDE() : this.jobDescriptionEN());
+    return currentText.length > 0 && otherText.length > 0;
   });
 
   /**
@@ -542,10 +547,15 @@ export class JobCreationFormComponent {
     const currentLang = this.currentDescriptionLanguage();
     if (newLang === currentLang) return;
 
-    // If a save is pending, flush it first so we don't lose text
+    // If a save is pending, flush it immediately so we don't lose text.
+    // syncCurrentEditorIntoLanguageSignals copies the editor HTML into the
+    // language signal, but the languageChangeEffect below sets the form
+    // value with emitEvent:false — so the autosave effect won't re-trigger.
+    // We must call performAutoSave explicitly to persist the content.
     if (this.autoSaveTimer !== undefined) {
       this.clearAutoSaveTimer();
       this.syncCurrentEditorIntoLanguageSignals();
+      void this.performAutoSave();
     }
 
     this.currentDescriptionLanguage.set(newLang);

--- a/src/main/webapp/app/shared/components/atoms/base-input/base-input.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/base-input/base-input.component.ts
@@ -99,7 +99,13 @@ export abstract class BaseInputDirective<T> {
   }
 
   onBlur(): void {
-    this.isTouched.set(true);
+    // When autofocus is enabled, skip marking as touched while the control is
+    // still pristine. This prevents showing validation errors from the
+    // focus→blur cycle triggered by dialog/modal animations before the user
+    // has actually interacted with the field.
+    if (!(this.autofocus() && this.formControl().pristine)) {
+      this.isTouched.set(true);
+    }
     this.isFocused.set(false);
   }
 

--- a/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.html
+++ b/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.html
@@ -26,7 +26,7 @@
         [disabled]="form.invalid || this.authOrchestrator.isBusy() || (form.pristine && submitError())"
         [fullWidth]="true"
         [label]="submitLabel()"
-        [loading]="authOrchestrator.isBusy()"
+        [loading]="isSubmitting()"
         [shouldTranslate]="true"
         type="submit"
       />

--- a/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/credentials-group/credentials-group.component.ts
@@ -61,21 +61,24 @@ export class CredentialsGroupComponent {
     otp: new FormControl<string>('', [Validators.pattern(/^[A-Z0-9]*$/), Validators.maxLength(this.otpLength)]),
   });
   submitError = signal<boolean>(false);
+  isSubmitting = signal<boolean>(false);
 
   async onSubmit(): Promise<void> {
     if (this.form.invalid) {
       return;
     }
-    const credentials = this.form.value as { email: string; password: string };
-    await this.submitHandler()(credentials.email, credentials.password)
-      .then(success => {
-        this.submitError.set(!success);
-        this.afterSubmit(success);
-      })
-      .catch(() => {
-        this.submitError.set(true);
-        this.form.markAsPristine();
-      });
+    this.isSubmitting.set(true);
+    try {
+      const credentials = this.form.value as { email: string; password: string };
+      const success = await this.submitHandler()(credentials.email, credentials.password);
+      this.submitError.set(!success);
+      this.afterSubmit(success);
+    } catch {
+      this.submitError.set(true);
+      this.form.markAsPristine();
+    } finally {
+      this.isSubmitting.set(false);
+    }
   }
 
   private afterSubmit(success: boolean): void {


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Fixes #2318

Several UI bugs were reported during testing of the job creation form and login dialog:
- Autosave content lost when switching language tabs within the 2s debounce window
- Next button incorrectly enabled when one or both job descriptions are empty (empty Quill editor HTML `<p></p>` passed string length checks)
- Login dialog email field showing validation error immediately on open (before user interaction)
- Submit/OTP button showing a loading spinner when Google/Apple IDP login is clicked

### Description

**1. Flush autosave on language switch** (`job-creation-form.component.ts`)
- `changeDescriptionLanguage()` now calls `performAutoSave()` when flushing a pending debounce timer. Previously, the timer was cleared and content was synced to signals, but never persisted — and `languageChangeEffect` sets the new language's form value with `emitEvent: false`, so the autosave effect never re-triggers.

**2. Strip HTML for description validation** (`job-creation-form.component.ts`)
- `bothDescriptionsFilled` now uses `extractTextFromHtml()` (existing utility) to check for actual text content instead of raw HTML string length. Quill stores `<p></p>` or `<p><br></p>` for empty editors, which has `length > 0` but no real content.
- Also changed to read `jobDescriptionSignal()` for the active language (updates every keystroke) instead of the stored EN/DE signals (only sync on autosave/tab switch), so the Next button reacts immediately while typing.

**3. Prevent autofocus blur from showing validation errors** (`base-input.component.ts`)
- `onBlur()` now skips setting `isTouched` when `autofocus()` is enabled and the form control is still `pristine`. This prevents the PrimeNG DynamicDialog animation's focus→blur cycle from marking the email field as touched before any user interaction.

**4. Separate submit spinner from IDP busy state** (`credentials-group.component.ts/html`)
- Added a local `isSubmitting` signal to `CredentialsGroupComponent`. The submit button's `[loading]` now uses `isSubmitting()` instead of the global `authOrchestrator.isBusy()`. The button remains **disabled** via `isBusy()` during any auth action, but the spinner only appears when the form itself is submitted.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a professor or employee

**Job form fixes:**
1. Navigate to job creation
2. Fill in required fields and type a job description in English
3. Switch to German within 2 seconds — verify "Saving Changes" resolves to "Saved" and the content is persisted
4. Clear the English description entirely — verify the Next button stays disabled (not re-enabled after save)
5. Fill only one language description — verify Next button remains disabled
6. Fill both languages — verify Next button becomes enabled

**Login dialog fixes:**
1. Log out and open the login dialog
2. Verify the email field does NOT show a red validation error on open
3. Click the Google login button — verify only the Google button shows activity, NOT the Continue/OTP submit button

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 64.57% | 1067 | 124 | 11.6 |
| base-input.component.ts | 100.00% | 97 | ? | ? |
| credentials-group.component.ts | 100.00% | 85 | 29 | 34.1 |

_Last updated: 2026-04-19 10:42:10 UTC_

