### PR TITLE
`Bugfix`: Load selected document on first dialog open

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
@@ -20,9 +20,6 @@ export class DocumentViewerComponent {
   private documentApi = inject(DocumentResourceApi);
   private cache: DocumentCacheService = inject(DocumentCacheService);
 
-  // Read the signal synchronously here so the dependency is captured even
-  // though the download is async. Mounting under a structural directive in
-  // a zoneless app can otherwise miss the first trigger.
   private readonly docDownloadEffect = effect(() => {
     const docId = this.documentId().id;
     void this.initDocument(docId);

--- a/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
@@ -22,13 +22,15 @@ export class DocumentViewerComponent {
 
   constructor() {
     effect(() => {
-      void this.initDocument();
+      // Read the signal synchronously here so the dependency is captured even
+      // though the download is async. Mounting under a structural directive in
+      // a zoneless app can otherwise miss the first trigger.
+      const docId = this.documentId().id;
+      void this.initDocument(docId);
     });
   }
 
-  async initDocument(): Promise<void> {
-    const docId = this.documentId().id;
-
+  async initDocument(docId: string = this.documentId().id): Promise<void> {
     // check cache first
     const cached = this.cache.get(docId);
     if (cached !== undefined) {

--- a/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.ts
@@ -20,15 +20,13 @@ export class DocumentViewerComponent {
   private documentApi = inject(DocumentResourceApi);
   private cache: DocumentCacheService = inject(DocumentCacheService);
 
-  constructor() {
-    effect(() => {
-      // Read the signal synchronously here so the dependency is captured even
-      // though the download is async. Mounting under a structural directive in
-      // a zoneless app can otherwise miss the first trigger.
-      const docId = this.documentId().id;
-      void this.initDocument(docId);
-    });
-  }
+  // Read the signal synchronously here so the dependency is captured even
+  // though the download is async. Mounting under a structural directive in
+  // a zoneless app can otherwise miss the first trigger.
+  private readonly docDownloadEffect = effect(() => {
+    const docId = this.documentId().id;
+    void this.initDocument(docId);
+  });
 
   async initDocument(docId: string = this.documentId().id): Promise<void> {
     // check cache first


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.

> Note on tests: this is a 6-line change to the effect/dependency-tracking pattern; the existing 12 unit tests for `DocumentViewerComponent` continue to pass and cover the public `initDocument()` contract. Verified manually using the steps below.

### Motivation and Context

Closes #2414.

QA reported that opening the documents view of an application for the first time leaves the preview pane blank — the master certificate is selected on the left but never loads on the right. Switching to a different document and back fixes it.

### Description

The viewer's `effect()` was structured as:

```ts
constructor() {
  effect(() => {
    void this.initDocument();
  });
}

async initDocument() {
  const docId = this.documentId().id;
  // ... await download, set sanitizedBlobUrl
}
```

The signal read lives inside an async helper. When the viewer is mounted under a structural directive (`@if (selectedDocument(); as doc)`) inside a PrimeNG dialog whose `[visible]` flips in the same change-detection cycle, the first effect run in zoneless mode can race the input propagation. Subsequent input changes always re-fire the effect cleanly, which is why switching documents works.

This PR reads `this.documentId().id` at the top of the effect callback and passes it into `initDocument`. The dependency is now captured before any await, so the first mount reliably triggers the download for the initially selected document. `initDocument(docId?: string)` keeps a default that reads the signal so callers (and existing unit tests) that invoke it without arguments continue to work.

### Steps for Testing

Prerequisites:

1. Log in as a professor.
2. Pick an applicant who has multiple uploaded documents (master certificate, CV, bachelor).

Test 1 — first open:

1. Open the application review and click **Document view**.
2. The master certificate should load immediately in the right pane (previously: blank).

Test 2 — switching docs (no regression):

1. With the dialog open, click another document — it loads.
2. Click back to the master certificate — it loads from cache, no flicker.

Test 3 — close and reopen:

1. Close the dialog.
2. Reopen it. The master certificate loads immediately on the first mount of the new viewer instance.

Automated:

- `npx vitest run src/test/webapp/app/shared/components/atoms/document-viewer/document-viewer.component.spec.ts` — all 12 tests pass.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — first open loads selected document
- [ ] Test 2 — switching documents still works
- [ ] Test 3 — close + reopen loads on first mount