### PR TITLE
`General`: Remove the suffix in the enable-notifications info text

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -373,7 +373,7 @@ export class JobCreationFormComponent {
     const deHtml = currentLang === 'de' ? currentHtml : this.jobDescriptionDE();
 
     // Helper to completely strip ALL whitespace, newlines, and non-breaking spaces for a strict comparison
-    const stripAllWhitespace = (str: string) => (str || '').replace(/[\s\u00A0\n\r]+/g, '');
+    const stripAllWhitespace = (str: string): string => (str || '').replace(/[\s\u00A0\n\r]+/g, '');
 
     // 2) Extract plain text from the user's input
     const enText = stripAllWhitespace(extractTextFromHtml(enHtml));

--- a/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card-list/job-card-list.component.html
@@ -75,6 +75,5 @@
     >
       {{ 'jobOverviewPage.notificationsCta.link' | translate }}
     </a>
-    <span>{{ 'jobOverviewPage.notificationsCta.textSuffix' | translate }}</span>
   </p>
 }

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -321,8 +321,7 @@
     "hoursPerWeek": "{{workload}} h/Woche",
     "notificationsCta": {
       "textPrefix": "Keine passende Stelle dabei? Erhalte",
-      "link": "Benachrichtigungen",
-      "textSuffix": "."
+      "link": "Benachrichtigungen"
     },
     "errors": {
       "loadFilter": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -321,8 +321,7 @@
     "hoursPerWeek": "{{workload}} h/week",
     "notificationsCta": {
       "textPrefix": "No suitable job? Receive",
-      "link": "notifications",
-      "textSuffix": "."
+      "link": "notifications"
     },
     "errors": {
       "loadFilter": {


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes https://github.com/ls1intum/tum-apply/issues/2329

### Description

Currently the enable-notifications info text in job overview ends with a dot suffix. This is not needed and should be removed.

### Steps for Testing

1. Log in as applicant
2. Go to job overview
3. Scroll down to the enable-notifications info text
4. Verify the link doesn't end with a "."

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="604" height="222" alt="image" src="https://github.com/user-attachments/assets/b5078087-9dfc-4432-8de9-ee910fec3bd0" />


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 62.45% | 1148 | 124 | 10.8 |

_Last updated: 2026-04-21 09:57:31 UTC_

