### PR TITLE
`General`: Fix mobile view 

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -203,6 +203,16 @@
                 />
                 <jhi-compliance-popover [issue]="activePopoverIssue()" [x]="popoverX()" [y]="popoverY()" />
               </div>
+              <!-- Mobile: Floating AI button for bottom sheet -->
+              <jhi-button
+                class="flex lg:hidden mb-3 mt-3"
+                severity="primary"
+                icon="custom-sparkle"
+                [label]="'jobCreationForm.aiSidebar.header'"
+                styleClass="!rounded-full !px-3 !py-2 !shadow-lg"
+                (click)="mobileSheetOpen.set(true)"
+                [shouldTranslate]="true"
+              />
             </div>
           </div>
         </form>
@@ -234,17 +244,6 @@
             (filterComplianceCat)="onComplianceFilterChange($event)"
           />
         </aside>
-
-        <!-- Mobile: Floating AI button for bottom sheet -->
-        <jhi-button
-          class="lg:hidden fixed right-4 bottom-34 z-40"
-          severity="primary"
-          icon="custom-sparkle"
-          [label]="'jobCreationForm.aiSidebar.header'"
-          styleClass="!rounded-full !px-4 !py-3 !shadow-lg"
-          (click)="mobileSheetOpen.set(true)"
-          [shouldTranslate]="true"
-        />
 
         <!-- Mobile bottom sheet -->
         <p-drawer

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -15,7 +15,7 @@
   <div class="page-container">
     <div class="page-header flex items-center justify-between">
       <h1 jhiTranslate="{{ pageTitle() }}"></h1>
-      <div class="flex items-center gap-2">
+      <div class="hidden lg:flex items-center gap-2">
         <jhi-segmented-toggle
           class="[&_button]:!min-w-[7rem] [&_button]:!whitespace-nowrap"
           [value]="aiToggleSignal() ? 'right' : 'left'"
@@ -164,9 +164,24 @@
               <!-- Editor -->
               <div>
                 @if (aiToggleSignal()) {
-                  <div class="flex items-center mt-5 -mb-5 justify-end gap-1 text-sm">
+                  <div class="hidden lg:flex items-center mt-5 -mb-5 justify-end gap-1 text-sm">
                     <fa-icon class="text-xs text-primary-default" [icon]="['fas', 'custom-sparkle']" />
                     <p class="m-0" jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiLabel"></p>
+                  </div>
+                  <!-- Mobile view-->
+                  <div class="flex lg:hidden mb-3">
+                    <jhi-button
+                      [label]="
+                        rewriteButtonSignal()
+                          ? 'jobCreationForm.positionDetailsSection.jobDescription.aiButton2'
+                          : 'jobCreationForm.positionDetailsSection.jobDescription.aiButton1'
+                      "
+                      [shouldTranslate]="true"
+                      severity="primary"
+                      icon="custom-sparkle"
+                      [disabled]="isGeneratingDraft()"
+                      (click)="generateJobApplicationDraft()"
+                    />
                   </div>
                 }
                 <jhi-editor
@@ -194,10 +209,10 @@
       </div>
 
       @if (aiToggleSignal()) {
-        <!--AI Assistant sidebar-->
+        <!--Desktop: AI Assistant sidebar-->
         <div class="panel1-divider hidden lg:block" aria-hidden="true"></div>
         <aside
-          class="flex flex-col mx-auto mt-4 w-full max-w-[52rem] overflow-hidden bg-background-default lg:sticky lg:top-0 lg:mx-0 lg:mt-0 lg:w-full lg:max-w-full lg:self-start"
+          class="hidden lg:flex lg:flex-col mx-auto mt-4 w-full max-w-[52rem] overflow-hidden bg-background-default lg:sticky lg:top-0 lg:mx-0 lg:mt-0 lg:w-full lg:max-w-full lg:self-start"
         >
           <div class="flex items-center">
             <div class="flex flex-1 items-center justify-start min-h-16 gap-3 px-5 py-3 text-text-primary">
@@ -213,10 +228,45 @@
             [isRewriteMode]="rewriteButtonSignal()"
             [currentLang]="currentDescriptionLanguage()"
             [complianceIssues]="complianceIssues()"
+            [inclusivePercentage]="genderWordPercentages().inclusivePercentage"
+            [nonInclusivePercentage]="genderWordPercentages().nonInclusivePercentage"
             (generate)="generateJobApplicationDraft()"
             (filterComplianceCat)="onComplianceFilterChange($event)"
           />
         </aside>
+
+        <!-- Mobile: Floating AI button for bottom sheet -->
+        <jhi-button
+          class="lg:hidden fixed right-4 bottom-34 z-40"
+          severity="primary"
+          icon="custom-sparkle"
+          [label]="'jobCreationForm.aiSidebar.header'"
+          styleClass="!rounded-full !px-4 !py-3 !shadow-lg"
+          (click)="mobileSheetOpen.set(true)"
+          [shouldTranslate]="true"
+        />
+
+        <!-- Mobile bottom sheet -->
+        <p-drawer
+          [visible]="mobileSheetOpen()"
+          (visibleChange)="mobileSheetOpen.set($event)"
+          position="bottom"
+          styleClass="lg:!hidden !h-[45vh] !rounded-t-2xl"
+          [showCloseIcon]="true"
+        >
+          <jhi-ai-assistant-card
+            [score]="aiScore()"
+            [isGenerating]="isGeneratingDraft()"
+            [isAnalyzing]="isScoreProcessing()"
+            [isRewriteMode]="rewriteButtonSignal()"
+            [currentLang]="currentDescriptionLanguage()"
+            [complianceIssues]="complianceIssues()"
+            [inclusivePercentage]="genderWordPercentages().inclusivePercentage"
+            [nonInclusivePercentage]="genderWordPercentages().nonInclusivePercentage"
+            [hideGenerateButton]="true"
+            (filterComplianceCat)="onComplianceFilterChange($event)"
+          />
+        </p-drawer>
       }
     </div>
   </ng-template>

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -9,6 +9,7 @@ import { firstValueFrom } from 'rxjs';
 import { DividerModule } from 'primeng/divider';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { CheckboxModule } from 'primeng/checkbox';
