### PR TITLE
`Bugfix`: Show "1 year" instead of "1 years" for contract duration

### DIFF
--- a/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
+++ b/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
@@ -84,7 +84,7 @@ public class PDFExportService {
                 )
                 .addOverviewItem(labels.get("researchArea"), getValue(job.researchArea()))
                 .addOverviewItem(labels.get("workload"), formatWorkload(job.workload(), labels.get("hoursPerWeek")))
-                .addOverviewItem(labels.get("duration"), formatContractDuration(job.contractDuration(), labels.get("years")))
+                .addOverviewItem(labels.get("duration"), formatContractDuration(job.contractDuration(), labels.get("year"), labels.get("years")))
                 .addOverviewItem(
                     labels.get("fundingType"),
                     job.fundingType() != null ? getValue(job.fundingType().correctLanguageValue(lang)) : "-"
@@ -197,7 +197,7 @@ public class PDFExportService {
                 job.subjectArea() != null ? job.subjectArea().correctLanguageValue(lang) : "-",
                 job.researchArea(),
                 formatWorkload(job.workload(), labels.get("hoursPerWeek")),
-                formatContractDuration(job.contractDuration(), labels.get("years")),
+                formatContractDuration(job.contractDuration(), labels.get("year"), labels.get("years")),
                 job.fundingType() != null ? getValue(job.fundingType().correctLanguageValue(lang)) : "-",
                 formatDate(job.startDate()),
                 formatDate(job.endDate())
@@ -262,7 +262,7 @@ public class PDFExportService {
                 jobFormDTO.subjectArea() != null ? jobFormDTO.subjectArea().correctLanguageValue(lang) : "-",
                 jobFormDTO.researchArea(),
                 jobFormDTO.workload() != null ? jobFormDTO.workload() + labels.get("hoursPerWeek") : "-",
-                jobFormDTO.contractDuration() != null ? jobFormDTO.contractDuration() + labels.get("years") : "-",
+                formatContractDuration(jobFormDTO.contractDuration(), labels.get("year"), labels.get("years")),
                 jobFormDTO.fundingType() != null ? jobFormDTO.fundingType().correctLanguageValue(lang) : "-",
                 jobFormDTO.startDate() != null ? jobFormDTO.startDate().format(DATE_FORMATTER) : "-",
                 jobFormDTO.endDate() != null ? jobFormDTO.endDate().format(DATE_FORMATTER) : "-"
@@ -565,8 +565,12 @@ public class PDFExportService {
         return workload != null ? workload + (" " + unit) : "-";
     }
 
-    private String formatContractDuration(Integer duration, String unit) {
-        return duration != null ? duration + (" " + unit) : "-";
+    private String formatContractDuration(Integer duration, String singularUnit, String pluralUnit) {
+        if (duration == null) {
+            return "-";
+        }
+        String unit = duration == 1 ? singularUnit : pluralUnit;
+        return duration + " " + unit;
     }
 
     private String sanitizeFilename(String filename) {

--- a/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
+++ b/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
@@ -84,7 +84,10 @@ public class PDFExportService {
                 )
                 .addOverviewItem(labels.get("researchArea"), getValue(job.researchArea()))
                 .addOverviewItem(labels.get("workload"), formatWorkload(job.workload(), labels.get("hoursPerWeek")))
-                .addOverviewItem(labels.get("duration"), formatContractDuration(job.contractDuration(), labels.get("year"), labels.get("years")))
+                .addOverviewItem(
+                    labels.get("duration"),
+                    formatContractDuration(job.contractDuration(), labels.get("year"), labels.get("years"))
+                )
                 .addOverviewItem(
                     labels.get("fundingType"),
                     job.fundingType() != null ? getValue(job.fundingType().correctLanguageValue(lang)) : "-"

--- a/src/main/webapp/app/job/job-detail/job-detail.component.html
+++ b/src/main/webapp/app/job/job-detail/job-detail.component.html
@@ -155,7 +155,10 @@
               <div class="info-row">
                 <span jhiTranslate="jobDetailPage.labels.contractDuration"></span>
                 @if (job.contractDuration !== '') {
-                  <span class="value">{{ job.contractDuration }} <span jhiTranslate="jobDetailPage.units.years"></span></span>
+                  <span class="value"
+                    >{{ job.contractDuration }}
+                    <span [jhiTranslate]="job.contractDuration === '1' ? 'jobDetailPage.units.year' : 'jobDetailPage.units.years'"></span
+                  ></span>
                 } @else {
                   <span class="value">-</span>
                 }

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -84,7 +84,8 @@
     <div class="flex flex-wrap gap-2 mt-auto">
       @if (formattedContractDuration()) {
         <span class="px-3 py-1 text-primary text-xs font-medium rounded-pill border border-primary">
-          {{ formattedContractDuration() }} <span jhiTranslate="jobDetailPage.units.years"></span>
+          {{ formattedContractDuration() }}
+          <span [jhiTranslate]="formattedContractDuration() === 1 ? 'jobDetailPage.units.year' : 'jobDetailPage.units.years'"></span>
         </span>
       }
       @if (formattedWorkload()) {

--- a/src/main/webapp/app/shared/language/pdf-labels.ts
+++ b/src/main/webapp/app/shared/language/pdf-labels.ts
@@ -56,6 +56,7 @@ function getOverviewItemLabel(translate: TranslateService): Record<string, strin
     workload: `${translate.instant('jobDetailPage.labels.workload')}:`,
     hoursPerWeek: translate.instant('jobDetailPage.units.hoursPerWeek'),
     duration: `${translate.instant('jobDetailPage.labels.contractDuration')}:`,
+    year: translate.instant('jobDetailPage.units.year'),
     years: translate.instant('jobDetailPage.units.years'),
     fundingType: `${translate.instant('jobDetailPage.labels.fundingType')}:`,
     startDate: `${translate.instant('jobDetailPage.labels.startDate')}:`,

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -406,6 +406,7 @@
     },
     "units": {
       "hoursPerWeek": "Stunden/Woche",
+      "year": "Jahr",
       "years": "Jahre"
     },
     "workload": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -406,6 +406,7 @@
     },
     "units": {
       "hoursPerWeek": "hours/week",
+      "year": "year",
       "years": "years"
     },
     "workload": {

--- a/src/test/java/de/tum/cit/aet/core/web/rest/PDFExportResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/core/web/rest/PDFExportResourceTest.java
@@ -153,6 +153,7 @@ class PDFExportResourceTest extends AbstractResourceTest {
         labels.put("workload", "Workload");
         labels.put("hoursPerWeek", " hours/week");
         labels.put("duration", "Duration");
+        labels.put("year", " year");
         labels.put("years", " years");
         labels.put("fundingType", "Funding Type");
         labels.put("startDate", "Start Date");


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://ls1intum.github.io/tum-apply/developer/server-guidelines/database-and-performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/server-guidelines/server-development).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: translation-key + template change on the client; small refactor of the PDF formatter on the server. Existing 71 client tests + the existing PDF export resource tests continue to pass after the formatter signature change.

### Motivation and Context

Closes #2417.

QA reported that one-year contracts show "1 years" / "1 Jahre" on the job detail page. The same plural-only label is used on the overview job-card badges, and on the server-side PDF export — fixed in all three places now.

### Description

Three pieces:

1. Added a singular `jobDetailPage.units.year` key to `i18n/en/job.json` and `i18n/de/job.json` (the existing plural `years` key is kept).
2. Switched the templates from a hardcoded plural to a ternary that picks `year` vs `years` based on the value:
   - `job-detail.component.html` — `job.contractDuration === '1' ? '...year' : '...years'`. The component already stores duration as a string.
   - `job-card.component.html` — `formattedContractDuration() === 1 ? '...year' : '...years'`. The card stores duration as a number.
3. Followed up Cathy's review note about the PDF export:
   - `pdf-labels.ts` now sends both `year` and `years` labels.
   - `PDFExportService.formatContractDuration` takes both labels and picks the singular form when the duration is 1, plural otherwise. Used by both the real job export (`exportJobToPDF`) and the preview export (`exportJobPreviewToPDF`).

### Steps for Testing

Prerequisites:

- Have at least one job with a 1-year contract and one with a longer contract.

Test 1 — job detail (1-year contract):

1. Open the job detail page of the 1-year job in English. The overview reads "Contract Duration: 1 year".
2. Switch the UI to German. It reads "Vertragsdauer: 1 Jahr".

Test 2 — job detail (multi-year contract):

1. Open a job with e.g. 3 years contract duration.
2. The page reads "3 years" / "3 Jahre".

Test 3 — job overview cards:

1. On the public job overview list / professor "My Positions" view, the badge of the 1-year job reads "1 year" / "1 Jahr"; multi-year jobs read "3 years" / "3 Jahre".

Test 4 — PDF export (1-year contract):

1. Export the 1-year job as PDF in English. The Position Overview reads "Contract Duration: 1 year".
2. Switch the UI to German and export again. It reads "Vertragsdauer: 1 Jahr".

Test 5 — PDF export (multi-year contract):

1. Export a job with e.g. 3 years contract duration. The PDF reads "3 years" / "3 Jahre".

Test 6 — Preview PDF (job creation/edit form):

1. In job creation, fill in 1 year and click Download PDF in preview mode. PDF reads singular.
2. Change to 3 years and re-export. PDF reads plural.

Automated:

- `npx vitest run src/test/webapp/app/job/job-detail/ src/test/webapp/app/job/job-overview/job-card/` — 71 tests pass.
- `./gradlew test --tests 'de.tum.cit.aet.core.web.rest.PDFExportResourceTest'` — passes; the test labels map now includes the new `year` key.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — job detail page, 1-year, EN + DE
- [ ] Test 2 — job detail page, multi-year, EN + DE
- [ ] Test 3 — job overview cards, 1-year + multi-year
- [ ] Test 4 — PDF export, 1-year, EN + DE
- [ ] Test 5 — PDF export, multi-year, EN + DE
- [ ] Test 6 — preview PDF on job creation