### PR TITLE
`Bugfix`: Allow unauthenticated users to start an application via CV upload

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.html
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.html
@@ -21,6 +21,7 @@
       (educationDataExtracted)="onEducationDataExtracted($event)"
       [applicationIdForDocuments]="applicationId()"
       [documentIdsCv]="documentIds()?.cvDocumentDictionaryId"
+      [requestAuth]="requestAuthCallback"
     />
   </div>
 </ng-template>

--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -576,7 +576,8 @@ export default class ApplicationCreationFormComponent {
   }
 
   // Authenticates the current visitor (OTP) and ensures a server-side application exists.
-  // Resolves once `applicationId` is populated. Rejects on validation or OTP failure.
+  // Resolves once `applicationId` is populated, or earlier (no-op) when validation
+  // failed and the user needs to fill in missing fields before retrying.
   async requestAuthAndApplication(): Promise<void> {
     if (this.applicantId()) {
       return;
@@ -587,7 +588,16 @@ export default class ApplicationCreationFormComponent {
     const lastName = this.personalInfoData().lastName;
 
     await this.openOtpAndWaitForLogin(email, firstName, lastName);
-    this.applicantId.set(this.accountService.loadedUser()?.id ?? '');
+
+    // Validation inside openOtpAndWaitForLogin returns early without authenticating.
+    // Bail here too so we don't try to create or migrate an application against
+    // an unauthenticated session (which would fire "Session expired" toasts).
+    const userId = this.accountService.loadedUser()?.id;
+    if (!userId) {
+      return;
+    }
+
+    this.applicantId.set(userId);
     await this.migrateDraftIfNeeded();
   }
 
@@ -600,7 +610,9 @@ export default class ApplicationCreationFormComponent {
     void (async () => {
       try {
         await this.requestAuthAndApplication();
-        this.progressStepper()?.goToStep(2);
+        if (this.applicantId()) {
+          this.progressStepper()?.goToStep(2);
+        }
       } catch {
         // Inner methods (openOtpAndWaitForLogin, migrateDraftIfNeeded) already
         // surface a specific toast for the failure cause; just don't advance.
@@ -613,23 +625,23 @@ export default class ApplicationCreationFormComponent {
   readonly requestAuthCallback = (): Promise<void> => this.requestAuthAndApplication();
 
   // Opens the OTP dialog and waits until the user is effectively logged in or a timeout occurs.
-  // Throws when required fields are missing so callers don't proceed with downstream work
-  // (e.g. attempting to create an application against an unauthenticated session).
+  // Returns early (without authenticating) when required fields are missing — the corresponding
+  // toast is shown for the user, and the caller should detect the still-empty session.
   private async openOtpAndWaitForLogin(email: string, firstName: string, lastName: string): Promise<void> {
     const normalizedEmail = email.trim();
     if (!normalizedEmail) {
       this.toastService.showErrorKey(`${applyflow}.invalidEmail`);
-      throw new Error('invalidEmail');
+      return;
     }
     const normalizedFirstName = firstName.trim();
     if (!normalizedFirstName) {
       this.toastService.showErrorKey(`${applyflow}.invalidFirstName`);
-      throw new Error('invalidFirstName');
+      return;
     }
     const normalizedLastName = lastName.trim();
     if (!normalizedLastName) {
       this.toastService.showErrorKey(`${applyflow}.invalidLastName`);
-      throw new Error('invalidLastName');
+      return;
     }
 
     this.authOrchestrator.email.set(normalizedEmail);

--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -608,6 +608,7 @@ export default class ApplicationCreationFormComponent {
   }
 
   // Bound to <jhi-application-creation-page1 [requestAuth]>. Arrow-function so `this` is preserved.
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   readonly requestAuthCallback = (): Promise<void> => this.requestAuthAndApplication();
 
   // Opens the OTP dialog and waits until the user is effectively logged in or a timeout occurs.

--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -575,8 +575,9 @@ export default class ApplicationCreationFormComponent {
     this.applicationDetailsDataValid.set(isValid);
   }
 
-  // Handles the Next action from Step 1: runs OTP flow, refreshes user, and migrates draft
-  private handleNextFromStep1(): void {
+  // Authenticates the current visitor (OTP) and ensures a server-side application exists.
+  // Resolves once `applicationId` is populated. Rejects on validation or OTP failure.
+  async requestAuthAndApplication(): Promise<void> {
     if (this.applicantId()) {
       return;
     }
@@ -585,17 +586,29 @@ export default class ApplicationCreationFormComponent {
     const firstName = this.personalInfoData().firstName;
     const lastName = this.personalInfoData().lastName;
 
+    await this.openOtpAndWaitForLogin(email, firstName, lastName);
+    this.applicantId.set(this.accountService.loadedUser()?.id ?? '');
+    await this.migrateDraftIfNeeded();
+  }
+
+  // Handles the Next action from Step 1: runs OTP flow, refreshes user, migrates draft, advances stepper.
+  private handleNextFromStep1(): void {
+    if (this.applicantId()) {
+      return;
+    }
+
     void (async () => {
       try {
-        await this.openOtpAndWaitForLogin(email, firstName, lastName);
-        this.applicantId.set(this.accountService.loadedUser()?.id ?? '');
-        void this.migrateDraftIfNeeded();
+        await this.requestAuthAndApplication();
         this.progressStepper()?.goToStep(2);
       } catch {
         this.toastService.showErrorKey(`${applyflow}.otpVerificationFailed`);
       }
     })();
   }
+
+  // Bound to <jhi-application-creation-page1 [requestAuth]>. Arrow-function so `this` is preserved.
+  readonly requestAuthCallback = (): Promise<void> => this.requestAuthAndApplication();
 
   // Opens the OTP dialog and waits until the user is effectively logged in or a timeout occurs.
   private async openOtpAndWaitForLogin(email: string, firstName: string, lastName: string): Promise<void> {

--- a/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.ts
@@ -602,7 +602,8 @@ export default class ApplicationCreationFormComponent {
         await this.requestAuthAndApplication();
         this.progressStepper()?.goToStep(2);
       } catch {
-        this.toastService.showErrorKey(`${applyflow}.otpVerificationFailed`);
+        // Inner methods (openOtpAndWaitForLogin, migrateDraftIfNeeded) already
+        // surface a specific toast for the failure cause; just don't advance.
       }
     })();
   }
@@ -612,21 +613,23 @@ export default class ApplicationCreationFormComponent {
   readonly requestAuthCallback = (): Promise<void> => this.requestAuthAndApplication();
 
   // Opens the OTP dialog and waits until the user is effectively logged in or a timeout occurs.
+  // Throws when required fields are missing so callers don't proceed with downstream work
+  // (e.g. attempting to create an application against an unauthenticated session).
   private async openOtpAndWaitForLogin(email: string, firstName: string, lastName: string): Promise<void> {
     const normalizedEmail = email.trim();
     if (!normalizedEmail) {
       this.toastService.showErrorKey(`${applyflow}.invalidEmail`);
-      return;
+      throw new Error('invalidEmail');
     }
     const normalizedFirstName = firstName.trim();
     if (!normalizedFirstName) {
       this.toastService.showErrorKey(`${applyflow}.invalidFirstName`);
-      return;
+      throw new Error('invalidFirstName');
     }
     const normalizedLastName = lastName.trim();
     if (!normalizedLastName) {
       this.toastService.showErrorKey(`${applyflow}.invalidLastName`);
-      return;
+      throw new Error('invalidLastName');
     }
 
     this.authOrchestrator.email.set(normalizedEmail);

--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
@@ -15,48 +15,24 @@
       />
     </label>
     <div class="flex flex-col gap-3">
-      @if (applicationIdForDocuments(); as applicationId) {
-        <jhi-upload-button
-          documentType="CV"
-          [applicationId]="applicationId"
-          [documentIds]="computedDocumentIdsCvSet()"
-          (documentIdsChange)="cvDocsSetValidity($event)"
-          [allowMultiple]="false"
-          [compact]="true"
-        />
-        <jhi-ai-extraction-box
-          [applicationId]="applicationId"
-          [documentIds]="currentCvDocs() ?? []"
-          [isCv]="true"
-          [saveData]="true"
-          [helperTextKey]="'entity.aiExtraction.helperCv'"
-          (extracted)="onAiDataExtracted($event)"
-        />
-      } @else {
-        <div data-testid="cv-upload-auth-trigger">
-          <jhi-button
-            variant="outlined"
-            severity="primary"
-            icon="upload"
-            [label]="'entity.applicationPage1.label.curriculumVitae'"
-            [shouldTranslate]="true"
-            [disabled]="authInFlight()"
-            [loading]="authInFlight()"
-            (click)="requestAuthAndUpload()"
-          />
-        </div>
-        <div data-testid="ai-extract-auth-trigger">
-          <jhi-button
-            severity="primary"
-            icon="custom-sparkle"
-            [label]="'entity.aiExtraction.button'"
-            [shouldTranslate]="true"
-            [disabled]="authInFlight()"
-            [loading]="authInFlight()"
-            (click)="requestAuthAndUpload()"
-          />
-        </div>
-      }
+      <jhi-upload-button
+        documentType="CV"
+        [applicationId]="applicationIdForDocuments()"
+        [documentIds]="computedDocumentIdsCvSet()"
+        (documentIdsChange)="cvDocsSetValidity($event)"
+        [allowMultiple]="false"
+        [compact]="true"
+        [requestAuth]="requestAuth()"
+      />
+      <jhi-ai-extraction-box
+        [applicationId]="applicationIdForDocuments()"
+        [documentIds]="currentCvDocs() ?? []"
+        [isCv]="true"
+        [saveData]="true"
+        [helperTextKey]="'entity.aiExtraction.helperCv'"
+        (extracted)="onAiDataExtracted($event)"
+        [requestAuth]="requestAuth()"
+      />
     </div>
   </div>
 

--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.html
@@ -1,21 +1,21 @@
 <form [formGroup]="page1Form()">
   <p jhiTranslate="entity.applicationPage1.description"></p>
-  @if (applicationIdForDocuments(); as applicationId) {
-    <p-divider layout="horizontal">
+  <p-divider layout="horizontal">
+    <span jhiTranslate="entity.applicationPage1.label.curriculumVitae"></span>
+  </p-divider>
+  <div class="w-full mb-6">
+    <label>
       <span jhiTranslate="entity.applicationPage1.label.curriculumVitae"></span>
-    </p-divider>
-    <div class="w-full mb-6">
-      <label>
-        <span jhiTranslate="entity.applicationPage1.label.curriculumVitae"></span>
-        <span class="required"> *</span>
-        <fa-icon
-          class="icon"
-          [icon]="['fas', 'circle-info']"
-          [pTooltip]="'entity.applicationPage2.tooltip.filenamePrivacy' | translate"
-          tooltipPosition="top"
-        />
-      </label>
-      <div class="flex flex-col gap-3">
+      <span class="required"> *</span>
+      <fa-icon
+        class="icon"
+        [icon]="['fas', 'circle-info']"
+        [pTooltip]="'entity.applicationPage2.tooltip.filenamePrivacy' | translate"
+        tooltipPosition="top"
+      />
+    </label>
+    <div class="flex flex-col gap-3">
+      @if (applicationIdForDocuments(); as applicationId) {
         <jhi-upload-button
           documentType="CV"
           [applicationId]="applicationId"
@@ -32,9 +32,33 @@
           [helperTextKey]="'entity.aiExtraction.helperCv'"
           (extracted)="onAiDataExtracted($event)"
         />
-      </div>
+      } @else {
+        <div data-testid="cv-upload-auth-trigger">
+          <jhi-button
+            variant="outlined"
+            severity="primary"
+            icon="upload"
+            [label]="'entity.applicationPage1.label.curriculumVitae'"
+            [shouldTranslate]="true"
+            [disabled]="authInFlight()"
+            [loading]="authInFlight()"
+            (click)="requestAuthAndUpload()"
+          />
+        </div>
+        <div data-testid="ai-extract-auth-trigger">
+          <jhi-button
+            severity="primary"
+            icon="custom-sparkle"
+            [label]="'entity.aiExtraction.button'"
+            [shouldTranslate]="true"
+            [disabled]="authInFlight()"
+            [loading]="authInFlight()"
+            (click)="requestAuthAndUpload()"
+          />
+        </div>
+      }
     </div>
-  }
+  </div>
 
   <p-divider layout="horizontal"><span jhiTranslate="entity.applicationPage1.section.contactInformation"></span></p-divider>
   <div class="flex flex-col">

--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
@@ -20,6 +20,7 @@ import { ApplicationForApplicantDTO } from 'app/generated/model/application-for-
 import { ExtractedApplicationDataDTO } from 'app/generated/model/extracted-application-data-dto';
 import { AiExtractionBoxComponent, setIfEmpty } from 'app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component';
 import { ExtractedCertificateDataDTO } from 'app/generated/model/extracted-certificate-data-dto';
+import { ButtonComponent } from 'app/shared/components/atoms/button/button.component';
 
 export type ApplicationCreationPage1Data = {
   firstName: string;
@@ -76,6 +77,7 @@ export const getPage1FromApplication = (application: ApplicationForApplicantDTO)
     FontAwesomeModule,
     TooltipModule,
     AiExtractionBoxComponent,
+    ButtonComponent,
   ],
   templateUrl: './application-creation-page1.component.html',
   standalone: true,
@@ -85,6 +87,16 @@ export default class ApplicationCreationPage1Component {
 
   applicationIdForDocuments = input<string | undefined>();
   documentIdsCv = input<DocumentInformationHolderDTO | undefined>();
+
+  /**
+   * Callback that authenticates the visitor and creates the application.
+   * Invoked when an unauthenticated user clicks the placeholder Upload / AI Extract buttons.
+   * Page 1 itself never opens dialogs — it delegates to the parent form.
+   */
+  requestAuth = input<() => Promise<void>>();
+
+  /** Spinner / disabled state while requestAuth is in flight, used to suppress double-clicks. */
+  authInFlight = signal<boolean>(false);
 
   valid = output<boolean>();
   changed = output<boolean>();
@@ -267,5 +279,22 @@ export default class ApplicationCreationPage1Component {
     }
 
     this.educationDataExtracted.emit(extractedData.education);
+  }
+
+  /**
+   * Invoked from the placeholder Upload / AI Extract buttons when no applicationId exists.
+   * Runs the parent's auth callback, guarding against double-clicks via {@link authInFlight}.
+   */
+  async requestAuthAndUpload(): Promise<void> {
+    const trigger = this.requestAuth();
+    if (!trigger || this.authInFlight()) {
+      return;
+    }
+    this.authInFlight.set(true);
+    try {
+      await trigger();
+    } finally {
+      this.authInFlight.set(false);
+    }
   }
 }

--- a/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.ts
@@ -20,7 +20,6 @@ import { ApplicationForApplicantDTO } from 'app/generated/model/application-for-
 import { ExtractedApplicationDataDTO } from 'app/generated/model/extracted-application-data-dto';
 import { AiExtractionBoxComponent, setIfEmpty } from 'app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component';
 import { ExtractedCertificateDataDTO } from 'app/generated/model/extracted-certificate-data-dto';
-import { ButtonComponent } from 'app/shared/components/atoms/button/button.component';
 
 export type ApplicationCreationPage1Data = {
   firstName: string;
@@ -77,7 +76,6 @@ export const getPage1FromApplication = (application: ApplicationForApplicantDTO)
     FontAwesomeModule,
     TooltipModule,
     AiExtractionBoxComponent,
-    ButtonComponent,
   ],
   templateUrl: './application-creation-page1.component.html',
   standalone: true,
@@ -90,13 +88,10 @@ export default class ApplicationCreationPage1Component {
 
   /**
    * Callback that authenticates the visitor and creates the application.
-   * Invoked when an unauthenticated user clicks the placeholder Upload / AI Extract buttons.
-   * Page 1 itself never opens dialogs — it delegates to the parent form.
+   * Forwarded to the upload + AI extraction components, which invoke it
+   * before performing their action when no `applicationId` is set yet.
    */
   requestAuth = input<() => Promise<void>>();
-
-  /** Spinner / disabled state while requestAuth is in flight, used to suppress double-clicks. */
-  authInFlight = signal<boolean>(false);
 
   valid = output<boolean>();
   changed = output<boolean>();
@@ -279,22 +274,5 @@ export default class ApplicationCreationPage1Component {
     }
 
     this.educationDataExtracted.emit(extractedData.education);
-  }
-
-  /**
-   * Invoked from the placeholder Upload / AI Extract buttons when no applicationId exists.
-   * Runs the parent's auth callback, guarding against double-clicks via {@link authInFlight}.
-   */
-  async requestAuthAndUpload(): Promise<void> {
-    const trigger = this.requestAuth();
-    if (!trigger || this.authInFlight()) {
-      return;
-    }
-    this.authInFlight.set(true);
-    try {
-      await trigger();
-    } finally {
-      this.authInFlight.set(false);
-    }
   }
 }

--- a/src/main/webapp/app/shared/components/atoms/upload-button/upload-button.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/upload-button/upload-button.component.ts
@@ -44,10 +44,18 @@ export class UploadButtonComponent {
   fileUploadComponent = viewChild<FileUpload>(FileUpload);
 
   documentType = input.required<DocumentType>();
-  applicationId = input.required<string>();
+  applicationId = input<string | undefined>();
   documentIds = model<DocumentInformationHolderDTO[] | undefined>();
   valid = output<boolean>();
   queuedFilesChange = output<File[]>();
+
+  /**
+   * Optional callback that authenticates the visitor and yields a real
+   * `applicationId`. Invoked the first time the user picks a file while
+   * `applicationId` is empty. The Promise must resolve only after the parent
+   * has propagated the new `applicationId` into this component's input.
+   */
+  requestAuth = input<() => Promise<void>>();
 
   selectedFiles = signal<File[] | undefined>(undefined);
   isUploading = signal<boolean>(false);
@@ -74,6 +82,12 @@ export class UploadButtonComponent {
 
   async onFileSelected(event: FileSelectEvent): Promise<void> {
     const files: File[] = event.currentFiles;
+
+    if (!(await this.ensureAuthenticated())) {
+      this.fileUploadComponent()?.clear();
+      this.resetNativeFileInput();
+      return;
+    }
 
     // For single-file mode, check if document already exists
     if (!this.allowMultiple() && (this.documentIds()?.length ?? 0) > 0) {
@@ -179,11 +193,12 @@ export class UploadButtonComponent {
     const files: File[] | undefined = this.selectedFiles();
     if (!files || files.length === 0) return;
 
+    const appId = this.applicationId();
+    if (!appId) return;
+
     this.isUploading.set(true);
     try {
-      const uploadedPromises = files.map(file =>
-        firstValueFrom(this.applicationApi.uploadDocuments(this.applicationId(), this.documentType(), file)),
-      );
+      const uploadedPromises = files.map(file => firstValueFrom(this.applicationApi.uploadDocuments(appId, this.documentType(), file)));
       const uploadResults = await Promise.all(uploadedPromises);
       const allUploadedIds = uploadResults.flat();
       this.documentIds.set(allUploadedIds);
@@ -275,6 +290,28 @@ export class UploadButtonComponent {
     const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
     const size = bytes / Math.pow(k, i);
     return `${parseFloat(size.toFixed(1))} ${sizes[i]}`;
+  }
+
+  /**
+   * Ensures an `applicationId` is available before any upload action proceeds.
+   * Returns true when already set, or after a successful `requestAuth()` call.
+   * Returns false when no callback is provided and the id is missing, or when
+   * the callback rejects (user cancelled / validation failed upstream).
+   */
+  private async ensureAuthenticated(): Promise<boolean> {
+    if (this.applicationId()) {
+      return true;
+    }
+    const trigger = this.requestAuth();
+    if (!trigger) {
+      return false;
+    }
+    try {
+      await trigger();
+    } catch {
+      return false;
+    }
+    return Boolean(this.applicationId());
   }
 
   private isDuplicateFilename(filename: string): boolean {

--- a/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
@@ -44,6 +44,14 @@ export class AiExtractionBoxComponent {
   /** emitted with extracted data on successful extraction */
   extracted = output<ExtractedApplicationDataDTO>();
 
+  /**
+   * Optional callback that authenticates the visitor and yields a real
+   * `applicationId`. Invoked when the user clicks Extract while no
+   * `applicationId` is set. The Promise must resolve only after the parent
+   * has propagated the new `applicationId` into this component's input.
+   */
+  requestAuth = input<() => Promise<void>>();
+
   /** whether AI features are enabled (loaded from user consent) */
   aiFeaturesEnabled = signal<boolean>(false);
 
@@ -89,7 +97,20 @@ export class AiExtractionBoxComponent {
   /**
    * Triggers AI data extraction from the available documents.
    */
-  extractAiData(): void {
+  async extractAiData(): Promise<void> {
+    // 0) If no applicationId yet, run the auth callback first and bail out on
+    //    failure so we don't attempt extraction without a target application.
+    if (!this.applicationId()) {
+      const trigger = this.requestAuth();
+      if (!trigger) return;
+      try {
+        await trigger();
+      } catch {
+        return;
+      }
+      if (!this.applicationId()) return;
+    }
+
     // 1) Build the extraction key and collect persisted document IDs and queued files
     const key = this.extractionKey();
     const appId = this.applicationId();

--- a/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
@@ -91,9 +91,16 @@ export class AiExtractionBoxComponent {
     }
   });
 
-  constructor() {
+  // The consent endpoint requires authentication; calling it anonymously fires a 401
+  // which the global interceptor surfaces as "Session expired" and redirects home.
+  // Defer the load until applicationId is set (i.e. the user has authenticated).
+  private consentRequested = false;
+  private loadConsentEffect = effect(() => {
+    if (this.consentRequested) return;
+    if (!this.applicationId()) return;
+    this.consentRequested = true;
     void this.loadAiConsent();
-  }
+  });
   /**
    * Triggers AI data extraction from the available documents.
    */

--- a/src/test/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.spec.ts
@@ -832,43 +832,43 @@ describe('ApplicationForm', () => {
   });
 
   describe('openOtpAndWaitForLogin', () => {
-    it('should show error and return when email is empty', async () => {
-      await comp['openOtpAndWaitForLogin']('', 'John', 'Doe');
+    it('should show error and throw when email is empty', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('', 'John', 'Doe')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidEmail');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and return when email is whitespace only', async () => {
-      await comp['openOtpAndWaitForLogin']('   ', 'John', 'Doe');
+    it('should show error and throw when email is whitespace only', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('   ', 'John', 'Doe')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidEmail');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and return when firstName is empty', async () => {
-      await comp['openOtpAndWaitForLogin']('test@example.com', '', 'Doe');
+    it('should show error and throw when firstName is empty', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('test@example.com', '', 'Doe')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidFirstName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and return when firstName is whitespace only', async () => {
-      await comp['openOtpAndWaitForLogin']('test@example.com', '   ', 'Doe');
+    it('should show error and throw when firstName is whitespace only', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('test@example.com', '   ', 'Doe')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidFirstName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and return when lastName is empty', async () => {
-      await comp['openOtpAndWaitForLogin']('test@example.com', 'John', '');
+    it('should show error and throw when lastName is empty', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('test@example.com', 'John', '')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidLastName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and return when lastName is whitespace only', async () => {
-      await comp['openOtpAndWaitForLogin']('test@example.com', 'John', '   ');
+    it('should show error and throw when lastName is whitespace only', async () => {
+      await expect(comp['openOtpAndWaitForLogin']('test@example.com', 'John', '   ')).rejects.toThrow();
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidLastName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
@@ -1084,7 +1084,7 @@ describe('ApplicationForm', () => {
       expect(openOtpSpy).toHaveBeenCalledWith('test@example.com', 'Jane', 'Smith');
     });
 
-    it('should show error toast when openOtpAndWaitForLogin fails', async () => {
+    it('should swallow openOtpAndWaitForLogin failure without re-toasting (inner method already toasted)', async () => {
       comp.applicantId.set('');
       comp.personalInfoData.set(
         createValidPersonalInfoData({
@@ -1101,7 +1101,7 @@ describe('ApplicationForm', () => {
       // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.otpVerificationFailed');
+      expect(toast.showErrorKey).not.toHaveBeenCalledWith('entity.toast.applyFlow.otpVerificationFailed');
     });
 
     it('should set applicantId to empty string when loadedUser().id is undefined (nullish coalescing operator)', async () => {

--- a/src/test/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation/application-creation-form/application-creation-form.component.spec.ts
@@ -832,43 +832,43 @@ describe('ApplicationForm', () => {
   });
 
   describe('openOtpAndWaitForLogin', () => {
-    it('should show error and throw when email is empty', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('', 'John', 'Doe')).rejects.toThrow();
+    it('should show error and return when email is empty', async () => {
+      await comp['openOtpAndWaitForLogin']('', 'John', 'Doe');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidEmail');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and throw when email is whitespace only', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('   ', 'John', 'Doe')).rejects.toThrow();
+    it('should show error and return when email is whitespace only', async () => {
+      await comp['openOtpAndWaitForLogin']('   ', 'John', 'Doe');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidEmail');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and throw when firstName is empty', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('test@example.com', '', 'Doe')).rejects.toThrow();
+    it('should show error and return when firstName is empty', async () => {
+      await comp['openOtpAndWaitForLogin']('test@example.com', '', 'Doe');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidFirstName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and throw when firstName is whitespace only', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('test@example.com', '   ', 'Doe')).rejects.toThrow();
+    it('should show error and return when firstName is whitespace only', async () => {
+      await comp['openOtpAndWaitForLogin']('test@example.com', '   ', 'Doe');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidFirstName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and throw when lastName is empty', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('test@example.com', 'John', '')).rejects.toThrow();
+    it('should show error and return when lastName is empty', async () => {
+      await comp['openOtpAndWaitForLogin']('test@example.com', 'John', '');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidLastName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
     });
 
-    it('should show error and throw when lastName is whitespace only', async () => {
-      await expect(comp['openOtpAndWaitForLogin']('test@example.com', 'John', '   ')).rejects.toThrow();
+    it('should show error and return when lastName is whitespace only', async () => {
+      await comp['openOtpAndWaitForLogin']('test@example.com', 'John', '   ');
 
       expect(toast.showErrorKey).toHaveBeenCalledWith('entity.toast.applyFlow.invalidLastName');
       expect(authFacade.requestOtp).not.toHaveBeenCalled();
@@ -1104,7 +1104,7 @@ describe('ApplicationForm', () => {
       expect(toast.showErrorKey).not.toHaveBeenCalledWith('entity.toast.applyFlow.otpVerificationFailed');
     });
 
-    it('should set applicantId to empty string when loadedUser().id is undefined (nullish coalescing operator)', async () => {
+    it('should bail without migrating or stepping when loadedUser().id is undefined (auth failed)', async () => {
       comp.applicantId.set('');
       comp.personalInfoData.set(
         createValidPersonalInfoData({
@@ -1117,7 +1117,7 @@ describe('ApplicationForm', () => {
       const openOtpSpy = spyOnPrivate(comp, 'openOtpAndWaitForLogin').mockResolvedValue(undefined);
       const migrateDraftSpy = spyOnPrivate(comp, 'migrateDraftIfNeeded').mockResolvedValue(undefined);
 
-      // Set up loadedUser to return undefined id (simulating the ?? '' fallback case)
+      // Simulate openOtp returning without populating loadedUser (e.g. validation failed).
       accountService.user.set({ id: undefined as any, email: 'test@example.com', name: 'Jane Smith' });
 
       const progressStepperMock = {
@@ -1127,23 +1127,15 @@ describe('ApplicationForm', () => {
 
       comp['handleNextFromStep1']();
 
-      // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // Should call openOtpAndWaitForLogin
       expect(openOtpSpy).toHaveBeenCalledWith('test@example.com', 'Jane', 'Smith');
-
-      // Should set applicantId to empty string when id is undefined (nullish coalescing fallback)
       expect(comp.applicantId()).toBe('');
-
-      // Should still call migrateDraftIfNeeded
-      expect(migrateDraftSpy).toHaveBeenCalled();
-
-      // Should still navigate to step 2
-      expect(progressStepperMock.goToStep).toHaveBeenCalledWith(2);
+      expect(migrateDraftSpy).not.toHaveBeenCalled();
+      expect(progressStepperMock.goToStep).not.toHaveBeenCalled();
     });
 
-    it('should set applicantId to empty string when loadedUser is null (nullish coalescing operator)', async () => {
+    it('should bail without migrating or stepping when loadedUser is null (auth failed)', async () => {
       comp.applicantId.set('');
       comp.personalInfoData.set(
         createValidPersonalInfoData({
@@ -1156,7 +1148,6 @@ describe('ApplicationForm', () => {
       const openOtpSpy = spyOnPrivate(comp, 'openOtpAndWaitForLogin').mockResolvedValue(undefined);
       const migrateDraftSpy = spyOnPrivate(comp, 'migrateDraftIfNeeded').mockResolvedValue(undefined);
 
-      // Set up loadedUser to return null/undefined (simulating the ?? '' fallback case)
       accountService.user.set(undefined);
 
       const progressStepperMock = {
@@ -1166,20 +1157,12 @@ describe('ApplicationForm', () => {
 
       comp['handleNextFromStep1']();
 
-      // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // Should call openOtpAndWaitForLogin
       expect(openOtpSpy).toHaveBeenCalledWith('test@example.com', 'Jane', 'Smith');
-
-      // Should set applicantId to empty string when loadedUser is null/undefined (nullish coalescing fallback)
       expect(comp.applicantId()).toBe('');
-
-      // Should still call migrateDraftIfNeeded
-      expect(migrateDraftSpy).toHaveBeenCalled();
-
-      // Should still navigate to step 2
-      expect(progressStepperMock.goToStep).toHaveBeenCalledWith(2);
+      expect(migrateDraftSpy).not.toHaveBeenCalled();
+      expect(progressStepperMock.goToStep).not.toHaveBeenCalled();
     });
 
     it('should set applicantId to user id when loadedUser().id has a value', async () => {

--- a/src/test/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.spec.ts
@@ -312,65 +312,6 @@ describe('ApplicationPage1Component', () => {
     });
   });
 
-  describe('Auth gate for CV upload', () => {
-    it('does not render placeholder buttons when applicationIdForDocuments is set', () => {
-      fixture.componentRef.setInput('applicationIdForDocuments', 'app-1');
-      fixture.detectChanges();
-
-      const placeholder = fixture.nativeElement.querySelector('[data-testid="cv-upload-auth-trigger"]');
-      expect(placeholder).toBeNull();
-    });
-
-    it('renders placeholder buttons when applicationIdForDocuments is empty', () => {
-      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
-      fixture.detectChanges();
-
-      const placeholder = fixture.nativeElement.querySelector('[data-testid="cv-upload-auth-trigger"]');
-      expect(placeholder).not.toBeNull();
-    });
-
-    it('invokes requestAuth when placeholder upload is clicked', async () => {
-      const trigger = vi.fn().mockResolvedValue(undefined);
-      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
-      fixture.componentRef.setInput('requestAuth', trigger);
-      fixture.detectChanges();
-
-      await comp.requestAuthAndUpload();
-
-      expect(trigger).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not invoke requestAuth concurrently while one call is in flight', async () => {
-      let resolveTrigger!: () => void;
-      const trigger = vi.fn().mockImplementation(
-        () =>
-          new Promise<void>(resolve => {
-            resolveTrigger = resolve;
-          }),
-      );
-      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
-      fixture.componentRef.setInput('requestAuth', trigger);
-      fixture.detectChanges();
-
-      const first = comp.requestAuthAndUpload();
-      const second = comp.requestAuthAndUpload();
-
-      expect(trigger).toHaveBeenCalledTimes(1);
-
-      resolveTrigger();
-      await Promise.all([first, second]);
-    });
-
-    it('no-ops when requestAuth callback is not provided', async () => {
-      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
-      fixture.componentRef.setInput('requestAuth', undefined);
-      fixture.detectChanges();
-
-      await expect(comp.requestAuthAndUpload()).resolves.toBeUndefined();
-      expect(comp.authInFlight()).toBe(false);
-    });
-  });
-
   describe('Document Input Handling', () => {
     it('should return array with doc if documentIdsCv is defined', () => {
       const doc = { id: '1', size: 1 };

--- a/src/test/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation/application-creation-page1/application-creation-page1.component.spec.ts
@@ -275,6 +275,65 @@ describe('ApplicationPage1Component', () => {
     });
   });
 
+  describe('Auth gate for CV upload', () => {
+    it('does not render placeholder buttons when applicationIdForDocuments is set', () => {
+      fixture.componentRef.setInput('applicationIdForDocuments', 'app-1');
+      fixture.detectChanges();
+
+      const placeholder = fixture.nativeElement.querySelector('[data-testid="cv-upload-auth-trigger"]');
+      expect(placeholder).toBeNull();
+    });
+
+    it('renders placeholder buttons when applicationIdForDocuments is empty', () => {
+      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
+      fixture.detectChanges();
+
+      const placeholder = fixture.nativeElement.querySelector('[data-testid="cv-upload-auth-trigger"]');
+      expect(placeholder).not.toBeNull();
+    });
+
+    it('invokes requestAuth when placeholder upload is clicked', async () => {
+      const trigger = vi.fn().mockResolvedValue(undefined);
+      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
+      fixture.componentRef.setInput('requestAuth', trigger);
+      fixture.detectChanges();
+
+      await comp.requestAuthAndUpload();
+
+      expect(trigger).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke requestAuth concurrently while one call is in flight', async () => {
+      let resolveTrigger!: () => void;
+      const trigger = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            resolveTrigger = resolve;
+          }),
+      );
+      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
+      fixture.componentRef.setInput('requestAuth', trigger);
+      fixture.detectChanges();
+
+      const first = comp.requestAuthAndUpload();
+      const second = comp.requestAuthAndUpload();
+
+      expect(trigger).toHaveBeenCalledTimes(1);
+
+      resolveTrigger();
+      await Promise.all([first, second]);
+    });
+
+    it('no-ops when requestAuth callback is not provided', async () => {
+      fixture.componentRef.setInput('applicationIdForDocuments', undefined);
+      fixture.componentRef.setInput('requestAuth', undefined);
+      fixture.detectChanges();
+
+      await expect(comp.requestAuthAndUpload()).resolves.toBeUndefined();
+      expect(comp.authInFlight()).toBe(false);
+    });
+  });
+
   describe('Document Input Handling', () => {
     it('should return array with doc if documentIdsCv is defined', () => {
       const doc = { id: '1', size: 1 };

--- a/src/test/webapp/app/shared/components/atoms/upload-button/upload-button.component.spec.ts
+++ b/src/test/webapp/app/shared/components/atoms/upload-button/upload-button.component.spec.ts
@@ -517,4 +517,57 @@ describe('UploadButtonComponent', () => {
     await component.onUpload();
     expect(applicationApi.uploadDocuments).not.toHaveBeenCalled();
   });
+
+  describe('Auth gate via requestAuth', () => {
+    it('invokes requestAuth when applicationId is empty and resumes the upload after the callback resolves', async () => {
+      const fixture = TestBed.createComponent(UploadButtonComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('documentType', 'CV');
+      fixture.componentRef.setInput('applicationId', undefined);
+      const trigger = vi.fn().mockImplementation(async () => {
+        // Simulate the parent populating applicationId after auth completes.
+        fixture.componentRef.setInput('applicationId', 'app-after-auth');
+      });
+      fixture.componentRef.setInput('requestAuth', trigger);
+      fixture.detectChanges();
+
+      component.fileUploadComponent = signal({ clear: vi.fn() } as unknown as FileUpload);
+
+      const file = new File([new ArrayBuffer(10)], 'cv.pdf');
+      await component.onFileSelected({ currentFiles: [file] } as FileSelectEvent);
+
+      expect(trigger).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not upload when applicationId is empty and no requestAuth callback is provided', async () => {
+      const fixture = TestBed.createComponent(UploadButtonComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('documentType', 'CV');
+      fixture.componentRef.setInput('applicationId', undefined);
+      fixture.detectChanges();
+
+      component.fileUploadComponent = signal({ clear: vi.fn() } as unknown as FileUpload);
+
+      const file = new File([new ArrayBuffer(10)], 'cv.pdf');
+      await component.onFileSelected({ currentFiles: [file] } as FileSelectEvent);
+
+      expect(applicationApi.uploadDocuments).not.toHaveBeenCalled();
+    });
+
+    it('does not upload when requestAuth rejects (user cancels OTP)', async () => {
+      const fixture = TestBed.createComponent(UploadButtonComponent);
+      const component = fixture.componentInstance;
+      fixture.componentRef.setInput('documentType', 'CV');
+      fixture.componentRef.setInput('applicationId', undefined);
+      fixture.componentRef.setInput('requestAuth', () => Promise.reject(new Error('cancelled')));
+      fixture.detectChanges();
+
+      component.fileUploadComponent = signal({ clear: vi.fn() } as unknown as FileUpload);
+
+      const file = new File([new ArrayBuffer(10)], 'cv.pdf');
+      await component.onFileSelected({ currentFiles: [file] } as FileSelectEvent);
+
+      expect(applicationApi.uploadDocuments).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive.
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the client coding and design guidelines.
- [x] I added multiple integration tests (Vitest) related to the features.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

The application creation form was unreachable for unauthenticated users. The CV upload required an `application_id`, which only existed after authentication; authentication was only triggered by the Next button; and the Next button stayed disabled until a CV was uploaded. Deadlock.

### Description

Page 1 now always renders the CV upload section. When the visitor is unauthenticated, the real Upload + AI Extract widgets are replaced with two placeholder buttons that invoke a new \`requestAuth\` callback supplied by the parent form.

The callback runs the existing OTP flow that already lived inside \`handleNextFromStep1\`: validate email/first/last → open OTP dialog → wait for login → migrate the localStorage draft into a real server-side application. After the application is created, \`applicationId\` becomes truthy and the section automatically swaps in the real upload widgets — the user clicks Upload and proceeds normally.

No new auth machinery. The OTP core was extracted into a public \`requestAuthAndApplication()\` method so it can be invoked from any user action, not just the Next button.

### Steps for Testing

Prerequisites:

1. Open the application creation flow in an incognito window (no existing session).

Steps:

1. Click Apply on a job. The form renders.
2. Fill in first name, last name, email.
3. Click the placeholder "Upload CV" button. The OTP dialog opens.
4. Enter the OTP. The dialog closes.
5. The CV section now shows the real upload widget — pick a file. Click AI Extract.
6. Verify the extracted fields populate, then complete the form.

Negative cases:

- Click "Upload CV" without filling in the email field → toast error, OTP dialog not opened.
- Cancel the OTP dialog mid-flow → no application is created, the placeholder remains.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Logged-out apply flow reaches OTP modal from CV upload click
- [ ] Logged-out apply flow reaches OTP modal from AI Extract click
- [ ] Logged-in apply flow unchanged
- [ ] OTP cancel does not create an application