### PR TITLE
`Bugfix`: Fix email template editor placeholder position and align page header

### DIFF
--- a/src/main/webapp/app/usermanagement/research-group/research-group-template-edit/research-group-template-edit.html
+++ b/src/main/webapp/app/usermanagement/research-group/research-group-template-edit/research-group-template-edit.html
@@ -1,9 +1,13 @@
 <div class="page-container">
-  <div class="header-container !items-center">
+  <div class="header-container">
     <div class="page-header">
       <div class="flex items-center gap-2">
         <jhi-back-button />
-        <h1 jhiTranslate="researchGroup.emailTemplatesHeader"></h1>
+        <h1>
+          <span jhiTranslate="sidebar.researchgroup.title"></span>
+          -
+          <span jhiTranslate="researchGroup.emailTemplatesHeader"></span>
+        </h1>
       </div>
     </div>
     <div

--- a/src/main/webapp/app/usermanagement/research-group/research-group-template-edit/research-group-template-edit.scss
+++ b/src/main/webapp/app/usermanagement/research-group/research-group-template-edit/research-group-template-edit.scss
@@ -165,10 +165,5 @@
   .ql-container {
     border-top: none;
     border-radius: 0 0 0.5rem 0.5rem;
-
-    .ql-editor {
-      font-size: 1rem;
-      line-height: 1.8rem;
-    }
   }
 }


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.

> Note on tests: this is a presentational fix — pure SCSS/template change with no logic touched. The existing 3 component tests still pass.

### Motivation and Context

Closes #2412.

QA reported two visual issues on the email template editor page:
- The \"Insert text here…\" placeholder in the message editor is positioned far below the toolbar instead of where the user would actually start typing.
- The page header is inconsistent with the rest of the research-group section. Other research-group pages (templates list, group info, images, departments) all use a two-part \"Forschungsgruppe - …\" title; this page uses a one-part title with an `!items-center` override.

### Description

- **Placeholder position.** Page-local SCSS forced `.ql-editor { font-size: 1rem; line-height: 1.8rem }`. Quill renders the placeholder inside the first empty `<p>`, so a 1.8 rem line-height made the placeholder visibly sit below the toolbar. Removed the override; Quill's default line metrics now apply, matching the placeholder position used everywhere else in the app.
- **Page header.** Switched the title to the canonical two-part pattern `<span jhiTranslate=\"sidebar.researchgroup.title\"></span> - <span jhiTranslate=\"researchGroup.emailTemplatesHeader\"></span>` (the same shape used by the parent templates list, `research-group-info`, `research-group-images`, etc.). Dropped the `header-container !items-center` Tailwind override since the canonical pattern doesn't need it. Kept the back button next to the title and the saving-state indicator on the right.

The mention/variables feature (`quill-mention`), autosave, language switching and the multilingual subject inputs are untouched.

### Steps for Testing

Prerequisites:

1. Log in as a professor with research-group access.

Test 1 — placeholder position:

1. Navigate to **Research Group → Email Templates** and open or create a custom template.
2. Make sure the message body of either tab is empty.
3. The \"Insert text here…\" placeholder appears immediately below the toolbar, with the same vertical offset as the cursor when you click into the editor.

Test 2 — page header consistency:

1. Open the template list page and note the title \"Research Group - Email Templates\".
2. Open a template for editing.
3. The edit page now shows the same two-part title (with the back button and the saving status indicator preserved).
4. Switch the UI language to German — the title reads \"Forschungsgruppe - E-Mail-Vorlagen\" (matches the list page).

Test 3 — no regression in editor features:

1. In the editor, type a `\$` to open the variable picker, insert e.g. `\$JOB_TITLE` — the mention is inserted as a styled span.
2. Type some content; after the autosave delay the saving indicator switches to **Saved**.
3. Switch tabs (English ↔ German) — content persists per tab.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — placeholder appears at the top of the typing area
- [ ] Test 2 — header matches the rest of the research-group section, in EN and DE
- [ ] Test 3 — variables, autosave, and tab switching still work