### PR TITLE
`Bugfix`: Fix job publication silently reverting to Draft when autosave is pending

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -544,12 +544,7 @@ export class JobCreationFormComponent {
   /** Timer ID for the debounced auto-save (2-second delay) */
   private autoSaveTimer: number | undefined;
 
-  /**
-   * The currently in-flight auto-save promise, or undefined if none is running.
-   * Used by publishJob to wait for an in-flight Draft save to settle before
-   * sending the Published DTO, so the autosave can't land afterwards and
-   * silently revert the job to Draft.
-   */
+  /** The currently in-flight auto-save promise, or undefined if none is running. */
   private autoSaveInFlight: Promise<void> | undefined;
 
   /** Flag to prevent auto-save from triggering during initial form population */
@@ -693,7 +688,7 @@ export class JobCreationFormComponent {
    * Before sending the Published DTO, cancels any pending debounced autosave
    * and waits for an in-flight autosave to settle. Otherwise a Draft autosave
    * could land on the server *after* the publish call and silently revert the
-   * job to Draft — see issue #2228.
+   * job to Draft.
    */
   async publishJob(): Promise<void> {
     const jobData = this.publishableJobData();

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -544,6 +544,14 @@ export class JobCreationFormComponent {
   /** Timer ID for the debounced auto-save (2-second delay) */
   private autoSaveTimer: number | undefined;
 
+  /**
+   * The currently in-flight auto-save promise, or undefined if none is running.
+   * Used by publishJob to wait for an in-flight Draft save to settle before
+   * sending the Published DTO, so the autosave can't land afterwards and
+   * silently revert the job to Draft.
+   */
+  private autoSaveInFlight: Promise<void> | undefined;
+
   /** Flag to prevent auto-save from triggering during initial form population */
   private autoSaveInitialized = false;
 
@@ -681,11 +689,21 @@ export class JobCreationFormComponent {
    * Publishes the job posting after validation.
    * Requires privacy consent and valid forms.
    * Navigates to /my-positions on success.
+   *
+   * Before sending the Published DTO, cancels any pending debounced autosave
+   * and waits for an in-flight autosave to settle. Otherwise a Draft autosave
+   * could land on the server *after* the publish call and silently revert the
+   * job to Draft — see issue #2228.
    */
   async publishJob(): Promise<void> {
     const jobData = this.publishableJobData();
 
     if (!jobData) return;
+
+    this.clearAutoSaveTimer();
+    if (this.autoSaveInFlight) {
+      await this.autoSaveInFlight;
+    }
 
     try {
       const saved = await firstValueFrom(this.jobApi.updateJob(this.jobId(), jobData));
@@ -1520,7 +1538,18 @@ export class JobCreationFormComponent {
    * Creates job on first save, updates on subsequent saves.
    * Triggers translation after successful save if content changed.
    */
-  private async performAutoSave(): Promise<void> {
+  private performAutoSave(): Promise<void> {
+    const work = this.runAutoSave();
+    this.autoSaveInFlight = work;
+    void work.finally(() => {
+      if (this.autoSaveInFlight === work) {
+        this.autoSaveInFlight = undefined;
+      }
+    });
+    return work;
+  }
+
+  private async runAutoSave(): Promise<void> {
     // 1) Capture current form state before any async work
     const currentLang = this.currentDescriptionLanguage();
     const description = this.basicInfoForm.get('jobDescription')?.value ?? '';

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -400,7 +400,10 @@ describe('JobCreationFormComponent', () => {
       component.jobId.set('id123');
 
       const draftSave = new Subject<JobFormDTO>();
-      mockJobApi.updateJob = vi.fn().mockReturnValueOnce(draftSave).mockReturnValueOnce(of({ jobId: 'id123', state: JobFormDTOStateEnum.Published }));
+      mockJobApi.updateJob = vi
+        .fn()
+        .mockReturnValueOnce(draftSave)
+        .mockReturnValueOnce(of({ jobId: 'id123', state: JobFormDTOStateEnum.Published }));
 
       const autoSavePromise = getPrivate(component).performAutoSave();
       const publishPromise = component.publishJob();

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { UrlSegment } from '@angular/router';
 import { signal, TemplateRef } from '@angular/core';
 
@@ -90,6 +90,7 @@ type ComponentPrivate = {
   performAutoSave: () => Promise<void>;
   clearAutoSaveTimer: () => void;
   autoSaveTimer?: number;
+  autoSaveInFlight: Promise<void> | undefined;
   autoSaveInitialized: boolean;
   populateForm: (job?: JobDTO) => void;
   createJobDTO: (state?: JobFormDTOStateEnum) => JobFormDTO;
@@ -373,6 +374,53 @@ describe('JobCreationFormComponent', () => {
       setup(component);
       await component.publishJob();
       expectations();
+    });
+
+    it('should cancel a pending debounced autosave before publishing (issue #2228)', async () => {
+      fillValidJobForm(component);
+      fixture.detectChanges();
+      component.jobId.set('id123');
+
+      const priv = getPrivate(component);
+      const triggered = vi.fn();
+      priv.autoSaveTimer = window.setTimeout(triggered, 10_000);
+
+      await component.publishJob();
+
+      expect(priv.autoSaveTimer).toBeUndefined();
+      expect(triggered).not.toHaveBeenCalled();
+      expect(mockJobApi.updateJob).toHaveBeenCalledTimes(1);
+      const [, sentDto] = mockJobApi.updateJob.mock.calls[0];
+      expect(sentDto.state).toBe(JobFormDTOStateEnum.Published);
+    });
+
+    it('should wait for an in-flight autosave before publishing so Published is the last write (issue #2228)', async () => {
+      fillValidJobForm(component);
+      fixture.detectChanges();
+      component.jobId.set('id123');
+
+      const draftSave = new Subject<JobFormDTO>();
+      mockJobApi.updateJob = vi.fn().mockReturnValueOnce(draftSave).mockReturnValueOnce(of({ jobId: 'id123', state: JobFormDTOStateEnum.Published }));
+
+      const autoSavePromise = getPrivate(component).performAutoSave();
+      const publishPromise = component.publishJob();
+      await Promise.resolve();
+
+      // While the autosave is still pending, the publish must NOT have fired.
+      expect(mockJobApi.updateJob).toHaveBeenCalledTimes(1);
+
+      // Resolve the in-flight Draft autosave; the publish should now run.
+      draftSave.next({ jobId: 'id123', state: JobFormDTOStateEnum.Draft } as JobFormDTO);
+      draftSave.complete();
+      await autoSavePromise;
+      await publishPromise;
+
+      expect(mockJobApi.updateJob).toHaveBeenCalledTimes(2);
+      const firstDto = mockJobApi.updateJob.mock.calls[0][1];
+      const secondDto = mockJobApi.updateJob.mock.calls[1][1];
+      expect(firstDto.state).toBe(JobFormDTOStateEnum.Draft);
+      expect(secondDto.state).toBe(JobFormDTOStateEnum.Published);
+      expect(mockToastService.showSuccessKey).toHaveBeenCalledWith('toast.published');
     });
   });
 

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -376,7 +376,7 @@ describe('JobCreationFormComponent', () => {
       expectations();
     });
 
-    it('should cancel a pending debounced autosave before publishing (issue #2228)', async () => {
+    it('should cancel a pending debounced autosave before publishing', async () => {
       fillValidJobForm(component);
       fixture.detectChanges();
       component.jobId.set('id123');
@@ -389,12 +389,12 @@ describe('JobCreationFormComponent', () => {
 
       expect(priv.autoSaveTimer).toBeUndefined();
       expect(triggered).not.toHaveBeenCalled();
-      expect(mockJobApi.updateJob).toHaveBeenCalledTimes(1);
+      expect(mockJobApi.updateJob).toHaveBeenCalledOnce();
       const [, sentDto] = mockJobApi.updateJob.mock.calls[0];
       expect(sentDto.state).toBe(JobFormDTOStateEnum.Published);
     });
 
-    it('should wait for an in-flight autosave before publishing so Published is the last write (issue #2228)', async () => {
+    it('should wait for an in-flight autosave before publishing so Published is the last write', async () => {
       fillValidJobForm(component);
       fixture.detectChanges();
       component.jobId.set('id123');
@@ -410,7 +410,7 @@ describe('JobCreationFormComponent', () => {
       await Promise.resolve();
 
       // While the autosave is still pending, the publish must NOT have fired.
-      expect(mockJobApi.updateJob).toHaveBeenCalledTimes(1);
+      expect(mockJobApi.updateJob).toHaveBeenCalledOnce();
 
       // Resolve the in-flight Draft autosave; the publish should now run.
       draftSave.next({ jobId: 'id123', state: JobFormDTOStateEnum.Draft } as JobFormDTO);


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Closes #2228.

When a professor clicks **Publish** on a job posting while the form's auto-save is mid-flight (or has a debounced save scheduled), the UI shows a "Publication successful" toast — but on reload the job has reverted to *Draft*. Cause: `publishJob` and the autosave both call `updateJob` on the same endpoint with different `state` values. The Published call from publish gets clobbered when the older Draft autosave lands on the server afterwards, last-write-wins.

This creates a false sense of completion. Professors navigate away believing their job is live, miss hiring windows, and the job never appears for students.

### Description

- `publishJob` now flushes the autosave queue before sending the Published DTO:
  - `clearAutoSaveTimer()` cancels any pending 2 s debounced autosave so it cannot fire after the publish.
  - If an autosave is currently mid-flight, `publishJob` `await`s it before issuing the Published call, so the older Draft response cannot land last on the server.
- Added a `private autoSaveInFlight: Promise<void> | undefined` field. `performAutoSave` is split into a thin wrapper that tracks the running promise and a `runAutoSave` private with the original implementation. The wrapper clears the field in `.finally`, but only if it still points at this run (so a later autosave's wrapper doesn't clear it prematurely).
- No redundant Draft save before publishing: the Published DTO already contains every field the autosave would have sent, so awaiting the in-flight one is enough.
- The existing success toast was already gated on the `updateJob` response — once the race is removed, the toast is correct again. Acceptance criterion 2 ("no Success when the update fails or is bypassed") is satisfied without further change.

### Steps for Testing

Prerequisites:

1. Log in as a professor.
2. Open a draft job posting (or create a new one).

Test 1 — pending debounced autosave:

1. Edit a field (e.g. the title).
2. Within ~1 second of typing — before the 2 s autosave debounce fires — click **Publish**.
3. The success toast appears, the user is redirected to **My Positions**, and the job shows as **Published**.
4. Reload the page. The job is still **Published** (previously: reverted to Draft).

Test 2 — autosave currently in flight:

1. Throttle the network in DevTools (e.g. Slow 3G) so an autosave takes a few seconds.
2. Edit a field, wait for the autosave request to start (badge shows "Saving").
3. While the request is still pending, click **Publish**.
4. The publish must wait for the Draft save to settle, then send the Published call. The job is **Published** after reload.

Test 3 — autosave failure does not block publish:

1. Force a temporary network error during autosave (e.g. block the API in DevTools, edit a field, wait for the failure toast, then unblock).
2. Click **Publish**.
3. The publish should still go through; the user's explicit action is honoured.

Automated:

- `npx vitest run src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts` — all 71 tests pass, including:
  - `should cancel a pending debounced autosave before publishing (issue #2228)`
  - `should wait for an in-flight autosave before publishing so Published is the last write (issue #2228)`

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — debounced autosave cancelled by publish
- [ ] Test 2 — in-flight autosave awaited before publish
- [ ] Test 3 — failed autosave does not block publish