### PR TITLE
`Bugfix`: Show AI toggle only on Basic Info step in job creation form

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -15,27 +15,29 @@
   <div class="page-container">
     <div class="page-header flex items-center justify-between">
       <h1 jhiTranslate="{{ pageTitle() }}"></h1>
-      <div class="flex items-center gap-2">
-        <jhi-segmented-toggle
-          class="[&_button]:!min-w-[7rem] [&_button]:!whitespace-nowrap"
-          [value]="aiToggleSignal() ? 'right' : 'left'"
-          [leftLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiToggleOff'"
-          [rightLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiToggleOn'"
-          [translateLabels]="true"
-          (valueChange)="onAiToggleChanged($event === 'right')"
-        />
-        <jhi-button
-          label="?"
-          severity="primary"
-          variant="outlined"
-          size="xs"
-          class="[&_button]:flex [&_button]:h-6 [&_button]:w-7 [&_button]:min-w-5 [&_button]:shrink-0 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-full [&_button]:border [&_button]:border-primary-default [&_button]:bg-background-default [&_button]:p-0 [&_button]:text-xs [&_button]:font-bold [&_button]:leading-none [&_button]:text-text-secondary hover:[&_button]:text-primary-default"
-          (click)="openAiInfoDialog()"
-        />
-      </div>
+      @if (stepper.currentStep() === 1) {
+        <div class="flex items-center gap-2">
+          <jhi-segmented-toggle
+            class="[&_button]:!min-w-[7rem] [&_button]:!whitespace-nowrap"
+            [value]="aiToggleSignal() ? 'right' : 'left'"
+            [leftLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiToggleOff'"
+            [rightLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiToggleOn'"
+            [translateLabels]="true"
+            (valueChange)="onAiToggleChanged($event === 'right')"
+          />
+          <jhi-button
+            label="?"
+            severity="primary"
+            variant="outlined"
+            size="xs"
+            class="[&_button]:flex [&_button]:h-6 [&_button]:w-7 [&_button]:min-w-5 [&_button]:shrink-0 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-full [&_button]:border [&_button]:border-primary-default [&_button]:bg-background-default [&_button]:p-0 [&_button]:text-xs [&_button]:font-bold [&_button]:leading-none [&_button]:text-text-secondary hover:[&_button]:text-primary-default"
+            (click)="openAiInfoDialog()"
+          />
+        </div>
+      }
     </div>
     <div>
-      <jhi-progress-stepper [steps]="stepData()" [shouldTranslate]="true" />
+      <jhi-progress-stepper #stepper [steps]="stepData()" [shouldTranslate]="true" />
     </div>
   </div>
 


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2388.

The AI Enabled / AI Disabled segmented toggle (and the `?` info button) in the job creation form was rendered in the page header on every step of the stepper. The AI features it controls (job description draft generation, AI assistant sidebar, compliance scoring) are only exposed on the Basic Info step, so showing the toggle on Employment Terms, Image Selection, and Summary was misleading — users could flip a switch that had no visible effect on those pages.

### Description

- Added a template reference variable `#stepper` to the `<jhi-progress-stepper>` element in `job-creation-form.component.html`.
- Wrapped the toggle and its `?` info button in `@if (stepper.currentStep() === 1) { ... }` so they only render on step 1 (Basic Info).
- No component logic, styling, or i18n changes — `ProgressStepperComponent.currentStep` is already a public signal, so the template can read it directly.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a professor / job creator
2. Open Create Job (or edit an existing job draft)

Then:

1. On the Basic Info step, confirm the AI toggle and `?` button are visible in the top-right of the page header and behave as before (toggling shows/hides the AI assistant sidebar and the AI label above the editor).
2. Click Next to advance to Employment Terms — the toggle and `?` button should no longer be visible.
3. Click Next to advance to Image Selection — still hidden.
4. Click Next to advance to Summary — still hidden.
5. Click Back to return to Basic Info — the toggle and `?` button reappear in the same position with the previously selected state preserved.
6. Open the AI info dialog via the `?` button on step 1 to confirm it still works.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] AI toggle is visible only on Basic Info
- [ ] Toggle state is preserved when navigating across steps and returning to Basic Info
- [ ] AI info dialog still opens from the `?` button

### Screenshots

_To be added._

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-05-01 18:56:48 UTC_

