### PR TITLE
`Bugfix`: Block deletion of past interview slots

### DIFF
--- a/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
+++ b/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
@@ -375,13 +375,13 @@ public class InterviewService {
 
     /**
      * Deletes a single interview slot.
-     * Only unbooked slots can be deleted.
+     * Only unbooked slots whose start time is in the future can be deleted.
      *
      * @param slotId the ID of the slot to delete
      * @throws EntityNotFoundException if the slot is not found
      * @throws AccessDeniedException   if the user is not authorized to delete this
      *                                 slot
-     * @throws BadRequestException     if the slot is booked
+     * @throws BadRequestException     if the slot is booked or has already started
      */
     public void deleteSlot(UUID slotId) {
         // 1. Load the slot
@@ -397,13 +397,18 @@ public class InterviewService {
         // 3. Security: Check if Job is CLOSED
         checkJobNotClosed(job);
 
-        // 4. Cannot delete booked slots
+        // 4. Cannot delete slots that have already started
+        if (slot.getStartDateTime() != null && slot.getStartDateTime().isBefore(Instant.now())) {
+            throw new BadRequestException("Cannot delete a slot that already started.");
+        }
+
+        // 5. Cannot delete booked slots
         // TODO: Implement deletion of booked slots with unassignment of applicant
         if (slot.getIsBooked()) {
             throw new BadRequestException("Cannot delete booked slot.");
         }
 
-        // 5. Delete the slot
+        // 6. Delete the slot
         interviewSlotRepository.delete(slot);
     }
 

--- a/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
+++ b/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
@@ -11,6 +11,7 @@ import de.tum.cit.aet.core.exception.AccessDeniedException;
 import de.tum.cit.aet.core.exception.BadRequestException;
 import de.tum.cit.aet.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.core.exception.InterviewProcessClosedException;
+import de.tum.cit.aet.core.exception.OperationNotAllowedException;
 import de.tum.cit.aet.core.exception.ResourceAlreadyExistsException;
 import de.tum.cit.aet.core.exception.TimeConflictException;
 import de.tum.cit.aet.core.service.CurrentUserService;
@@ -381,7 +382,8 @@ public class InterviewService {
      * @throws EntityNotFoundException if the slot is not found
      * @throws AccessDeniedException   if the user is not authorized to delete this
      *                                 slot
-     * @throws BadRequestException     if the slot is booked or has already started
+     * @throws OperationNotAllowedException if the slot has already started
+     * @throws BadRequestException          if the slot is booked
      */
     public void deleteSlot(UUID slotId) {
         // 1. Load the slot
@@ -399,7 +401,7 @@ public class InterviewService {
 
         // 4. Cannot delete slots that have already started
         if (slot.getStartDateTime() != null && slot.getStartDateTime().isBefore(Instant.now())) {
-            throw new BadRequestException("Cannot delete a slot that already started.");
+            throw new OperationNotAllowedException("Cannot delete a slot that already started.");
         }
 
         // 5. Cannot delete booked slots

--- a/src/main/webapp/app/interview/interview-process-detail/slots-section/slot-card/slot-card.component.ts
+++ b/src/main/webapp/app/interview/interview-process-detail/slots-section/slot-card/slot-card.component.ts
@@ -60,7 +60,7 @@ export class SlotCardComponent {
         command: () => this.onCancelInterview(),
         severity: 'danger',
       });
-    } else {
+    } else if (!this.isPast()) {
       items.push({
         label: 'button.delete',
         icon: 'trash',


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://ls1intum.github.io/tum-apply/developer/server-guidelines/database-and-performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/server-guidelines/server-development).
- [x] I documented the Java code using JavaDoc style.

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

### Motivation and Context

`InterviewService.deleteSlot()` validated research-group access, job-not-closed, and not-booked, but did **not** check whether the slot's `startDateTime` is in the past. Combined with the kebab menu in `slot-card` always showing a "Delete" entry for unbooked slots, this made it possible to delete slots that have already started — destroying historical scheduling state.

Closes #2373

### Description

- **Server** (`src/main/java/de/tum/cit/aet/interview/service/InterviewService.java`): `deleteSlot()` now throws `OperationNotAllowedException` when `slot.getStartDateTime().isBefore(Instant.now())`. `OperationNotAllowedException` was chosen over `BadRequestException` because the request body is well-formed — it's a state-based business-rule violation (matches the existing `OPERATION_NOT_ALLOWED` error code in `GlobalExceptionHandler`).
- **Server**: javadoc on `deleteSlot()` updated to reflect the new precondition.
- **Client** (`src/main/webapp/app/interview/interview-process-detail/slots-section/slot-card/slot-card.component.ts`): the kebab menu's `menuItems` computed signal only pushes the "Delete" entry when the slot is not booked **and** not in the past (`!isPast()`). Booked slots still get the existing "Cancel Interview" entry as before.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a Professor or Employee with access to a research group that has an interview process with slots in the past, future, and booked states
2. Navigate to the interview process detail page for that research group

Server tests:

3. Issue `DELETE /api/interview-slots/{id}` for an **unbooked past** slot → expect `400 Bad Request` with error code `OPERATION_NOT_ALLOWED` and message `Cannot delete a slot that already started.`
4. Issue `DELETE /api/interview-slots/{id}` for an **unbooked future** slot → expect `200/204` and the slot to be gone
5. Issue `DELETE /api/interview-slots/{id}` for a **booked** slot → expect `400` with `Cannot delete booked slot.` (regression check)

Client tests:

6. Open the kebab menu on a future unbooked slot → "Delete" and "Edit" entry is present and functional
7. Open the kebab menu on a past booked/unbooked slot → no "Delete" entry
8. Open the kebab menu on a booked future slot → "Cancel Interview" and "Edit" entry as before

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Server rejects deletion of past slots
- [ ] Client hides Delete on past unbooked slots
- [ ] Future / booked behavior unchanged

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| slot-card.component.ts | 91.42% | 78 | 12 | 15.4 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| InterviewService.java | 76.60% | 681 |

_Last updated: 2026-04-28 23:00:43 UTC_

