### PR TITLE
`Bugfix`: Translate "No results found" in dropdowns when language is German

### DIFF
--- a/src/main/webapp/app/shared/language/primeng-translation.service.ts
+++ b/src/main/webapp/app/shared/language/primeng-translation.service.ts
@@ -3,11 +3,13 @@ import { TranslateService } from '@ngx-translate/core';
 import { PrimeNG } from 'primeng/config';
 
 /**
- * Wires PrimeNG's internal i18n (month/weekday names, Today/Clear labels) to the app language.
- * PrimeNG v20 reads these from a global translation map, configured via PrimeNG.setTranslation().
+ * Wires PrimeNG's internal i18n (month/weekday names, calendar labels, dropdown empty
+ * messages) to the app language. PrimeNG reads these from a global translation map,
+ * configured via PrimeNG.setTranslation().
  *
- * This service is primarily used by PrimeNG Calendar components (DatePicker) to display
- * localized month names, day names, and UI labels based on the current application language.
+ * Used by PrimeNG Calendar/DatePicker components for localized month/day names and by
+ * Select/Dropdown components for the "no results found" / "no available options"
+ * placeholders shown when filtering yields no match or the option list is empty.
  */
 @Injectable({ providedIn: 'root' })
 export class PrimengTranslationService {
@@ -34,6 +36,8 @@ export class PrimengTranslationService {
         today: 'Heute',
         clear: 'Zurücksetzen',
         weekHeader: 'KW',
+        emptyFilterMessage: 'Keine Ergebnisse gefunden',
+        emptyMessage: 'Keine Optionen verfügbar',
       });
     } else {
       this.primeNG.setTranslation({
@@ -58,6 +62,8 @@ export class PrimengTranslationService {
         today: 'Today',
         clear: 'Clear',
         weekHeader: 'Wk',
+        emptyFilterMessage: 'No results found',
+        emptyMessage: 'No available options',
       });
     }
   }

--- a/src/test/webapp/app/shared/language/primeng-translation.service.spec.ts
+++ b/src/test/webapp/app/shared/language/primeng-translation.service.spec.ts
@@ -141,6 +141,15 @@ describe('PrimengTranslationService', () => {
         }),
       );
     });
+
+    it('should set English dropdown empty messages', () => {
+      expect(primeNG.setTranslation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emptyFilterMessage: 'No results found',
+          emptyMessage: 'No available options',
+        }),
+      );
+    });
   });
 
   describe('German locale configuration', () => {
@@ -198,6 +207,15 @@ describe('PrimengTranslationService', () => {
       expect(primeNG.setTranslation).toHaveBeenCalledWith(
         expect.objectContaining({
           monthNamesShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
+        }),
+      );
+    });
+
+    it('should set German dropdown empty messages', () => {
+      expect(primeNG.setTranslation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emptyFilterMessage: 'Keine Ergebnisse gefunden',
+          emptyMessage: 'Keine Optionen verfügbar',
         }),
       );
     });


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Closes #2408.

When the UI is set to German and a user filters in a PrimeNG dropdown with no matching options (e.g. typing a non-existing nationality on the application creation form), the placeholder still reads "No results found" in English. The same applies when a dropdown has no options at all — PrimeNG shows "No available options" in English. Reported by QA on the application creation flow.

### Description

`PrimengTranslationService.applyLocale` previously only configured calendar-related PrimeNG i18n keys (day/month names, *Today*, *Clear*, *Wk*). The PrimeNG `Select` component reads `emptyFilterMessage` and `emptyMessage` from the same translation map; since they were never set, PrimeNG fell back to its built-in English defaults regardless of the app language.

This PR extends both the EN and DE branches of `applyLocale` with:

- `emptyFilterMessage` — shown after typing in a filterable dropdown when nothing matches.
- `emptyMessage` — shown when the option list is empty.

Updated the service-level JSDoc to reflect that the service now also wires up dropdown empty-state messages, not just calendar labels.

### Steps for Testing

Prerequisites:

1. Run the client locally.

Test 1 — German filter with no match:

1. Switch the UI language to **DE**.
2. Open the application creation form and scroll to the **Nationalität** dropdown.
3. Open the dropdown and type a non-existing nationality (e.g. `lalala`).
4. The placeholder reads **"Keine Ergebnisse gefunden"**.

Test 2 — English filter with no match (regression):

1. Switch the UI language to **EN**.
2. Repeat the previous steps.
3. The placeholder reads **"No results found"** (unchanged behaviour).

Test 3 — language switch at runtime:

1. Open a dropdown that supports filtering and apply a filter that yields no results.
2. Without closing the dropdown, switch the language toggle.
3. The placeholder updates to the other language.

Automated:

- `npx vitest run src/test/webapp/app/shared/language/primeng-translation.service.spec.ts` — all 20 tests pass, including the two new ones for the EN and DE empty-message keys.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — German filter, "Keine Ergebnisse gefunden"
- [ ] Test 2 — English filter, "No results found" (no regression)
- [ ] Test 3 — language switch updates placeholder live