### PR TITLE
`Bugfix`: Translate localized enums in PDF export for any German locale tag

### DIFF
--- a/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
+++ b/src/main/java/de/tum/cit/aet/core/service/PDFExportService.java
@@ -607,8 +607,9 @@ public class PDFExportService {
      * @return the selected job description for export or a "-" if none is available
      */
     private String selectJobDescriptionForLang(String englishDesc, String germanDesc, String lang) {
-        String primary = "de".equalsIgnoreCase(lang) ? germanDesc : englishDesc;
-        String secondary = "de".equalsIgnoreCase(lang) ? englishDesc : germanDesc;
+        boolean isGerman = lang != null && lang.toLowerCase(Locale.ROOT).startsWith("de");
+        String primary = isGerman ? germanDesc : englishDesc;
+        String secondary = isGerman ? englishDesc : germanDesc;
 
         if (primary != null && !primary.trim().isEmpty()) {
             return primary;

--- a/src/main/java/de/tum/cit/aet/job/constants/LocalizedEnum.java
+++ b/src/main/java/de/tum/cit/aet/job/constants/LocalizedEnum.java
@@ -1,11 +1,16 @@
 package de.tum.cit.aet.job.constants;
 
+import java.util.Locale;
+
 public interface LocalizedEnum {
     String getEnglishValue();
 
     String getGermanValue();
 
     default String correctLanguageValue(String lang) {
-        return "de".equalsIgnoreCase(lang) ? getGermanValue() : getEnglishValue();
+        if (lang == null) {
+            return getEnglishValue();
+        }
+        return lang.toLowerCase(Locale.ROOT).startsWith("de") ? getGermanValue() : getEnglishValue();
     }
 }

--- a/src/test/java/de/tum/cit/aet/job/constants/LocalizedEnumTest.java
+++ b/src/test/java/de/tum/cit/aet/job/constants/LocalizedEnumTest.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.job.constants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LocalizedEnumTest {
+
+    @Test
+    void shouldReturnGermanWhenLangIsDe() {
+        assertThat(SubjectArea.COMPUTER_SCIENCE.correctLanguageValue("de")).isEqualTo("Informatik");
+        assertThat(FundingType.RESEARCH_GRANT.correctLanguageValue("de")).isEqualTo("Forschungsstipendium");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "DE", "De", "dE", "de-DE", "de-AT", "de_DE" })
+    void shouldReturnGermanWhenLangStartsWithDeIgnoringCase(String lang) {
+        assertThat(SubjectArea.COMPUTER_SCIENCE.correctLanguageValue(lang)).isEqualTo("Informatik");
+        assertThat(FundingType.RESEARCH_GRANT.correctLanguageValue(lang)).isEqualTo("Forschungsstipendium");
+    }
+
+    @Test
+    void shouldReturnEnglishWhenLangIsEn() {
+        assertThat(SubjectArea.COMPUTER_SCIENCE.correctLanguageValue("en")).isEqualTo("Computer Science");
+        assertThat(FundingType.RESEARCH_GRANT.correctLanguageValue("en")).isEqualTo("Research Grant");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "en-US", "fr", "" })
+    void shouldFallBackToEnglishWhenLangIsNotGerman(String lang) {
+        assertThat(SubjectArea.COMPUTER_SCIENCE.correctLanguageValue(lang)).isEqualTo("Computer Science");
+        assertThat(FundingType.RESEARCH_GRANT.correctLanguageValue(lang)).isEqualTo("Research Grant");
+    }
+
+    @Test
+    void shouldFallBackToEnglishWhenLangIsNull() {
+        assertThat(SubjectArea.COMPUTER_SCIENCE.correctLanguageValue(null)).isEqualTo("Computer Science");
+        assertThat(FundingType.RESEARCH_GRANT.correctLanguageValue(null)).isEqualTo("Research Grant");
+    }
+}


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://ls1intum.github.io/tum-apply/developer/server-guidelines/database-and-performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/server-guidelines/server-development).
- [x] I added multiple server tests (JUnit) related to the features (with a high test coverage), while following the [server test guidelines](https://ls1intum.github.io/tum-apply/developer/server-guidelines/server-tests).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Closes #2421.

QA reported that on a German PDF export the labels are German but two values stay in English: *Field of Studies* (e.g. "Computer Science" instead of "Informatik") and *Funding Type* (e.g. "Research Grant" instead of "Forschungsstipendium").

### Description

`LocalizedEnum.correctLanguageValue` and `PDFExportService.selectJobDescriptionForLang` both required an exact `"de"` (or `"DE"`) match for the lang parameter. In practice the client sends `translate.getCurrentLang()`, which can be a locale-tagged value (e.g. `"de-DE"`, `"de-AT"`) or `undefined` (key stripped by JSON.stringify, server defaults to `"en"`). Any of these silently fell back to the English value on the enum, while the rest of the page rendered as German.

This PR makes both checks lenient: any lang that starts with `"de"` after lowercasing selects the German value; `null` still defaults to English.

Added `LocalizedEnumTest` to lock in the new contract:

- `de`, `DE`, `de-DE`, `de-AT`, `de_DE` → German
- `en`, `en-US`, `fr`, `""`, `null` → English

The existing `PDFExportResourceTest.exportJobToPDFLanguageSelection` parameterized test still passes (its existing `"en"` / `"de"` / `null` cases are unchanged).

### Steps for Testing

Prerequisites:

1. Run the server locally.
2. Have a job with `subjectArea = COMPUTER_SCIENCE` and `fundingType = RESEARCH_GRANT` (the seed data already does).

Test 1 — German UI exports a German PDF:

1. Switch the UI to **DE**.
2. Open the job and click **PDF herunterladen**.
3. The PDF Position Overview reads "Studienrichtung: **Informatik**" and "Finanzierungsart: **Forschungsstipendium**".

Test 2 — English UI exports an English PDF (no regression):

1. Switch the UI to **EN**.
2. Same export.
3. Reads "Subject Area: Computer Science" and "Funding Type: Research Grant".

Test 3 — locale-tagged lang still resolves correctly:

1. From a Postman or curl, hit `/api/export/job/{id}/pdf` with `{"lang": "de-DE", ...}` in the body.
2. The PDF renders the German enum values.

Automated:

- `./gradlew test --tests 'de.tum.cit.aet.job.constants.LocalizedEnumTest'` — 5 new tests pass (covers all the lang variants).
- `./gradlew test --tests 'de.tum.cit.aet.core.web.rest.PDFExportResourceTest'` — existing PDF tests pass.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — German PDF shows Informatik / Forschungsstipendium
- [ ] Test 2 — English PDF unchanged
- [ ] Test 3 — locale-tagged `de-DE` lang resolves to German