### PR TITLE
`Bugfix`: Use comma in German contract duration tooltip example

### DIFF
--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -128,7 +128,7 @@
       "contractDuration": {
         "label": "Vertragslaufzeit",
         "placeholder": "z.B. 3 Jahre",
-        "toolTipText": "Gib die Dauer des Vertrags für die Doktorandenstelle in Jahren an (z.B. 1.5). Du kannst bis zu 6 Jahre eingeben."
+        "toolTipText": "Gib die Dauer des Vertrags für die Doktorandenstelle in Jahren an (z.B. 1,5). Du kannst bis zu 6 Jahre eingeben."
       },
       "fundingType": {
         "label": "Finanzierungsart",


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: this is a single-character translation change in `de/job.json`; no source code is touched.

### Motivation and Context

Closes #2419.

QA noticed that on the German Job creation form, the Contract Duration tooltip says "(z.B. 1.5)" with a dot, but the locale-aware number input only accepts the comma form "1,5". Tooltip and input format should agree.

### Description

Changed `jobCreationForm.basicInformationSection.contractDuration.toolTipText` in `i18n/de/job.json` from `(z.B. 1.5)` to `(z.B. 1,5)`. The English tooltip already uses `(e.g. 1.5)` correctly for the English convention and is unchanged.

### Steps for Testing

Prerequisites:

1. Log in as a professor with rights to create jobs.

Test 1 — German tooltip uses comma:

1. Switch the UI to **DE**.
2. Open the Job creation form and hover the info icon next to **Vertragslaufzeit**.
3. The tooltip reads "… (z.B. **1,5**). Du kannst bis zu 6 Jahre eingeben."
4. Type `1,5` into the field — accepted; the value is parsed as 1.5 years.

Test 2 — English tooltip unchanged:

1. Switch the UI to **EN**.
2. The tooltip on the same field still reads "… (e.g. **1.5**). You can enter up to 6 years." (no regression).

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — German tooltip + input use comma
- [ ] Test 2 — English tooltip + input use dot, unchanged