### PR TITLE
`Development`: Replace oval "?" info button with shared `jhi-info-icon` atom

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -25,13 +25,10 @@
             [translateLabels]="true"
             (valueChange)="onAiToggleChanged($event === 'right')"
           />
-          <jhi-button
-            label="?"
-            severity="primary"
-            variant="outlined"
-            size="xs"
-            class="[&_button]:flex [&_button]:h-6 [&_button]:w-7 [&_button]:min-w-5 [&_button]:shrink-0 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-full [&_button]:border [&_button]:border-primary-default [&_button]:bg-background-default [&_button]:p-0 [&_button]:text-xs [&_button]:font-bold [&_button]:leading-none [&_button]:text-text-secondary hover:[&_button]:text-primary-default"
-            (click)="openAiInfoDialog()"
+          <jhi-info-icon
+            [clickable]="true"
+            [ariaLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiInfoDialog.title' | translate"
+            (clicked)="openAiInfoDialog()"
           />
         </div>
       }

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -27,7 +27,8 @@
           />
           <jhi-info-icon
             [clickable]="true"
-            [ariaLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiInfoDialog.title' | translate"
+            ariaLabel="jobCreationForm.positionDetailsSection.jobDescription.aiInfoDialog.title"
+            [shouldTranslate]="true"
             (clicked)="openAiInfoDialog()"
           />
         </div>

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -21,6 +21,7 @@ import { SelectComponent } from 'app/shared/components/atoms/select/select.compo
 import { NumberInputComponent } from 'app/shared/components/atoms/number-input/number-input.component';
 import { ProgressSpinnerComponent } from 'app/shared/components/atoms/progress-spinner/progress-spinner.component';
 import { InfoBoxComponent } from 'app/shared/components/atoms/info-box/info-box.component';
+import { InfoIconComponent } from 'app/shared/components/atoms/info-icon/info-icon.component';
 import { MessageComponent } from 'app/shared/components/atoms/message/message.component';
 import { SegmentedToggleComponent, SegmentedToggleValue } from 'app/shared/components/atoms/segmented-toggle/segmented-toggle.component';
 import { SavingState, SavingStates } from 'app/shared/constants/saving-states';
@@ -99,6 +100,7 @@ type JobFormMode = 'create' | 'edit';
     CheckboxModule,
     ProgressSpinnerComponent,
     InfoBoxComponent,
+    InfoIconComponent,
     MessageComponent,
     SegmentedToggleComponent,
     ImageUploadButtonComponent,

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
@@ -84,6 +84,7 @@
               }
               @if (shouldShowButton()) {
                 <jhi-info-icon
+                  class="[&_button]:!float-none [&_button]:!h-auto [&_button]:!w-auto [&_button]:!p-0"
                   [clickable]="true"
                   size="sm"
                   [disabled]="!analysisResult()"

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
@@ -88,9 +88,10 @@
                   [clickable]="true"
                   size="sm"
                   [disabled]="!analysisResult()"
-                  [tooltip]="'genderDecoder.openAnaylsis' | translate"
+                  tooltip="genderDecoder.openAnaylsis"
                   tooltipPosition="top"
-                  [ariaLabel]="'genderDecoder.openAnaylsis' | translate"
+                  ariaLabel="genderDecoder.openAnaylsis"
+                  [shouldTranslate]="true"
                   (clicked)="onGenderDecoderClick()"
                 />
               }

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.html
@@ -83,17 +83,15 @@
                 </span>
               }
               @if (shouldShowButton()) {
-                <button
-                  type="button"
-                  class="whitespace-nowrap w-5 h-5 rounded-full text-xs font-bold flex items-center justify-center cursor-pointer hover:brightness-93 flex-shrink-0"
-                  [style]="'color: var(--p-primary-color); border: 1px solid var(--p-primary-color); background-color: var(--p-background-default);'"
-                  (click)="onGenderDecoderClick()"
-                  [pTooltip]="'genderDecoder.openAnaylsis' | translate"
-                  tooltipPosition="top"
+                <jhi-info-icon
+                  [clickable]="true"
+                  size="sm"
                   [disabled]="!analysisResult()"
-                >
-                  ?
-                </button>
+                  [tooltip]="'genderDecoder.openAnaylsis' | translate"
+                  tooltipPosition="top"
+                  [ariaLabel]="'genderDecoder.openAnaylsis' | translate"
+                  (clicked)="onGenderDecoderClick()"
+                />
               }
             </span>
           }

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
@@ -13,6 +13,7 @@ import { map, switchMap } from 'rxjs';
 import { franc } from 'franc-min';
 import Quill from 'quill';
 import { GenderBiasAnalysisDialogComponent } from 'app/shared/gender-bias-analysis/gender-bias-analysis-dialog/gender-bias-analysis-dialog';
