### PR TITLE
`Bugfix`: Fix frozen Login button on slow networks

### DIFF
--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -57,38 +57,63 @@ export class AuthFacadeService {
    * First attempts the email session refresh,
    * otherwise falls back to Keycloak SSO initialization.
    *
+   * Runs as a background bootstrap and intentionally does NOT go through
+   * `runAuthAction`: this is silent SSO/refresh, not a user-initiated action,
+   * so it must not toggle `authOrchestrator.isBusy`. Otherwise a slow Keycloak
+   * iframe or refresh call would leave the orchestrator busy and silently reject
+   * subsequent user clicks on Login.
+   *
+   * If a user-driven login establishes a session while this is still in flight,
+   * the `authMethod !== 'none'` guards prevent init from overriding it.
+   *
    * @return true if the user is authenticated, false otherwise.
    */
   async initAuth(): Promise<boolean> {
-    return this.runAuthAction(
-      async () => {
-        // 1) Email-Authentication-Flow (server session)
-        const refreshed = await this.serverAuthenticationService.refreshTokens(true);
-        if (refreshed) {
-          await this.accountService.loadUser();
-          this.authMethod = 'server';
+    try {
+      // 1) Email-Authentication-Flow (server session)
+      const refreshed = await this.serverAuthenticationService.refreshTokens(true);
+      if (this.authMethod !== 'none') {
+        return true;
+      }
+      if (refreshed) {
+        await this.accountService.loadUser();
+        if (this.authMethod !== 'none') {
           return true;
         }
+        this.authMethod = 'server';
+        return true;
+      }
 
-        // 2) Keycloak-Flow
-        const keycloakInitialized = await this.keycloakAuthenticationService.init();
-        if (keycloakInitialized) {
-          await this.accountService.loadUser();
-          this.authMethod = 'keycloak';
-
-          // Check if IdP registration to be done
-          await this.handlePendingIdpRegistration();
+      // 2) Keycloak-Flow
+      const keycloakInitialized = await this.keycloakAuthenticationService.init();
+      if (this.authMethod !== 'none') {
+        return true;
+      }
+      if (keycloakInitialized) {
+        await this.accountService.loadUser();
+        if (this.authMethod !== 'none') {
           return true;
         }
+        this.authMethod = 'keycloak';
 
-        // 3) not authenticated
-        return false;
-      },
-      {
+        // Check if IdP registration to be done
+        await this.handlePendingIdpRegistration();
+        return true;
+      }
+
+      // 3) not authenticated
+      return false;
+    } catch (e) {
+      this.toastService.showError({
         summary: this.translate.instant(`${this.translationKey}.autoSignInFailed.summary`),
         detail: this.translate.instant(`${this.translationKey}.autoSignInFailed.detail`),
-      },
-    );
+      });
+      // Don't rethrow: initAuth is awaited by Angular's appInitializer at startup,
+      // and a rejected promise there would block app bootstrap. Mirrors the pattern
+      // used by KeycloakAuthenticationService.init().
+      console.warn('Auto sign-in failed:', e);
+      return false;
+    }
   }
 
   // --------------- Email/Password ---------------

--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -72,12 +72,12 @@ export class AuthFacadeService {
     try {
       // 1) Email-Authentication-Flow (server session)
       const refreshed = await this.serverAuthenticationService.refreshTokens(true);
-      if (this.authMethod !== 'none') {
+      if (this.hasActiveAuthMethod()) {
         return true;
       }
       if (refreshed) {
         await this.accountService.loadUser();
-        if (this.authMethod !== 'none') {
+        if (this.hasActiveAuthMethod()) {
           return true;
         }
         this.authMethod = 'server';
@@ -86,12 +86,12 @@ export class AuthFacadeService {
 
       // 2) Keycloak-Flow
       const keycloakInitialized = await this.keycloakAuthenticationService.init();
-      if (this.authMethod !== 'none') {
+      if (this.hasActiveAuthMethod()) {
         return true;
       }
       if (keycloakInitialized) {
         await this.accountService.loadUser();
-        if (this.authMethod !== 'none') {
+        if (this.hasActiveAuthMethod()) {
           return true;
         }
         this.authMethod = 'keycloak';
@@ -247,6 +247,17 @@ export class AuthFacadeService {
         detail: this.translate.instant(`${this.translationKey}.logoutFailed.detail`),
       },
     );
+  }
+
+  /**
+   * Read the current auth method through a method call so the TypeScript compiler
+   * cannot narrow the field to its initializer literal across `await` boundaries.
+   * Concurrent user-driven login flows can mutate `authMethod` while `initAuth`
+   * is still in flight; the narrowing would otherwise hide that possibility from
+   * the guards in `initAuth`.
+   */
+  private hasActiveAuthMethod(): boolean {
+    return this.authMethod !== 'none';
   }
 
   private async handlePendingIdpRegistration(): Promise<void> {

--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -103,15 +103,13 @@ export class AuthFacadeService {
 
       // 3) not authenticated
       return false;
-    } catch (e) {
+    } catch {
+      // Don't rethrow: initAuth is awaited by Angular's appInitializer at startup,
+      // and a rejected promise there would block app bootstrap.
       this.toastService.showError({
         summary: this.translate.instant(`${this.translationKey}.autoSignInFailed.summary`),
         detail: this.translate.instant(`${this.translationKey}.autoSignInFailed.detail`),
       });
-      // Don't rethrow: initAuth is awaited by Angular's appInitializer at startup,
-      // and a rejected promise there would block app bootstrap. Mirrors the pattern
-      // used by KeycloakAuthenticationService.init().
-      console.warn('Auto sign-in failed:', e);
       return false;
     }
   }

--- a/src/test/webapp/app/core/auth/auth-facade.service.spec.ts
+++ b/src/test/webapp/app/core/auth/auth-facade.service.spec.ts
@@ -79,6 +79,46 @@ describe('AuthFacadeService', () => {
       const result = await facade.initAuth();
       expect(result).toBe(false);
     });
+
+    it('does not toggle orchestrator isBusy (background bootstrap)', async () => {
+      const { facade, server, keycloak, orchestrator } = setup();
+      let observedDuringRefresh = false;
+      server.refreshTokens.mockImplementation(async () => {
+        observedDuringRefresh = orchestrator.isBusy();
+        return false;
+      });
+      keycloak.init.mockResolvedValue(false);
+
+      await facade.initAuth();
+
+      expect(observedDuringRefresh).toBe(false);
+      expect(orchestrator.isBusy()).toBe(false);
+    });
+
+    it('does not block user-initiated login while in flight', async () => {
+      const { facade, server, keycloak, account } = setup();
+
+      let resolveKeycloakInit: (v: boolean) => void = () => {};
+      const keycloakInitPromise = new Promise<boolean>(resolve => {
+        resolveKeycloakInit = resolve;
+      });
+      server.refreshTokens.mockResolvedValue(false);
+      keycloak.init.mockReturnValue(keycloakInitPromise);
+      account.loadUser.mockResolvedValue(undefined);
+
+      // Kick off init but don't await — simulates a slow Keycloak silent SSO check.
+      const initPromise = facade.initAuth();
+
+      // While init is still in flight, the user clicks Login. It must succeed.
+      server.login.mockResolvedValue(undefined);
+      await expect(facade.loginWithEmail('a@b.com', 'pw')).resolves.toBe(true);
+      expect(server.login).toHaveBeenCalledTimes(1);
+
+      // Finish the slow init; it must not overwrite the server-established session.
+      resolveKeycloakInit(true);
+      await initPromise;
+      expect((facade as any).authMethod).toBe('server');
+    });
   });
 
   describe('loginWithEmail', () => {

--- a/src/test/webapp/app/core/auth/auth-facade.service.spec.ts
+++ b/src/test/webapp/app/core/auth/auth-facade.service.spec.ts
@@ -80,7 +80,7 @@ describe('AuthFacadeService', () => {
       expect(result).toBe(false);
     });
 
-    it('does not toggle orchestrator isBusy (background bootstrap)', async () => {
+    it('should not toggle orchestrator isBusy when running as background bootstrap', async () => {
       const { facade, server, keycloak, orchestrator } = setup();
       let observedDuringRefresh = false;
       server.refreshTokens.mockImplementation(async () => {
@@ -95,7 +95,7 @@ describe('AuthFacadeService', () => {
       expect(orchestrator.isBusy()).toBe(false);
     });
 
-    it('does not block user-initiated login while in flight', async () => {
+    it('should not block user-initiated login when initAuth is still in flight', async () => {
       const { facade, server, keycloak, account } = setup();
 
       let resolveKeycloakInit: (v: boolean) => void = () => {};


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Closes #2405.

On slow or unstable networks — and sometimes right after logging out — clicking the Login button does nothing. No toast, no error, nothing opens. Users perceive the page as frozen.

Root cause: `AuthFacadeService.initAuth()` was wrapped in `runAuthAction`, which means the silent SSO / refresh bootstrap that runs at app startup sets `authOrchestrator.isBusy = true` for the entire duration of its work (server refresh + Keycloak `check-sso` iframe). User-initiated auth actions guard on `isBusy()` and silently throw "AuthOrchestrator is busy". On a slow Keycloak / slow network, that window is large enough for users to click Login and get nothing.

### Description

- `initAuth` no longer goes through `runAuthAction`. It is a silent background bootstrap, not a user-initiated action, so it must not toggle the user-facing busy flag. The `isBusy` lane now belongs only to explicit user actions (Login, OTP, Logout, Register).
- Added `authMethod !== 'none'` guards after every `await` inside `initAuth`, so a slow init that finishes after a user-driven login cannot clobber the session that the user just established.
- Errors during init no longer rethrow. They surface a toast and log a warning, but resolve to `false`. `initAuth` is awaited by Angular's `provideAppInitializer`, so a rejected promise there would block app bootstrap. This mirrors the existing pattern in `KeycloakAuthenticationService.init()`.
- Added two unit tests:
  - `initAuth` does not toggle `authOrchestrator.isBusy`.
  - `loginWithEmail` succeeds while a slow Keycloak `init()` is still in flight, and the late-resolving init does not overwrite `authMethod`.

### Steps for Testing

Prerequisites:

1. Run the client locally against a working Keycloak.
2. In Chrome DevTools, open the Network tab and throttle the connection (or use a custom profile that adds 3–5 s latency to the Keycloak host).

Test 1 — slow load:

1. Reload the page with the throttled network active.
2. As soon as the page is interactive, click **Login**. The login dialog should open immediately, even while the Keycloak silent-SSO check is still in flight in the background.

Test 2 — logout into login:

1. Log in with email/password.
2. Log out.
3. Immediately click **Login** again. The login dialog should open without delay, no silent rejection.

Test 3 — race protection:

1. Throttle Keycloak as in Test 1.
2. Reload, then immediately log in with email/password.
3. After the slow Keycloak silent-SSO check finally resolves, the user must remain authenticated as the server-session user — the late init must not flip the active auth method to Keycloak.

Automated:

- `npx vitest run src/test/webapp/app/core/auth/auth-facade.service.spec.ts` — all 16 tests pass, including the two new ones covering the scenarios above.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — slow load, Login button responsive
- [ ] Test 2 — logout then Login, no freeze
- [ ] Test 3 — server session is not overwritten by late silent SSO