+import { DrawerModule } from 'primeng/drawer';
 import { TranslateDirective } from 'app/shared/language';
 import { ProgressStepperComponent, StepData } from 'app/shared/components/molecules/progress-stepper/progress-stepper.component';
 import { ButtonColor, ButtonComponent } from 'app/shared/components/atoms/button/button.component';
@@ -105,6 +106,7 @@ type JobFormMode = 'create' | 'edit';
     CheckboxComponent,
     AiAssistantCardComponent,
     CompliancePopoverComponent,
+    DrawerModule,
   ],
   providers: [JobResourceApi],
 })
@@ -253,7 +255,7 @@ export class JobCreationFormComponent {
   private researchGroupApi = inject(ResearchGroupResourceApi);
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // AI SIGNALS
+  // AI SIDEBAR SIGNALS
   // ═══════════════════════════════════════════════════════════════════════════
 
   /** Score shown in the AI sidebar (undefined = not yet calculated) */
@@ -290,6 +292,21 @@ export class JobCreationFormComponent {
       }
     }
     return undefined;
+  });
+
+  /** Percentage split of gender-coded words from the existing gender-decoder analysis. */
+  readonly genderWordPercentages = computed(() => {
+    const analysis = this.jobDescriptionEditor()?.analysisResult();
+    const words = analysis?.biasedWords ?? [];
+
+    const inclusiveCount = words.filter(word => word.type === 'inclusive').length;
+    const nonInclusiveCount = words.filter(word => word.type === 'non-inclusive').length;
+    const total = inclusiveCount + nonInclusiveCount;
+
+    return {
+      inclusivePercentage: total > 0 ? Math.round((inclusiveCount / total) * 100) : 100,
+      nonInclusivePercentage: total > 0 ? Math.round((nonInclusiveCount / total) * 100) : 0,
+    };
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -332,6 +349,9 @@ export class JobCreationFormComponent {
 
   /** Reference to the job description rich-text editor */
   jobDescriptionEditor = viewChild<EditorComponent>('jobDescriptionEditor');
+
+  /** Signal controlling mobile bottom sheet visibility for AI assistant */
+  mobileSheetOpen = signal(false);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // FORM VALIDITY SIGNALS

--- a/src/main/webapp/app/layouts/footer/footer.component.scss
+++ b/src/main/webapp/app/layouts/footer/footer.component.scss
@@ -1,3 +1,5 @@
+@use '../../../content/scss/breakpoints' as bp;
+
 .footer {
   display: flex;
   background-color: var(--p-background-footer);
@@ -49,12 +51,21 @@
 @media (max-width: 600px) {
   .footer {
     font-size: 0.75rem;
-    padding: 0.5rem;
+    padding: 0.75rem 0.5rem;
+    text-align: left;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    width:100%;
   }
 
-  .logo-section,
-  .rights-section,
-  .legal-section {
-    padding: 0 0.5rem;
+  .footer .logo-section,
+  .footer .rights-section,
+  .footer .legal-section{
+    display: flex;
+    padding-left: 0.5rem;
+    width:100%;
   }
+
+
 }

--- a/src/main/webapp/app/layouts/footer/footer.component.scss
+++ b/src/main/webapp/app/layouts/footer/footer.component.scss
@@ -56,16 +56,14 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-    width:100%;
+    width: 100%;
   }
 
   .footer .logo-section,
   .footer .rights-section,
-  .footer .legal-section{
+  .footer .legal-section {
     display: flex;
     padding-left: 0.5rem;
-    width:100%;
+    width: 100%;
   }
-
-
 }

--- a/src/main/webapp/app/layouts/main/main.component.scss
+++ b/src/main/webapp/app/layouts/main/main.component.scss
@@ -1,3 +1,4 @@
+@use '../../../content/scss/breakpoints' as bp;
 .whole-page {
   display: flex;
   flex-direction: column;
@@ -12,9 +13,13 @@
 
 .main-page {
   --sidebar-expanded: 15rem;
-  --sidebar-collapsed: 5rem;
+  --sidebar-collapsed: 3rem;
   --sidebar-width: var(--sidebar-expanded);
   --sidebar-edge: var(--sidebar-width);
+
+  @media (min-width: bp.$lg) {
+    --sidebar-collapsed: 5rem;
+  }
 
   display: flex;
   flex: 1 1 auto;

--- a/src/main/webapp/app/shared/components/atoms/ai-score-ring/ai-score-ring.component.html
+++ b/src/main/webapp/app/shared/components/atoms/ai-score-ring/ai-score-ring.component.html
@@ -1,4 +1,4 @@
-<div class="grid h-[7.75rem] w-[7.75rem] place-items-center">
+<div class="grid h-24 w-24 lg:h-[7.75rem] lg:w-[7.75rem] place-items-center">
   <svg
     viewBox="0 0 38 38"
     class="col-start-1 row-start-1 h-full w-full origin-center -scale-x-100 rotate-180 overflow-visible fill-none"
@@ -25,10 +25,10 @@
   <!-- Animated score percentage -->
   <div class="col-start-1 row-start-1 inline-flex items-baseline leading-none">
     @if (hasScore()) {
-      <span class="text-3xl font-bold text-text-primary">{{ animatedScore() }}</span>
-      <span class="text-base font-bold text-text-tertiary">%</span>
+      <span class="text-2xl lg:text-3xl font-bold text-text-primary">{{ animatedScore() }}</span>
+      <span class="text-sm lg:text-base font-bold text-text-tertiary">%</span>
     } @else if (isLoading()) {
-      <span class="text-lg font-bold text-text-tertiary animate-pulse">...</span>
+      <span class="text-base lg:text-lg font-bold text-text-tertiary animate-pulse">...</span>
     } @else {
       <span class="text-2xl font-bold text-text-tertiary">N/A</span>
     }

--- a/src/main/webapp/app/shared/components/atoms/ai-score-ring/ai-score-ring.component.html
+++ b/src/main/webapp/app/shared/components/atoms/ai-score-ring/ai-score-ring.component.html
@@ -1,4 +1,4 @@
-<div class="grid h-24 w-24 lg:h-[7.75rem] lg:w-[7.75rem] place-items-center">
+<div class="grid h-24 w-24 lg:h-31 lg:w-31 place-items-center">
   <svg
     viewBox="0 0 38 38"
     class="col-start-1 row-start-1 h-full w-full origin-center -scale-x-100 rotate-180 overflow-visible fill-none"

--- a/src/main/webapp/app/shared/components/atoms/sidebar-button/sidebar-button.component.scss
+++ b/src/main/webapp/app/shared/components/atoms/sidebar-button/sidebar-button.component.scss
@@ -1,3 +1,4 @@
+@use '../../../../../content/scss/breakpoints' as bp;
 .sidebar-button {
   display: flex;
   height: 2.75rem;
@@ -19,6 +20,13 @@
   &.icon-only {
     justify-content: center;
     width: 2.75rem;
+
+    @media (max-width: bp.$lg) {
+      width: 2.25rem;
+      height: 2.25rem;
+      padding: 0.5rem;
+      border-radius: 0.375rem;
+    }
   }
 
   .icon {

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -1,149 +1,205 @@
-<div class="px-4 pt-4 pb-2">
+<div class="px-4 pt-2 pb-2 lg:pt-4">
   <div class="flex flex-col mx-auto w-full max-w-72 gap-4 lg:mx-0">
-    <div class="flex flex-col ai-score-block gap-4">
-      <div class="flex justify-center ai-score-ring-wrapper" [class.opacity-50]="isScoreLoading() && displayedScore() !== undefined">
+    <!-- Mobile: Inclusivity Header -->
+    <div class="flex lg:hidden flex-col gap-2 -mt-2">
+      <h3
+        class="m-0 text-2xl font-semibold text-left text-text-secondary"
+        jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiScoreTitle"
+      ></h3>
+      <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
+    </div>
+
+    <!-- Score + Feedback -->
+    <div class="flex lg:hidden flex-row items-center justify-between gap-4 w-full">
+      <p class="m-0 text-xs md:text-sm leading-tight text-text-secondary text-left flex-1" [jhiTranslate]="scoreFeedback()"></p>
+      <div
+        class="flex justify-center ai-score-ring-wrapper shrink-0"
+        [class.opacity-50]="isScoreLoading() && displayedScore() !== undefined"
+      >
         <jhi-ai-score-ring [score]="displayedScore()" [isLoading]="isScoreLoading()" />
       </div>
-
-      <div class="flex items-center justify-center gap-2 lg:justify-start">
-        <h3
-          class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
-          jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiScoreTitle"
-        ></h3>
-        <jhi-button
-          label="?"
-          severity="primary"
-          variant="outlined"
-          styleClass="!flex !h-6 !w-7 !min-w-5 !shrink-0 !cursor-pointer !items-center !justify-center !whitespace-nowrap !rounded-full !border !border-primary-default !bg-background-default !p-0 !text-xs !font-bold !leading-none !text-text-secondary hover:!text-primary-default hover:brightness-93"
-          (click)="openScoreDialog()"
-        />
-      </div>
-      <!-- Inclusivity feedback text -->
-      <p class="mt-1.5 mb-0 text-sm leading-6 text-text-tertiary text-center lg:text-left" [jhiTranslate]="scoreFeedback()"></p>
     </div>
 
-    <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
-
-    <!-- Compliance Checker -->
-    <h3
-      class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
-      jhiTranslate="jobCreationForm.aiSidebar.complianceHeader"
-    ></h3>
-
-    <div class="flex flex-col gap-1">
-      <p class="m-0 mb-1 text-xs text-text-tertiary" jhiTranslate="jobCreationForm.aiSidebar.filterByCategory"></p>
-
-      <div class="flex flex-col gap-2">
-        <jhi-status-pill
-          labelKey="jobCreationForm.aiSidebar.critical"
-          dotColor="bg-negative-default"
-          [count]="criticalCount()"
-          [isActive]="activeFilter() === ComplianceIssueCategoryEnum.CriticalAgg"
-          [loading]="isAnalyzing()"
-          (selected)="selectCategoryFilter(ComplianceIssueCategoryEnum.CriticalAgg)"
-        />
-        <jhi-status-pill
-          labelKey="jobCreationForm.aiSidebar.transparency"
-          dotColor="bg-warning-default"
-          [count]="transparencyCount()"
-          [isActive]="activeFilter() === ComplianceIssueCategoryEnum.Transparency"
-          [loading]="isAnalyzing()"
-          (selected)="selectCategoryFilter(ComplianceIssueCategoryEnum.Transparency)"
-        />
-      </div>
-    </div>
-
-    <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
-
-    <div class="flex items-start justify-center gap-2 lg:justify-start">
+    <!-- Mobile: Vocabulary Section -->
+    <div class="flex lg:hidden flex-col gap-3">
       <h3
-        class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
-        jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
+        class="m-0 text-2xl font-semibold text-left text-text-secondary"
+        jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.mobileView.genderScaleHeader"
       ></h3>
-      <!-- Tooltip with AI assistant hint -->
-      <fa-icon
-        class="text-primary"
-        [icon]="['fas', 'circle-info']"
-        [pTooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate"
-        tooltipPosition="top"
-      />
+      <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
+
+      <!-- Scale 1: Gender Exclusive Words -->
+      <div class="flex items-center gap-2">
+        <span
+          class="text-xs text-text-secondary whitespace-nowrap"
+          jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.mobileView.genderScale1"
+        ></span>
+        <span class="text-xs font-semibold text-primary-default min-w-10">{{ nonInclusivePercentageDisplay() }}%</span>
+        <div class="flex-1 h-2 rounded-full bg-border-default overflow-hidden">
+          <div class="h-full bg-primary-default rounded-full" [style.width.%]="nonInclusivePercentageDisplay()"></div>
+        </div>
+      </div>
+
+      <!-- Scale 2: Gender Inclusive Words -->
+      <div class="flex items-center gap-2">
+        <span
+          class="text-xs text-text-secondary whitespace-nowrap"
+          jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.mobileView.genderScale2"
+        ></span>
+        <span class="text-xs font-semibold text-primary-default min-w-10">{{ inclusivePercentageDisplay() }}%</span>
+        <div class="flex-1 h-2 rounded-full bg-border-default overflow-hidden">
+          <div class="h-full bg-primary-default rounded-full" [style.width.%]="inclusivePercentageDisplay()"></div>
+        </div>
+      </div>
     </div>
 
-    <p
-      class="m-0 text-sm leading-6 text-text-tertiary text-center lg:text-left"
-      jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHelperText"
-    ></p>
-
-    <div>
-      @if (isGenerating()) {
-        <div class="flex w-full items-center justify-center gap-2 rounded-lg border border-border-default px-3 h-10">
-          <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />
-          <span
-            class="text-sm font-semibold text-text-primary whitespace-nowrap"
-            jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiFillerText"
-          ></span>
+    <div class="flex flex-col ai-score-block gap-4">
+      <!-- Desktop: Score + Feedback  -->
+      <div class="hidden lg:flex lg:flex-col gap-4">
+        <div class="flex justify-center ai-score-ring-wrapper" [class.opacity-50]="isScoreLoading() && displayedScore() !== undefined">
+          <jhi-ai-score-ring [score]="displayedScore()" [isLoading]="isScoreLoading()" />
         </div>
-      } @else {
-        <jhi-button
-          [label]="
-            isRewriteMode()
-              ? 'jobCreationForm.positionDetailsSection.jobDescription.aiButton2'
-              : 'jobCreationForm.positionDetailsSection.jobDescription.aiButton1'
-          "
-          [shouldTranslate]="true"
-          severity="primary"
-          [icon]="buttonIcon()"
-          styleClass="!w-full !justify-center !whitespace-nowrap"
-          (click)="onGenerate()"
-        />
+        <div class="flex align-items gap-2">
+          <h3
+            class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
+            jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiScoreTitle"
+          ></h3>
+          <jhi-button
+            label="?"
+            severity="primary"
+            variant="outlined"
+            styleClass="!flex !h-6 !w-7 !min-w-5 !shrink-0 !cursor-pointer !items-center !justify-center !whitespace-nowrap !rounded-full !border !border-primary-default !bg-background-default !p-0 !text-xs !font-bold !leading-none !text-text-secondary hover:!text-primary-default hover:brightness-93"
+            (click)="openScoreDialog()"
+          />
+        </div>
+        <!-- Inclusivity feedback text -->
+        <p class="mt-1.5 mb-0 text-sm leading-6 text-text-tertiary text-center lg:text-left" [jhiTranslate]="scoreFeedback()"></p>
+      </div>
+
+      <hr class="hidden lg:flex m-0 w-full border-0 border-t border-border-default opacity-70" />
+
+      <!-- Compliance Checker -->
+      <h3
+        class="hidden lg:flex m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
+        jhiTranslate="jobCreationForm.aiSidebar.complianceHeader"
+      ></h3>
+
+      <div class="hidden lg:flex flex-col gap-1">
+        <p class="m-0 mb-1 text-xs text-text-tertiary" jhiTranslate="jobCreationForm.aiSidebar.filterByCategory"></p>
+
+        <div class="flex flex-col gap-2">
+          <jhi-status-pill
+            labelKey="jobCreationForm.aiSidebar.critical"
+            dotColor="bg-negative-default"
+            [count]="criticalCount()"
+            [isActive]="activeFilter() === ComplianceIssueCategoryEnum.CriticalAgg"
+            [loading]="isAnalyzing()"
+            (selected)="selectCategoryFilter(ComplianceIssueCategoryEnum.CriticalAgg)"
+          />
+          <jhi-status-pill
+            labelKey="jobCreationForm.aiSidebar.transparency"
+            dotColor="bg-warning-default"
+            [count]="transparencyCount()"
+            [isActive]="activeFilter() === ComplianceIssueCategoryEnum.Transparency"
+            [loading]="isAnalyzing()"
+            (selected)="selectCategoryFilter(ComplianceIssueCategoryEnum.Transparency)"
+          />
+        </div>
+      </div>
+      @if (!hideGenerateButton()) {
+        <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
+
+        <div class="flex items-start justify-center gap-2 lg:justify-start">
+          <h3
+            class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
+            jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
+          ></h3>
+          <!-- Tooltip with AI assistant hint -->
+          <fa-icon
+            class="text-primary"
+            [icon]="['fas', 'circle-info']"
+            [pTooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate"
+            tooltipPosition="top"
+          />
+        </div>
+
+        <p
+          class="m-0 text-sm leading-6 text-text-tertiary text-center lg:text-left"
+          jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHelperText"
+        ></p>
+
+        <div>
+          @if (isGenerating()) {
+            <div class="flex w-full items-center justify-center gap-2 rounded-lg border border-border-default px-3 h-10">
+              <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />
+              <span
+                class="text-sm font-semibold text-text-primary whitespace-nowrap"
+                jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiFillerText"
+              ></span>
+            </div>
+          } @else {
+            <jhi-button
+              [label]="
+                isRewriteMode()
+                  ? 'jobCreationForm.positionDetailsSection.jobDescription.aiButton2'
+                  : 'jobCreationForm.positionDetailsSection.jobDescription.aiButton1'
+              "
+              [shouldTranslate]="true"
+              severity="primary"
+              [icon]="buttonIcon()"
+              styleClass="!w-full !justify-center !whitespace-nowrap"
+              (click)="onGenerate()"
+            />
+          }
+        </div>
       }
     </div>
   </div>
+
+  <jhi-dialog
+    [visible]="scoreDialogVisible()"
+    [modal]="true"
+    [draggable]="false"
+    [appendTo]="'body'"
+    header="jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title"
+    (visibleChange)="onScoreDialogVisibleChange($event)"
+    styleClass="!w-[90vw] md:!w-[42rem] rounded-xs bg-background-default"
+  >
+    <div class="space-y-6">
+      <div class="text-center">
+        <p class="m-0 text-lg font-semibold leading-6">
+          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.summary' | translate }}
+        </p>
+      </div>
+
+      <div class="grid grid-rows-3 divide-y divide-border-default rounded-md border border-border-default">
+        <div class="grid h-full gap-2 p-4">
+          <p class="m-0 font-semibold leading-6">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section1.title' | translate }}
+          </p>
+          <p class="m-0 leading-6 text-text-secondary">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section1.body' | translate }}
+          </p>
+        </div>
+
+        <div class="grid h-full gap-2 p-4">
+          <p class="m-0 font-semibold leading-6">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section2.title' | translate }}
+          </p>
+          <p class="m-0 leading-6 text-text-secondary">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section2.body' | translate }}
+          </p>
+        </div>
+
+        <div class="grid h-full gap-2 p-4">
+          <p class="m-0 font-semibold leading-6">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section3.title' | translate }}
+          </p>
+          <p class="m-0 leading-6 text-text-secondary">
+            {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section3.body' | translate }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </jhi-dialog>
 </div>
-
-<jhi-dialog
-  [visible]="scoreDialogVisible()"
-  [modal]="true"
-  [draggable]="false"
-  [appendTo]="'body'"
-  header="jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title"
-  (visibleChange)="onScoreDialogVisibleChange($event)"
-  styleClass="!w-[90vw] md:!w-[42rem] rounded-xs bg-background-default"
->
-  <div class="space-y-6">
-    <div class="text-center">
-      <p class="m-0 text-lg font-semibold leading-6">
-        {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.summary' | translate }}
-      </p>
-    </div>
-
-    <div class="grid grid-rows-3 divide-y divide-border-default rounded-md border border-border-default">
-      <div class="grid h-full gap-2 p-4">
-        <p class="m-0 font-semibold leading-6">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section1.title' | translate }}
-        </p>
-        <p class="m-0 leading-6 text-text-secondary">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section1.body' | translate }}
-        </p>
-      </div>
-
-      <div class="grid h-full gap-2 p-4">
-        <p class="m-0 font-semibold leading-6">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section2.title' | translate }}
-        </p>
-        <p class="m-0 leading-6 text-text-secondary">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section2.body' | translate }}
-        </p>
-      </div>
-
-      <div class="grid h-full gap-2 p-4">
-        <p class="m-0 font-semibold leading-6">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section3.title' | translate }}
-        </p>
-        <p class="m-0 leading-6 text-text-secondary">
-          {{ 'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.section3.body' | translate }}
-        </p>
-      </div>
-    </div>
-  </div>
-</jhi-dialog>

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -29,9 +29,9 @@
       <hr class="m-0 w-full border-0 border-t border-border-default opacity-70" />
 
       <!-- Scale 1: Gender Exclusive Words -->
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-3">
         <span
-          class="text-xs text-text-secondary whitespace-nowrap"
+          class="text-[11px] text-text-secondary whitespace-nowrap w-38 shrink-0"
           jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.mobileView.genderScale1"
         ></span>
         <span class="text-xs font-semibold text-primary-default min-w-10">{{ nonInclusivePercentageDisplay() }}%</span>
@@ -41,9 +41,9 @@
       </div>
 
       <!-- Scale 2: Gender Inclusive Words -->
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-3">
         <span
-          class="text-xs text-text-secondary whitespace-nowrap"
+          class="text-[11px] text-text-secondary whitespace-nowrap w-38 shrink-0"
           jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.mobileView.genderScale2"
         ></span>
         <span class="text-xs font-semibold text-primary-default min-w-10">{{ inclusivePercentageDisplay() }}%</span>

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.ts
@@ -39,6 +39,9 @@ export class AiAssistantCardComponent {
   buttonIcon = input<string>('custom-sparkle');
   complianceIssues = input<ComplianceIssue[]>([]);
   currentLang = input<string>('en');
+  hideGenerateButton = input<boolean>(false);
+  inclusivePercentage = input<number | undefined>(undefined);
+  nonInclusivePercentage = input<number | undefined>(undefined);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // CONSTANTS
@@ -77,6 +80,12 @@ export class AiAssistantCardComponent {
     }
     return Math.max(0, Math.min(100, Math.round(value)));
   });
+
+  /** Mobile view genderInclusive percentage for scale */
+  readonly inclusivePercentageDisplay = computed(() => this.toPercentage(this.inclusivePercentage(), 100));
+
+  /** Mobile view genderExclusive percentage for scale */
+  readonly nonInclusivePercentageDisplay = computed(() => this.toPercentage(this.nonInclusivePercentage(), 0));
 
   readonly scoreFeedback = computed(() => {
     const score = this.displayedScore();
@@ -159,5 +168,12 @@ export class AiAssistantCardComponent {
 
   onScoreDialogVisibleChange(isVisible: boolean): void {
     this.scoreDialogVisible.set(isVisible);
+  }
+
+  private toPercentage(value: number | undefined, fallback: number): number {
+    if (value === undefined || !Number.isFinite(value)) {
+      return fallback;
+    }
+    return Math.max(0, Math.min(100, Math.round(value)));
   }
 }

--- a/src/main/webapp/app/shared/components/organisms/header/header.component.html
+++ b/src/main/webapp/app/shared/components/organisms/header/header.component.html
@@ -16,7 +16,7 @@
     }
   </a>
 
-  <div class="flex items-center gap-1 flex-shrink-0">
+  <div class="flex items-center gap-1 flex-shrink-0 ml-4 lg:ml-0">
     <div class="flex items-center gap-1 mr-2">
       @for (language of languages; track language; let isLast = $last) {
         <button

--- a/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.scss
+++ b/src/main/webapp/app/shared/components/organisms/sidebar/sidebar.component.scss
@@ -1,3 +1,5 @@
+@use '../../../../../content/scss/breakpoints' as bp;
+
 .sidebar,
 .sidebar-collapsed {
   display: flex;
@@ -7,8 +9,12 @@
   position: sticky;
   flex: 1 1 auto;
   padding-block: 1rem;
-  padding-inline: 1rem;
+  padding-inline: 0.25rem;
   width: var(--sidebar-width);
+
+  @media (min-width: bp.$lg) {
+    padding-inline: 1rem;
+  }
 
   .settings-content,
   .sidebar-content {

--- a/src/main/webapp/content/scss/prime-ng-overrides.scss
+++ b/src/main/webapp/content/scss/prime-ng-overrides.scss
@@ -198,3 +198,20 @@ p-step[data-p-active='true'] .p-step-title {
 .p-progress-spinner-circle {
   stroke: var(--p-primary-color) !important;
 }
+
+/* -------------------------------
+   Mobile bottom sheet for AI analysis
+---------------------------------- */
+.p-drawer.p-drawer-bottom {
+  padding: 0 !important;
+  margin: 0 !important;
+
+  .p-drawer-content {
+    padding: 0 !important;
+  }
+
+  .p-drawer-header {
+    justify-content: flex-end !important;
+    padding: 0.5rem !important;
+  }
+}

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -7,7 +7,7 @@
       },
       "steps": {
         "basicInfo": {
-          "name": "Grundlegende Informationen",
+          "name": "Grundinformationen",
           "description": "Gib die wichtigsten Details der Stelle an und füge eine klare Beschreibung hinzu."
         },
         "employmentTerms": {
@@ -207,6 +207,11 @@
           "warning": "Deine Ausschreibung könnte inklusiver sein. Stellenanzeigen mit höherem Score sprechen vielfältigere Bewerbende an und erhalten mehr Rückmeldungen.",
           "good": "Das ist schon eine gute Grundlage. Deine Ausschreibung ist bereits inklusiv und spricht viele Bewerbende an. Mit gezielten Verfeinerungen kannst du sie noch stärker machen.",
           "excellent": "Eine wirklich gelungene und einladende Ausschreibung! Deine Ausschreibung ist sehr einladend formuliert und spricht eine breite Vielfalt an Bewerbenden an."
+        },
+        "mobileView": {
+          "genderScaleHeader": "Wortschatz",
+          "genderScale1": "Gender-exklusive Wörter",
+          "genderScale2": "Gender-inklusive Wörter"
         }
       }
     },

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -210,7 +210,7 @@
         },
         "mobileView": {
           "genderScaleHeader": "Wortschatz",
-          "genderScale1": "Gender-exklusive Wörter",
+          "genderScale1": "Nicht-Gender-inklusive Wörter",
           "genderScale2": "Gender-inklusive Wörter"
         }
       }

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -207,6 +207,11 @@
           "warning": "Your job could be more inclusive. Job descriptions with a higher score attract more diverse applicants and get more responses.",
           "good": "This is already a solid foundation. Your posting is inclusive and reaches many candidates. With a few targeted refinements, it can perform even better.",
           "excellent": "A very well-written and inviting job posting! Your posting is very welcoming and appeals to a broad and diverse range of applicants."
+        },
+        "mobileView": {
+          "genderScaleHeader": "Vocabulary",
+          "genderScale1": "Gender-exclusive words",
+          "genderScale2": "Gender-inclusive words"
         }
       }
     },

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -210,7 +210,7 @@
         },
         "mobileView": {
           "genderScaleHeader": "Vocabulary",
-          "genderScale1": "Gender-exclusive words",
+          "genderScale1": "Non-Gender-inclusive words",
           "genderScale2": "Gender-inclusive words"
         }
       }


### PR DESCRIPTION

<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).


#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Ai features are only stacked under the editor. to make it visually more attractive and user friendly I introduce a bottom sheet in mobile view that summarieses the analysis. 
 Closes: https://github.com/ls1intum/tum-apply/issues/2341

### Description


<!-- Describe your changes in detail -->
Optimized the sidebar and header spacing. On mobile, the sidebar width was reduced (via --sidebar-collapsed: 3rem) and padding adjusted to prevent scrunching the main content.
Refactored footer.component to use a vertical stack with left alignment on mobile screens.

AI Assistant has been redesigned for smaller screens. A bottom sheet was introduced using primeNG `p-drawer`, that includes the sidebar features. Compliance is hidden for now, but it still marks compliance errors with highlighter and popover explanations. A new "Vocabulary" section has been added to `ai-assistant-card` to visualize and conclude the gender-inclusivitiy. The ai-score-ring was resized for mobile view.
Updated `prime-ng-overrides` to customize the p-drawer xmark position and default paddings. 
The AI disable button is  temporary hidden till we find a good space for it. However users can still disable in settings which is why I removed it from mobile view for now. 
The generate button was moved on top of the editor so it becomes more attractive on mobile.


### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to TUMApply as prof
2. Nav to Create new position 
3. Turn Responsive Design for developers on and verify changes for both mobile and desktop versions
4. Verify in header userLanguage has gap to professor:in 
5. Verify footer is stacked vertically in columns and left-align
6. Verify navigator sidebar is smaller in mobile version 
7. Verify compliance and Ai enable toggle are hidden in creation form -> mobile view 
8. Verify compliance and Ai enable toggle are displayed in creation form -> desktop view 
9. Verify bottom sheet calculates gender inclusive words correctly 

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

Before: 
<img width="367" height="276" alt="Bildschirmfoto 2026-04-23 um 15 20 06" src="https://github.com/user-attachments/assets/802f396c-07d7-4c1a-b3c3-5cb48f73bafc" />
<img width="380" height="631" alt="Bildschirmfoto 2026-04-23 um 15 19 56" src="https://github.com/user-attachments/assets/41c9890f-55f2-43a3-88b0-079b2a6b7e68" />
<img width="464" height="121" alt="Bildschirmfoto 2026-04-23 um 15 19 47" src="https://github.com/user-attachments/assets/1ad96f82-9005-4bb4-ab71-6cd88abe1606" />
<img width="371" height="646" alt="Bildschirmfoto 2026-04-23 um 15 19 41" src="https://github.com/user-attachments/assets/4a766445-0153-456c-8b48-a59ee9430fe1" />
<img width="409" height="98" alt="Bildschirmfoto 2026-04-23 um 15 19 35" src="https://github.com/user-attachments/assets/d2601f85-8ea0-4803-b14d-b30cd49152d5" />




After: 
<img width="475" height="863" alt="Bildschirmfoto 2026-04-23 um 00 33 54" src="https://github.com/user-attachments/assets/3362340f-4394-44f4-a5cc-ce948caa5a37" />
<img width="465" height="347" alt="Bildschirmfoto 2026-04-23 um 00 34 09" src="https://github.com/user-attachments/assets/49556aa9-e23e-4058-9872-02434054c4df" />
<img width="418" height="824" alt="Bildschirmfoto 2026-04-23 um 03 45 48" src="https://github.com/user-attachments/assets/cdae8347-824d-4e7b-b5d7-d4eeb2366b04" />
<img width="423" height="820" alt="Bildschirmfoto 2026-04-23 um 03 47 20" src="https://github.com/user-attachments/assets/f18da634-23ea-4f5c-ab29-2b802b95d420" />



<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 62.93% | 1162 | 124 | 10.7 |
| ai-assistant-card.component.ts | 91.93% | 117 | 9 | 7.7 |

_Last updated: 2026-04-27 10:01:40 UTC_

