### PR TITLE
`Bugfix`: Cancel in-flight translation when AI generation starts

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -876,6 +876,13 @@ export class JobCreationFormComponent {
     const originalContent = this.basicInfoForm.get('jobDescription')?.value;
     const language = this.currentDescriptionLanguage();
 
+    // Abort any in-flight translation. Generation will re-trigger a fresh
+    // translation in postGenerationSaveAndProcess once it completes, so an
+    // active translation against the soon-to-be-replaced text is wasted work.
+    if (this.isTranslating()) {
+      this.cancelTranslation();
+    }
+
     // 1) Enter generation mode and show placeholder
     this.isGeneratingDraft.set(true);
     this.rewriteButtonSignal.set(true);

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -973,6 +973,46 @@ describe('JobCreationFormComponent', () => {
 
         expect(component.rewriteButtonSignal()).toBe(true);
       });
+
+      it('should cancel any in-flight translation before starting generation', async () => {
+        component.jobId.set('job123');
+        fillValidJobForm(component);
+
+        const mockEditor = { forceUpdate: vi.fn() };
+        Object.defineProperty(component, 'jobDescriptionEditor', {
+          value: () => mockEditor,
+          configurable: true,
+        });
+
+        component.isTranslating.set(true);
+        const cancelSpy = vi.spyOn(component as unknown as { cancelTranslation: () => void }, 'cancelTranslation');
+
+        mockAiStreamingService.generateJobApplicationDraftStream.mockRejectedValue(new Error('fail'));
+
+        await component.generateJobApplicationDraft();
+
+        expect(cancelSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not invoke cancelTranslation when no translation is in flight', async () => {
+        component.jobId.set('job123');
+        fillValidJobForm(component);
+
+        const mockEditor = { forceUpdate: vi.fn() };
+        Object.defineProperty(component, 'jobDescriptionEditor', {
+          value: () => mockEditor,
+          configurable: true,
+        });
+
+        component.isTranslating.set(false);
+        const cancelSpy = vi.spyOn(component as unknown as { cancelTranslation: () => void }, 'cancelTranslation');
+
+        mockAiStreamingService.generateJobApplicationDraftStream.mockRejectedValue(new Error('fail'));
+
+        await component.generateJobApplicationDraft();
+
+        expect(cancelSpy).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive.
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the client coding and design guidelines.
- [x] I added multiple integration tests (Vitest) related to the features.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

When a professor clicked "Generate" on the job creation form while a translation was already in flight, both processes ran concurrently. Generation always re-triggers a fresh translation on completion, so the running translation against the soon-to-be-replaced text is wasted work — slower UI, higher API costs.

### Description

\`generateJobApplicationDraft()\` now calls \`cancelTranslation()\` at the very top when \`isTranslating()\` is true. \`cancelTranslation()\` already exists and aborts the SSE stream via \`AbortController\` and clears the related state signals. The post-generation re-translation in \`postGenerationSaveAndProcess()\` is unchanged — it kicks off the new translation against the freshly generated text once generation completes.

### Steps for Testing

Prerequisites:

1. Log in as a professor.

Steps:

1. Open the job creation form, write some text in the description.
2. Switch language tabs to trigger an auto-translation, then immediately switch back. While the translation indicator is still active, click "Generate".
3. Verify in DevTools Network tab that the in-flight \`translateJobDescriptionStream\` request is cancelled the moment Generate is clicked, and no second translation runs concurrently with generation.
4. After generation completes, a fresh translation kicks off as before.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Generate while translation is in flight cancels the translation
- [ ] Generate without an active translation behaves identically to before
- [ ] Post-generation translation still fires