+import { InfoIconComponent } from 'app/shared/components/atoms/info-icon/info-icon.component';
 import { ChangeDetectorRef } from '@angular/core';
 import { viewChild } from '@angular/core';
 import { TranslateDirective } from 'app/shared/language';
@@ -100,6 +101,7 @@ const STANDARD_CHARACTER_BUFFER = 300;
     TranslateModule,
     TooltipModule,
     GenderBiasAnalysisDialogComponent,
+    InfoIconComponent,
     TranslateDirective,
   ],
   templateUrl: './editor.component.html',

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -32,7 +32,7 @@
 }
 
 <ng-template #infoSvg>
-  <svg [class]="iconSizeClass() + ' translate-y-[0.08em]'" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+  <svg [class]="iconSizeClass() + ' translate-y-[0.12em]'" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
     <circle
       cx="12"
       cy="12"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -9,10 +9,10 @@
         ? 'cursor-not-allowed opacity-50'
         : 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
     "
-    [attr.aria-label]="ariaLabel()"
+    [attr.aria-label]="shouldTranslate() ? (ariaLabel() | translate) : ariaLabel()"
     [attr.aria-disabled]="disabled() ? true : null"
     [disabled]="disabled()"
-    [pTooltip]="tooltip()"
+    [pTooltip]="shouldTranslate() && tooltip() ? (tooltip()! | translate) : tooltip()"
     [tooltipPosition]="tooltipPosition()"
     (click)="onClick($event)"
     (keydown)="onKeydown($event)"
@@ -23,8 +23,8 @@
   <span
     class="inline-flex shrink-0 items-center justify-center leading-none text-text-secondary"
     role="img"
