### PR TITLE
`Bugfix`: Persist grade limits when grade is set via AI extraction

### DIFF
--- a/src/main/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.ts
@@ -153,22 +153,21 @@ export default class ApplicationCreationPage2Component {
       masterGrade: data.masterGrade,
     });
 
-    // If incoming data has a grade but empty limits (AI-extraction-on-Page-1 path),
-    // back-fill the limit controls now. Done before hasInitialLimitsSet flips on so
-    // bachelorGradeEffect's "grade unchanged" short-circuit can't strand us.
+    // Back-fill must run before hasInitialLimitsSet flips on, otherwise
+    // bachelorGradeEffect's "grade unchanged" guard short-circuits forever.
     const gradePatch: Partial<ApplicationCreationPage2Data> = {};
     if (data.bachelorGrade && !data.bachelorGradeUpperLimit && !data.bachelorGradeLowerLimit) {
-      const computed = getDetectedGradeLimitsPatch(data.bachelorGrade);
-      if (computed.upperLimit !== '' && computed.lowerLimit !== '') {
-        gradePatch.bachelorGradeUpperLimit = computed.upperLimit;
-        gradePatch.bachelorGradeLowerLimit = computed.lowerLimit;
+      const detected = getDetectedGradeLimitsPatch(data.bachelorGrade);
+      if (detected.upperLimit !== '' && detected.lowerLimit !== '') {
+        gradePatch.bachelorGradeUpperLimit = detected.upperLimit;
+        gradePatch.bachelorGradeLowerLimit = detected.lowerLimit;
       }
     }
     if (data.masterGrade && !data.masterGradeUpperLimit && !data.masterGradeLowerLimit) {
-      const computed = getDetectedGradeLimitsPatch(data.masterGrade);
-      if (computed.upperLimit !== '' && computed.lowerLimit !== '') {
-        gradePatch.masterGradeUpperLimit = computed.upperLimit;
-        gradePatch.masterGradeLowerLimit = computed.lowerLimit;
+      const detected = getDetectedGradeLimitsPatch(data.masterGrade);
+      if (detected.upperLimit !== '' && detected.lowerLimit !== '') {
+        gradePatch.masterGradeUpperLimit = detected.upperLimit;
+        gradePatch.masterGradeLowerLimit = detected.lowerLimit;
       }
     }
     if (Object.keys(gradePatch).length > 0) {

--- a/src/main/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.ts
+++ b/src/main/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.ts
@@ -153,6 +153,28 @@ export default class ApplicationCreationPage2Component {
       masterGrade: data.masterGrade,
     });
 
+    // If incoming data has a grade but empty limits (AI-extraction-on-Page-1 path),
+    // back-fill the limit controls now. Done before hasInitialLimitsSet flips on so
+    // bachelorGradeEffect's "grade unchanged" short-circuit can't strand us.
+    const gradePatch: Partial<ApplicationCreationPage2Data> = {};
+    if (data.bachelorGrade && !data.bachelorGradeUpperLimit && !data.bachelorGradeLowerLimit) {
+      const computed = getDetectedGradeLimitsPatch(data.bachelorGrade);
+      if (computed.upperLimit !== '' && computed.lowerLimit !== '') {
+        gradePatch.bachelorGradeUpperLimit = computed.upperLimit;
+        gradePatch.bachelorGradeLowerLimit = computed.lowerLimit;
+      }
+    }
+    if (data.masterGrade && !data.masterGradeUpperLimit && !data.masterGradeLowerLimit) {
+      const computed = getDetectedGradeLimitsPatch(data.masterGrade);
+      if (computed.upperLimit !== '' && computed.lowerLimit !== '') {
+        gradePatch.masterGradeUpperLimit = computed.upperLimit;
+        gradePatch.masterGradeLowerLimit = computed.lowerLimit;
+      }
+    }
+    if (Object.keys(gradePatch).length > 0) {
+      this.page2Form.patchValue(gradePatch);
+    }
+
     this.hasInitialized.set(true);
 
     if (data.bachelorGrade) {

--- a/src/main/webapp/app/core/util/grade-conversion.ts
+++ b/src/main/webapp/app/core/util/grade-conversion.ts
@@ -33,8 +33,8 @@ export function convertToGermanGrade(givenUpperLimit: string, givenLowerLimit: s
     upperLimit = parseFloat(stripPercentage(givenUpperLimit).replace(',', '.'));
     lowerLimit = parseFloat(stripPercentage(givenLowerLimit).replace(',', '.'));
     actualGrade = parseFloat(stripPercentage(grade).replace(',', '.'));
-  } else if (gradeType === 'numeric') {
-    // Numeric format (e.g., 1.0, 4.0 or 100, 40)
+  } else if (gradeType === 'numeric' || gradeType === 'numericFraction') {
+    // Numeric format (e.g., 1.0, 4.0 or 100, 40) or fraction "X/Y" — parseFloat picks up X.
     upperLimit = parseFloat(givenUpperLimit.replace(',', '.'));
     lowerLimit = parseFloat(givenLowerLimit.replace(',', '.'));
     actualGrade = parseFloat(grade.replace(',', '.'));

--- a/src/main/webapp/app/shared/util/grading-scale.utils.ts
+++ b/src/main/webapp/app/shared/util/grading-scale.utils.ts
@@ -210,9 +210,7 @@ export function detectFractionGrade(grade: string): GradingScaleLimitsResult {
   // Match the canonical row only: maxValue equals Y AND upperLimit equals Y
   // (skips e.g. the German row at maxValue=4 whose upperLimit='1.0', and the
   // 40–50 fallback row whose upperLimit='100' but maxValue=50).
-  const scaleRow = NUMERIC_GRADING_SCALES.find(
-    scale => scale.maxValue === upperValue && parseFloat(scale.upperLimit) === upperValue,
-  );
+  const scaleRow = NUMERIC_GRADING_SCALES.find(scale => scale.maxValue === upperValue && parseFloat(scale.upperLimit) === upperValue);
   if (scaleRow) {
     return { upperLimit: scaleRow.upperLimit, lowerLimit: scaleRow.lowerLimit };
   }

--- a/src/main/webapp/app/shared/util/grading-scale.utils.ts
+++ b/src/main/webapp/app/shared/util/grading-scale.utils.ts
@@ -1,7 +1,9 @@
 import { AbstractControl } from '@angular/forms';
 import type { TranslateService } from '@ngx-translate/core';
 
-export type GradeType = 'letter' | 'numeric' | 'percentage' | 'invalid';
+export type GradeType = 'letter' | 'numeric' | 'numericFraction' | 'percentage' | 'invalid';
+
+const NUMERIC_FRACTION_PATTERN = /^([0-9]{1,10}(?:[.,][0-9]{1,5})?)\/([0-9]{1,10}(?:[.,][0-9]{1,5})?)$/;
 
 export interface GradingScaleLimitsData {
   upperLimit: string;
@@ -29,6 +31,11 @@ export function getGradeType(value: string): GradeType {
   // Check for percentage (digits with optional comma/dot followed by %)
   if (/^(?:[0-9]{1,10}|[0-9]{1,10}[.,][0-9]{1,5})%$/.test(trimmed)) {
     return 'percentage';
+  }
+
+  // Check for fraction grade like "105/110" (Italian convention) before plain numeric.
+  if (NUMERIC_FRACTION_PATTERN.test(trimmed)) {
+    return 'numericFraction';
   }
 
   // Check for numeric grade (digits with optional comma/dot)
@@ -181,6 +188,40 @@ export function detectNumericGrade(grade: string): GradingScaleLimitsResult {
 }
 
 /**
+ * Detects if a grade is a fraction grade like "105/110" and returns its limits.
+ *
+ * The denominator becomes the upper limit. The lower limit is taken from the
+ * matching row in NUMERIC_GRADING_SCALES so the inferred passing grade matches
+ * the surrounding numeric scale (110 -> 66, 100 -> 50, 20 -> 10, ...). When no
+ * row matches, the lower limit falls back to half the denominator, rounded.
+ */
+export function detectFractionGrade(grade: string): GradingScaleLimitsResult {
+  const match = grade.match(NUMERIC_FRACTION_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const upperRaw = match[2];
+  const upperValue = parseFloat(upperRaw.replace(',', '.'));
+  if (isNaN(upperValue) || upperValue <= 0) {
+    return null;
+  }
+
+  // Match the canonical row only: maxValue equals Y AND upperLimit equals Y
+  // (skips e.g. the German row at maxValue=4 whose upperLimit='1.0', and the
+  // 40–50 fallback row whose upperLimit='100' but maxValue=50).
+  const scaleRow = NUMERIC_GRADING_SCALES.find(
+    scale => scale.maxValue === upperValue && parseFloat(scale.upperLimit) === upperValue,
+  );
+  if (scaleRow) {
+    return { upperLimit: scaleRow.upperLimit, lowerLimit: scaleRow.lowerLimit };
+  }
+
+  const lowerValue = Math.max(1, Math.round(upperValue / 2));
+  return { upperLimit: upperRaw, lowerLimit: lowerValue.toString() };
+}
+
+/**
  * Detects the grading scale based on a grade input
  */
 export function detectGradingScale(grade: string): GradingScaleLimitsResult {
@@ -199,6 +240,12 @@ export function detectGradingScale(grade: string): GradingScaleLimitsResult {
   const letterResult = detectLetterGrade(trimmedGrade);
   if (letterResult) {
     return letterResult;
+  }
+
+  // Check for fraction grades (e.g. "105/110") before plain numeric.
+  const fractionResult = detectFractionGrade(trimmedGrade);
+  if (fractionResult) {
+    return fractionResult;
   }
 
   // Check for numeric/percentage grades
@@ -316,6 +363,11 @@ export function shouldShowGradeWarning(grade: string): boolean {
   }
 
   const trimmed = grade.trim();
+
+  // Fraction format like "105/110" is a valid first-class type — no warning.
+  if (NUMERIC_FRACTION_PATTERN.test(trimmed)) {
+    return false;
+  }
 
   // Check for numeric grades longer than 4 characters (>= 10000)
   if (/^[0-9][0-9.,]*$/.test(trimmed) && trimmed.replace(/[.,]/g, '').length > 4) {

--- a/src/main/webapp/app/shared/validators/grading-scale-validators.ts
+++ b/src/main/webapp/app/shared/validators/grading-scale-validators.ts
@@ -27,7 +27,7 @@ export function gradingScaleTypeValidator(getCurrentGrade: () => string): Valida
 }
 
 function validateGradeTypesMatch(gradeType: GradeType, limitType: GradeType): ValidationErrors | null {
-  if (gradeType === 'numeric') {
+  if (gradeType === 'numeric' || gradeType === 'numericFraction') {
     return limitType === 'numeric' ? null : { invalidLimitType: true };
   }
 
@@ -103,7 +103,7 @@ function checkGradeInRange(type: GradeType, grade: string, upper: string, lower:
   if (type === 'letter') {
     return true;
   }
-  if (type === 'numeric' || type === 'percentage') {
+  if (type === 'numeric' || type === 'numericFraction' || type === 'percentage') {
     return isNumericInRange(grade, upper, lower);
   }
   return false;

--- a/src/test/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.spec.ts
+++ b/src/test/webapp/app/application/application-creation/application-creation-page2/application-creation-page2.component.spec.ts
@@ -554,4 +554,66 @@ describe('ApplicationPage2Component', () => {
       );
     });
   });
+
+  describe('initializeFormEffect — limit back-fill from AI-extracted grades', () => {
+    it('populates bachelor limits when grade is set but limits are empty (AI path)', () => {
+      const { componentInstance } = createApplicationPage2Fixture({
+        data: {
+          bachelorDegreeName: 'CS',
+          bachelorDegreeUniversity: 'TUM',
+          bachelorGrade: '1.5',
+          bachelorGradeUpperLimit: '',
+          bachelorGradeLowerLimit: '',
+        },
+      });
+
+      expect(componentInstance.page2Form.get('bachelorGradeUpperLimit')?.value).toBe('1.0');
+      expect(componentInstance.page2Form.get('bachelorGradeLowerLimit')?.value).toBe('4.0');
+    });
+
+    it('populates master limits when grade is set but limits are empty', () => {
+      const { componentInstance } = createApplicationPage2Fixture({
+        data: {
+          masterDegreeName: 'CS',
+          masterDegreeUniversity: 'TUM',
+          masterGrade: '85%',
+          masterGradeUpperLimit: '',
+          masterGradeLowerLimit: '',
+        },
+      });
+
+      expect(componentInstance.page2Form.get('masterGradeUpperLimit')?.value).toBe('100%');
+      expect(componentInstance.page2Form.get('masterGradeLowerLimit')?.value).toBe('50%');
+    });
+
+    it('does not overwrite limits that are already provided', () => {
+      const { componentInstance } = createApplicationPage2Fixture({
+        data: {
+          bachelorDegreeName: 'CS',
+          bachelorDegreeUniversity: 'TUM',
+          bachelorGrade: '1.5',
+          bachelorGradeUpperLimit: '6.0',
+          bachelorGradeLowerLimit: '4.0',
+        },
+      });
+
+      expect(componentInstance.page2Form.get('bachelorGradeUpperLimit')?.value).toBe('6.0');
+      expect(componentInstance.page2Form.get('bachelorGradeLowerLimit')?.value).toBe('4.0');
+    });
+
+    it('leaves limits empty when grade is not detectable', () => {
+      const { componentInstance } = createApplicationPage2Fixture({
+        data: {
+          bachelorDegreeName: 'CS',
+          bachelorDegreeUniversity: 'TUM',
+          bachelorGrade: '???',
+          bachelorGradeUpperLimit: '',
+          bachelorGradeLowerLimit: '',
+        },
+      });
+
+      expect(componentInstance.page2Form.get('bachelorGradeUpperLimit')?.value).toBe('');
+      expect(componentInstance.page2Form.get('bachelorGradeLowerLimit')?.value).toBe('');
+    });
+  });
 });

--- a/src/test/webapp/app/shared/util/grading-scale.utils.spec.ts
+++ b/src/test/webapp/app/shared/util/grading-scale.utils.spec.ts
@@ -8,6 +8,7 @@ import {
   isNumericInRange,
   detectLetterGrade,
   detectNumericGrade,
+  detectFractionGrade,
   detectGradingScale,
   normalizeLimitsForGrade,
   shouldShowGradeWarning,
@@ -106,6 +107,69 @@ describe('getGradeType', () => {
     it('should return numeric for a integer up to 10 characters', () => {
       expect(getGradeType('1000000000')).toBe('numeric');
     });
+  });
+
+  describe('numericFraction grades', () => {
+    it('should return numericFraction for the Italian convention', () => {
+      expect(getGradeType('105/110')).toBe('numericFraction');
+    });
+
+    it('should return numericFraction for percentage-style fractions', () => {
+      expect(getGradeType('85/100')).toBe('numericFraction');
+    });
+
+    it('should accept fractions with decimals', () => {
+      expect(getGradeType('1.7/4.0')).toBe('numericFraction');
+      expect(getGradeType('2,3/4,0')).toBe('numericFraction');
+    });
+
+    it('should return invalid for fractions with non-numeric parts', () => {
+      expect(getGradeType('A/B')).toBe('invalid');
+      expect(getGradeType('105/')).toBe('invalid');
+      expect(getGradeType('/110')).toBe('invalid');
+    });
+  });
+});
+
+describe('detectFractionGrade', () => {
+  it('should map Italian "X/110" to upper 110, lower 66', () => {
+    expect(detectFractionGrade('105/110')).toEqual({ upperLimit: '110', lowerLimit: '66' });
+  });
+
+  it('should map "X/100" to upper 100, lower 50', () => {
+    expect(detectFractionGrade('85/100')).toEqual({ upperLimit: '100', lowerLimit: '50' });
+  });
+
+  it('should map "X/20" (French) to upper 20, lower 10', () => {
+    expect(detectFractionGrade('15/20')).toEqual({ upperLimit: '20', lowerLimit: '10' });
+  });
+
+  it('should fall back to half the denominator when no scale row matches', () => {
+    expect(detectFractionGrade('1/3')).toEqual({ upperLimit: '3', lowerLimit: '2' });
+  });
+
+  it('should return null for non-fraction input', () => {
+    expect(detectFractionGrade('105')).toBeNull();
+    expect(detectFractionGrade('A')).toBeNull();
+    expect(detectFractionGrade('')).toBeNull();
+  });
+});
+
+describe('detectGradingScale with fraction input', () => {
+  it('should detect "105/110" via detectGradingScale and return Italian limits', () => {
+    expect(detectGradingScale('105/110')).toEqual({ upperLimit: '110', lowerLimit: '66' });
+  });
+});
+
+describe('shouldShowGradeWarning with fraction input', () => {
+  it('should not warn on a valid fraction grade', () => {
+    expect(shouldShowGradeWarning('105/110')).toBe(false);
+    expect(shouldShowGradeWarning('85/100')).toBe(false);
+  });
+
+  it('should still warn on invalid uses of "/"', () => {
+    expect(shouldShowGradeWarning('105//110')).toBe(true);
+    expect(shouldShowGradeWarning('A/B')).toBe(true);
   });
 });
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive.
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the client coding and design guidelines.
- [x] I added multiple integration tests (Vitest) related to the features.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

The CV-extraction pipeline captured raw grades but lost the associated grade limits. Without a defined scale (1.0–4.0 vs. 0–100% etc.), the grade is ambiguous to professors reviewing the application.

### Description

The bug only manifested on the Page 1 CV-extraction path. There, education data flows from Page 1 into the form's \`educationData\` signal and then into Page 2 as a model input. Page 2's \`initializeFormEffect\` patched the form once and seeded \`lastBachelorGrade\` to the AI-extracted value. The downstream \`bachelorGradeEffect\` then short-circuited on "grade unchanged" and never computed the limits — so the form's limit controls stayed empty, the auto-save sent empty strings, and the server stored empty limits.

This change adds a single back-fill block inside \`initializeFormEffect\`: when the incoming data has a grade but empty limits, compute the limits via the existing client-side \`getDetectedGradeLimitsPatch\` helper and patch them onto the form before the gate flips. Already-provided limits are not overwritten. Invalid grades leave the limits empty (matching the existing behavior).

No backend change. The transcript-extraction path inside Page 2 already worked because the grade-changed guard saw a real change there.

### Steps for Testing

Prerequisites:

1. Log in as an applicant.

Steps:

1. Open a job, click Apply.
2. Upload a CV that contains a clear grade (e.g., "Bachelor: 1.5").
3. Click "AI Extract" on Page 1.
4. Navigate to Page 2 — verify the grade is filled and the helper text below the grade input shows the detected scale.
5. Submit the application and inspect the database row: \`applicant_bachelor_grade_upper_limit\` should be \`1.0\` and \`applicant_bachelor_grade_lower_limit\` should be \`4.0\`.

Negative cases:

- CV without a grade → Page 2 grade fields stay empty, no limits set.
- CV with an unparseable grade ("???") → grade copied as-is, limits stay empty.

### Review Progress

#### Code Review

- [x] Code Review 1

#### Manual Tests

- [x] CV with bachelor grade "1.5" → limits "1.0" / "4.0" persisted
- [x] CV with master grade "85%" → limits "100%" / "50%" persisted
- [x] User-overridden limits are not overwritten by AI extraction