-    [attr.aria-label]="ariaLabel()"
-    [pTooltip]="tooltip()"
+    [attr.aria-label]="shouldTranslate() ? (ariaLabel() | translate) : ariaLabel()"
+    [pTooltip]="shouldTranslate() && tooltip() ? (tooltip()! | translate) : tooltip()"
     [tooltipPosition]="tooltipPosition()"
   >
     <ng-container [ngTemplateOutlet]="infoSvg" />

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -7,7 +7,7 @@
       ' m-0 border-0 leading-none rounded-md bg-transparent text-text-secondary transition-colors duration-150 ' +
       (disabled()
         ? 'cursor-not-allowed opacity-50'
-        : 'cursor-pointer hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
+        : 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
     "
     [attr.aria-label]="ariaLabel()"
     [attr.aria-disabled]="disabled() ? true : null"
@@ -38,17 +38,9 @@
       cy="12"
       r="9.25"
       stroke-width="1.75"
-      class="fill-transparent stroke-current transition-colors duration-150 group-hover:fill-primary-default group-hover:stroke-primary-default"
+      class="fill-transparent stroke-current transition-colors duration-150 group-hover:fill-text-secondary/15"
     />
-    <line
-      x1="12"
-      y1="11"
-      x2="12"
-      y2="16.5"
-      stroke-width="1.75"
-      stroke-linecap="round"
-      class="stroke-current transition-colors duration-150 group-hover:stroke-text-on-primary"
-    />
-    <circle cx="12" cy="7.75" r="0.9" class="fill-current transition-colors duration-150 group-hover:fill-text-on-primary" />
+    <line x1="12" y1="11" x2="12" y2="16.5" stroke-width="1.75" stroke-linecap="round" class="stroke-current" />
+    <circle cx="12" cy="7.75" r="0.9" class="fill-current" />
   </svg>
 </ng-template>

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -2,12 +2,12 @@
   <button
     type="button"
     [class]="
-      'inline-flex shrink-0 items-center justify-center ' +
+      'group inline-flex shrink-0 items-center justify-center ' +
       paddingClass() +
       ' m-0 border-0 leading-none rounded-md bg-transparent text-text-secondary transition-colors duration-150 ' +
       (disabled()
         ? 'cursor-not-allowed opacity-50'
-        : 'cursor-pointer hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
+        : 'cursor-pointer hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
     "
     [attr.aria-label]="ariaLabel()"
     [attr.aria-disabled]="disabled() ? true : null"
@@ -32,20 +32,23 @@
 }
 
 <ng-template #infoSvg>
-  <svg
-    [class]="iconSizeClass()"
-    width="1em"
-    height="1em"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="1.75"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <circle cx="12" cy="12" r="9.25" />
-    <line x1="12" y1="11" x2="12" y2="16.5" />
-    <circle cx="12" cy="7.75" r="0.9" fill="currentColor" stroke="none" />
+  <svg [class]="iconSizeClass()" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+    <circle
+      cx="12"
+      cy="12"
+      r="9.25"
+      stroke-width="1.75"
+      class="fill-transparent stroke-current transition-colors duration-150 group-hover:fill-primary-default group-hover:stroke-primary-default"
+    />
+    <line
+      x1="12"
+      y1="11"
+      x2="12"
+      y2="16.5"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      class="stroke-current transition-colors duration-150 group-hover:stroke-text-on-primary"
+    />
+    <circle cx="12" cy="7.75" r="0.9" class="fill-current transition-colors duration-150 group-hover:fill-text-on-primary" />
   </svg>
 </ng-template>

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,7 +1,7 @@
 @if (clickable()) {
   <button
     type="button"
-    class="inline-flex shrink-0 items-center justify-center p-1 m-0 border-0 leading-none cursor-pointer rounded-md bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
+    class="inline-flex shrink-0 items-center justify-center p-2 m-0 border-0 leading-none cursor-pointer rounded-md bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
     [attr.aria-label]="ariaLabel()"
     [pTooltip]="tooltip()"
     [tooltipPosition]="tooltipPosition()"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -32,7 +32,7 @@
 }
 
 <ng-template #infoSvg>
-  <svg [class]="iconSizeClass()" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
+  <svg [class]="iconSizeClass() + ' translate-y-[0.08em]'" width="1em" height="1em" viewBox="0 0 24 24" aria-hidden="true">
     <circle
       cx="12"
       cy="12"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,18 +1,11 @@
 @if (clickable()) {
   <button
     type="button"
-    [class]="
-      'group inline-flex shrink-0 items-center justify-center ' +
-      paddingClass() +
-      ' m-0 border-0 leading-none rounded-md bg-transparent text-text-secondary transition-colors duration-150 ' +
-      (disabled()
-        ? 'cursor-not-allowed opacity-50'
-        : 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
-    "
-    [attr.aria-label]="shouldTranslate() ? (ariaLabel() | translate) : ariaLabel()"
-    [attr.aria-disabled]="disabled() ? true : null"
+    [class]="buttonClass()"
+    [attr.aria-label]="displayAriaLabel()"
+    [attr.aria-disabled]="disabled() ? true : undefined"
     [disabled]="disabled()"
-    [pTooltip]="shouldTranslate() && tooltip() ? (tooltip()! | translate) : tooltip()"
+    [pTooltip]="displayTooltip()"
     [tooltipPosition]="tooltipPosition()"
     (click)="onClick($event)"
     (keydown)="onKeydown($event)"
@@ -23,8 +16,8 @@
   <span
     class="inline-flex shrink-0 items-center justify-center leading-none text-text-secondary"
     role="img"
-    [attr.aria-label]="shouldTranslate() ? (ariaLabel() | translate) : ariaLabel()"
-    [pTooltip]="shouldTranslate() && tooltip() ? (tooltip()! | translate) : tooltip()"
+    [attr.aria-label]="displayAriaLabel()"
+    [pTooltip]="displayTooltip()"
     [tooltipPosition]="tooltipPosition()"
   >
     <ng-container [ngTemplateOutlet]="infoSvg" />

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,8 +1,17 @@
 @if (clickable()) {
   <button
     type="button"
-    class="inline-flex shrink-0 items-center justify-center p-2 m-0 border-0 leading-none cursor-pointer rounded-md bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
+    [class]="
+      'inline-flex shrink-0 items-center justify-center ' +
+      paddingClass() +
+      ' m-0 border-0 leading-none rounded-md bg-transparent text-text-secondary transition-colors duration-150 ' +
+      (disabled()
+        ? 'cursor-not-allowed opacity-50'
+        : 'cursor-pointer hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1')
+    "
     [attr.aria-label]="ariaLabel()"
+    [attr.aria-disabled]="disabled() ? true : null"
+    [disabled]="disabled()"
     [pTooltip]="tooltip()"
     [tooltipPosition]="tooltipPosition()"
     (click)="onClick($event)"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,0 +1,23 @@
+@if (clickable()) {
+  <button
+    type="button"
+    class="inline-flex shrink-0 items-center justify-center bg-transparent p-0 m-0 border-0 leading-none cursor-pointer text-text-secondary hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1 rounded-full transition-colors"
+    [attr.aria-label]="ariaLabel()"
+    [pTooltip]="tooltip()"
+    [tooltipPosition]="tooltipPosition()"
+    (click)="onClick($event)"
+    (keydown)="onKeydown($event)"
+  >
+    <fa-icon [icon]="['fas', 'circle-info']" [class]="iconSizeClass()" />
+  </button>
+} @else {
+  <span
+    class="inline-flex shrink-0 items-center justify-center leading-none text-text-secondary"
+    role="img"
+    [attr.aria-label]="ariaLabel()"
+    [pTooltip]="tooltip()"
+    [tooltipPosition]="tooltipPosition()"
+  >
+    <fa-icon [icon]="['fas', 'circle-info']" [class]="iconSizeClass()" />
+  </span>
+}

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,7 +1,7 @@
 @if (clickable()) {
   <button
     type="button"
-    class="inline-flex shrink-0 items-center justify-center bg-transparent p-0 m-0 border-0 leading-none cursor-pointer text-text-secondary hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1 rounded-full transition-colors"
+    class="inline-flex shrink-0 items-center justify-center p-1 m-0 border-0 leading-none cursor-pointer rounded-full bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
     [attr.aria-label]="ariaLabel()"
     [pTooltip]="tooltip()"
     [tooltipPosition]="tooltipPosition()"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -17,7 +17,7 @@
     (click)="onClick($event)"
     (keydown)="onKeydown($event)"
   >
-    <fa-icon [icon]="['fas', 'circle-info']" [class]="iconSizeClass()" />
+    <ng-container [ngTemplateOutlet]="infoSvg" />
   </button>
 } @else {
   <span
@@ -27,6 +27,25 @@
     [pTooltip]="tooltip()"
     [tooltipPosition]="tooltipPosition()"
   >
-    <fa-icon [icon]="['fas', 'circle-info']" [class]="iconSizeClass()" />
+    <ng-container [ngTemplateOutlet]="infoSvg" />
   </span>
 }
+
+<ng-template #infoSvg>
+  <svg
+    [class]="iconSizeClass()"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="9.25" />
+    <line x1="12" y1="11" x2="12" y2="16.5" />
+    <circle cx="12" cy="7.75" r="0.9" fill="currentColor" stroke="none" />
+  </svg>
+</ng-template>

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.html
@@ -1,7 +1,7 @@
 @if (clickable()) {
   <button
     type="button"
-    class="inline-flex shrink-0 items-center justify-center p-1 m-0 border-0 leading-none cursor-pointer rounded-full bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
+    class="inline-flex shrink-0 items-center justify-center p-1 m-0 border-0 leading-none cursor-pointer rounded-md bg-transparent text-text-secondary transition-colors duration-150 hover:bg-primary-default/10 hover:text-primary-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1"
     [attr.aria-label]="ariaLabel()"
     [pTooltip]="tooltip()"
     [tooltipPosition]="tooltipPosition()"

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { TooltipModule } from 'primeng/tooltip';
 
 export type InfoIconSize = 'sm' | 'md';
@@ -7,7 +8,7 @@ export type InfoIconSize = 'sm' | 'md';
 @Component({
   selector: 'jhi-info-icon',
   standalone: true,
-  imports: [NgTemplateOutlet, TooltipModule],
+  imports: [NgTemplateOutlet, TooltipModule, TranslateModule],
   templateUrl: './info-icon.component.html',
 })
 export class InfoIconComponent {
@@ -17,6 +18,7 @@ export class InfoIconComponent {
   size = input<InfoIconSize>('md');
   clickable = input<boolean>(false);
   disabled = input<boolean>(false);
+  shouldTranslate = input<boolean>(false);
 
   clicked = output();
 

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -1,6 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, input, output } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
+import { Component, computed, inject, input, output } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
 import { TooltipModule } from 'primeng/tooltip';
 
 export type InfoIconSize = 'sm' | 'md';
@@ -8,13 +9,13 @@ export type InfoIconSize = 'sm' | 'md';
 @Component({
   selector: 'jhi-info-icon',
   standalone: true,
-  imports: [NgTemplateOutlet, TooltipModule, TranslateModule],
+  imports: [NgTemplateOutlet, TooltipModule],
   templateUrl: './info-icon.component.html',
 })
 export class InfoIconComponent {
   tooltip = input<string | undefined>(undefined);
   tooltipPosition = input<'top' | 'bottom' | 'left' | 'right'>('top');
-  ariaLabel = input<string>('More information');
+  ariaLabel = input<string | undefined>(undefined);
   size = input<InfoIconSize>('md');
   clickable = input<boolean>(false);
   disabled = input<boolean>(false);
@@ -23,7 +24,36 @@ export class InfoIconComponent {
   clicked = output();
 
   iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-base' : 'text-xl'));
-  paddingClass = computed(() => 'p-0');
+
+  buttonClass = computed(() => {
+    const base =
+      'group inline-flex shrink-0 items-center justify-center p-0 m-0 border-0 leading-none rounded-md bg-transparent text-text-secondary transition-colors duration-150';
+    const interactive = this.disabled()
+      ? 'cursor-not-allowed opacity-50'
+      : 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-default focus-visible:ring-offset-1';
+    return `${base} ${interactive}`;
+  });
+
+  displayTooltip = computed(() => {
+    this.langChange();
+    const value = this.tooltip();
+    if (value === undefined) {
+      return undefined;
+    }
+    return this.shouldTranslate() ? this.translateService.instant(value) : value;
+  });
+
+  displayAriaLabel = computed(() => {
+    this.langChange();
+    const value = this.ariaLabel();
+    if (value === undefined) {
+      return undefined;
+    }
+    return this.shouldTranslate() ? this.translateService.instant(value) : value;
+  });
+
+  private translateService = inject(TranslateService);
+  private langChange = toSignal(this.translateService.onLangChange, { initialValue: undefined });
 
   onClick(event: Event): void {
     if (this.disabled()) {

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -16,17 +16,25 @@ export class InfoIconComponent {
   ariaLabel = input<string>('More information');
   size = input<InfoIconSize>('md');
   clickable = input<boolean>(false);
+  disabled = input<boolean>(false);
 
   clicked = output();
 
   iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-sm' : 'text-base'));
+  paddingClass = computed(() => (this.size() === 'sm' ? 'p-1' : 'p-2'));
 
   onClick(event: Event): void {
+    if (this.disabled()) {
+      return;
+    }
     event.stopPropagation();
     this.clicked.emit();
   }
 
   onKeydown(event: KeyboardEvent): void {
+    if (this.disabled()) {
+      return;
+    }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       this.clicked.emit();

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -1,0 +1,35 @@
+import { Component, computed, input, output } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { TooltipModule } from 'primeng/tooltip';
+
+export type InfoIconSize = 'sm' | 'md';
+
+@Component({
+  selector: 'jhi-info-icon',
+  standalone: true,
+  imports: [FontAwesomeModule, TooltipModule],
+  templateUrl: './info-icon.component.html',
+})
+export class InfoIconComponent {
+  tooltip = input<string | undefined>(undefined);
+  tooltipPosition = input<'top' | 'bottom' | 'left' | 'right'>('top');
+  ariaLabel = input<string>('More information');
+  size = input<InfoIconSize>('md');
+  clickable = input<boolean>(false);
+
+  clicked = output();
+
+  iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-sm' : 'text-base'));
+
+  onClick(event: Event): void {
+    event.stopPropagation();
+    this.clicked.emit();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.clicked.emit();
+    }
+  }
+}

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -20,7 +20,7 @@ export class InfoIconComponent {
 
   clicked = output();
 
-  iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-sm' : 'text-base'));
+  iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-base' : 'text-xl'));
   paddingClass = computed(() => (this.size() === 'sm' ? 'p-1' : 'p-2'));
 
   onClick(event: Event): void {

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -1,5 +1,5 @@
+import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { TooltipModule } from 'primeng/tooltip';
 
 export type InfoIconSize = 'sm' | 'md';
@@ -7,7 +7,7 @@ export type InfoIconSize = 'sm' | 'md';
 @Component({
   selector: 'jhi-info-icon',
   standalone: true,
-  imports: [FontAwesomeModule, TooltipModule],
+  imports: [NgTemplateOutlet, TooltipModule],
   templateUrl: './info-icon.component.html',
 })
 export class InfoIconComponent {

--- a/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/info-icon/info-icon.component.ts
@@ -21,7 +21,7 @@ export class InfoIconComponent {
   clicked = output();
 
   iconSizeClass = computed(() => (this.size() === 'sm' ? 'text-base' : 'text-xl'));
-  paddingClass = computed(() => (this.size() === 'sm' ? 'p-1' : 'p-2'));
+  paddingClass = computed(() => 'p-0');
 
   onClick(event: Event): void {
     if (this.disabled()) {

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -60,11 +60,7 @@
         jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
       ></h3>
       <!-- Tooltip with AI assistant hint -->
-      <jhi-info-icon
-        size="sm"
-        [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate"
-        tooltipPosition="top"
-      />
+      <jhi-info-icon [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate" tooltipPosition="top" />
     </div>
 
     <p

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -60,7 +60,11 @@
         jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
       ></h3>
       <!-- Tooltip with AI assistant hint -->
-      <jhi-info-icon [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate" tooltipPosition="top" />
+      <jhi-info-icon
+        size="sm"
+        [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate"
+        tooltipPosition="top"
+      />
     </div>
 
     <p

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -10,12 +10,10 @@
           class="m-0 text-base font-semibold text-text-secondary text-center lg:text-left"
           jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiScoreTitle"
         ></h3>
-        <jhi-button
-          label="?"
-          severity="primary"
-          variant="outlined"
-          styleClass="!flex !h-6 !w-7 !min-w-5 !shrink-0 !cursor-pointer !items-center !justify-center !whitespace-nowrap !rounded-full !border !border-primary-default !bg-background-default !p-0 !text-xs !font-bold !leading-none !text-text-secondary hover:!text-primary-default hover:brightness-93"
-          (click)="openScoreDialog()"
+        <jhi-info-icon
+          [clickable]="true"
+          [ariaLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title' | translate"
+          (clicked)="openScoreDialog()"
         />
       </div>
       <!-- Inclusivity feedback text -->
@@ -61,12 +59,7 @@
         jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
       ></h3>
       <!-- Tooltip with AI assistant hint -->
-      <fa-icon
-        class="text-primary"
-        [icon]="['fas', 'circle-info']"
-        [pTooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate"
-        tooltipPosition="top"
-      />
+      <jhi-info-icon [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate" tooltipPosition="top" />
     </div>
 
     <p

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -12,6 +12,7 @@
         ></h3>
         <jhi-info-icon
           [clickable]="true"
+          size="sm"
           [ariaLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title' | translate"
           (clicked)="openScoreDialog()"
         />

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.html
@@ -13,7 +13,8 @@
         <jhi-info-icon
           [clickable]="true"
           size="sm"
-          [ariaLabel]="'jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title' | translate"
+          ariaLabel="jobCreationForm.positionDetailsSection.jobDescription.aiScoreDialog.title"
+          [shouldTranslate]="true"
           (clicked)="openScoreDialog()"
         />
       </div>
@@ -60,7 +61,11 @@
         jhiTranslate="jobCreationForm.positionDetailsSection.jobDescription.aiHeaderText"
       ></h3>
       <!-- Tooltip with AI assistant hint -->
-      <jhi-info-icon [tooltip]="'jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText' | translate" tooltipPosition="top" />
+      <jhi-info-icon
+        tooltip="jobCreationForm.positionDetailsSection.jobDescription.aiTooltipText"
+        tooltipPosition="top"
+        [shouldTranslate]="true"
+      />
     </div>
 
     <p

--- a/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/ai-assistant-card/ai-assistant-card.component.ts
@@ -11,6 +11,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ComplianceIssue, ComplianceIssueCategoryEnum } from 'app/generated/model/compliance-issue';
 import { StatusPillComponent } from 'app/shared/components/atoms/status-pill/status-pill.component';
 import { InfoBoxComponent } from 'app/shared/components/atoms/info-box/info-box.component';
+import { InfoIconComponent } from 'app/shared/components/atoms/info-icon/info-icon.component';
 
 @Component({
   selector: 'jhi-ai-assistant-card',
@@ -27,6 +28,7 @@ import { InfoBoxComponent } from 'app/shared/components/atoms/info-box/info-box.
     AiScoreRingComponent,
     StatusPillComponent,
     InfoBoxComponent,
+    InfoIconComponent,
   ],
   templateUrl: './ai-assistant-card.component.html',
 })

--- a/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.html
@@ -8,13 +8,7 @@
     </div>
 
     <div class="flex-shrink-0 inline-flex flex-row-reverse justify-end items-center gap-2 md:flex-row md:justify-start">
-      <jhi-button
-        label="?"
-        variant="outlined"
-        severity="primary"
-        styleClass="!relative !flex !h-6 !w-7 !min-w-5 !shrink-0 !cursor-pointer !items-center !justify-center !whitespace-nowrap !rounded-full !border !border-primary-default !bg-background-default !p-0 !text-xs !font-bold !leading-none !text-text-secondary hover:!text-primary-default hover:brightness-93"
-        (click)="aiConsentVisible.set(true)"
-      />
+      <jhi-info-icon [clickable]="true" (clicked)="aiConsentVisible.set(true)" />
       @if (isExtractingAi()) {
         <div class="flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-border-default">
           <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />

--- a/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.html
+++ b/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.html
@@ -8,7 +8,12 @@
     </div>
 
     <div class="flex-shrink-0 inline-flex flex-row-reverse justify-end items-center gap-2 md:flex-row md:justify-start">
-      <jhi-info-icon [clickable]="true" (clicked)="aiConsentVisible.set(true)" />
+      <jhi-info-icon
+        [clickable]="true"
+        ariaLabel="entity.aiExtraction.consentInfo"
+        [shouldTranslate]="true"
+        (clicked)="aiConsentVisible.set(true)"
+      />
       @if (isExtractingAi()) {
         <div class="flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-border-default">
           <jhi-progress-spinner styleClass="w-4 h-4" strokeWidth="4" />

--- a/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
+++ b/src/main/webapp/app/shared/components/molecules/ai-extraction-box/ai-extraction-box.component.ts
@@ -11,6 +11,7 @@ import { ToastService } from 'app/service/toast-service';
 import { AiConsentModalComponent } from 'app/shared/settings/ai-consent-settings/ai-consent-modal/ai-consent-modal.component';
 
 import { ButtonComponent } from '../../atoms/button/button.component';
+import { InfoIconComponent } from '../../atoms/info-icon/info-icon.component';
 import { ProgressSpinnerComponent } from '../../atoms/progress-spinner/progress-spinner.component';
 import TranslateDirective from '../../../language/translate.directive';
 
@@ -19,7 +20,7 @@ const activeExtractions = new Map<string, Observable<ExtractedApplicationDataDTO
 @Component({
   selector: 'jhi-ai-extraction-box',
   standalone: true,
-  imports: [ButtonComponent, ProgressSpinnerComponent, AiConsentModalComponent, TranslateDirective],
+  imports: [ButtonComponent, InfoIconComponent, ProgressSpinnerComponent, AiConsentModalComponent, TranslateDirective],
   templateUrl: './ai-extraction-box.component.html',
 })
 export class AiExtractionBoxComponent {

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -351,6 +351,7 @@
       "helperCv": "Spare Zeit und lass unsere KI deine Daten automatisch aus deinem Lebenslauf ausfüllen.",
       "helperCertificates": "Spare Zeit und lass unsere KI deine Studiendaten automatisch aus deinen Zeugnissen ausfüllen.",
       "checkInfo": "Bitte überprüfe die extrahierten Informationen auf Vollständigkeit und Richtigkeit.",
+      "consentInfo": "Informationen zur KI-Zustimmung",
       "button": "KI-Extraktion",
       "loading": "Extrahiert...",
       "aiExtractionFailed": {

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -351,6 +351,7 @@
       "helperCv": "Save time by letting our AI automatically fill your details from your CV.",
       "helperCertificates": "Save time by letting our AI automatically fill your degree information from your certificates.",
       "checkInfo": "Please check the extracted information for completeness and accuracy.",
+      "consentInfo": "AI consent information",
       "button": "AI Extraction",
       "loading": "Extracting...",
       "aiExtractionFailed": {


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [ ] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2390.

The job creation form (and two other shared molecules) rendered an info affordance as a small oval `?` button. The styling was duplicated inline at three sites — it was not actually a shared component despite that perception, so any future visual change would have to be repeated in each location. The oval `?` glyph also conflicts with the rest of the design system (Nielsen heuristic: consistency and standards).

### Description

Introduces a new shared atom `<jhi-info-icon>` at `shared/components/atoms/info-icon/` rendering FontAwesome's `circle-info` and supporting both interaction modes via a single component:

- **Click mode** (`[clickable]="true"`) — renders a `<button>` with keyboard activation (Enter / Space), focus-visible ring, and an `(clicked)` output. Used for opening dialogs.
- **Tooltip mode** (`[tooltip]="..."`) — renders a `<span role="img">` with PrimeNG `pTooltip`. Used for hover hints.
- Both modes can be combined.

Inputs: `tooltip`, `tooltipPosition`, `ariaLabel`, `size` (`sm` | `md`), `clickable`. Output: `clicked`.

Migrated four call sites to the new component:

1. `job-creation-form.component.html` — AI enabled/disabled toggle help (click → dialog)
2. `ai-assistant-card.component.html` — AI score help (click → dialog)
3. `ai-assistant-card.component.html` — AI hint (replaced existing inline `fa-icon` tooltip)
4. `ai-extraction-box.component.html` — AI consent help (click → modal)

Future updates to the info-icon visual treatment now propagate automatically from a single source.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a Professor.
2. Navigate to **Create Job** (or **Edit Job**).

On the **Basic Info** step, in the page header next to the **AI On / AI Off** toggle, verify:

- [ ] The info icon is a circular `circle-info` glyph (not an oval `?` button).
- [ ] Hovering changes the color to the primary color and the cursor is a pointer.
- [ ] Clicking opens the AI info dialog.
- [ ] Pressing **Tab** focuses the icon, **Enter** / **Space** opens the dialog.
- [ ] A focus ring is visible when keyboard-focused.

On the **Position Details** step (with AI enabled), verify:

- [ ] The info icon next to the AI Score title opens the AI score dialog (click and keyboard).
- [ ] The info icon next to the AI assistant header shows a tooltip on hover (no click action).

In an application creation flow that surfaces the AI extraction box (with AI consent enabled), verify:

- [ ] The info icon opens the AI consent modal (click and keyboard).

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] AI info dialog opens from the toggle on the Basic Info step
- [ ] AI score dialog opens from the score header
- [ ] AI hint tooltip shows on hover
- [ ] AI extraction consent modal opens from the extraction box

### Screenshots

_To be added._

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 63.06% | 1153 | 126 | 10.9 |
| editor.component.ts | 76.19% | 328 | 56 | 17.1 |
| info-icon.component.ts | 76.92% | 65 | ? | ? |
| ai-assistant-card.component.ts | 90.74% | 110 | 9 | 8.2 |
| ai-extraction-box.component.ts | 56.62% | 123 | ? | ? |

_Last updated: 2026-05-01 20:25:24 UTC_

