### PR TITLE
`Bugfix`: Append datepicker overlay to body so it isn't clipped on small viewports

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.html
+++ b/src/main/webapp/app/shared/components/atoms/datepicker/datepicker.component.html
@@ -40,6 +40,7 @@
     inputId="startDate"
     showIcon="true"
     [inputStyleClass]="'w-full'"
+    [appendTo]="'body'"
   >
     <ng-template pTemplate="triggericon">
       <fa-icon [icon]="['fas', 'calendar']" class="text-text-on-primary" />


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: this is a one-line template binding. The existing 37 component tests across `jhi-datepicker` and the consuming application page 3 continue to pass.

### Motivation and Context

Closes #2423.

QA reported that on a short or zoomed-in viewport the desired-start-date calendar opens upwards and is hidden behind the page header. Users cannot pick a date in that state.

### Description

`<jhi-datepicker>` wrapped `<p-datepicker>` without an `appendTo` binding, so PrimeNG kept the overlay inside the parent's stacking context. When the input is near the bottom of the viewport, PrimeNG auto-flips the overlay upward, and any ancestor with its own stacking context (the sticky page header / `overflow: hidden` containers) clips it.

Added `[appendTo]=\"'body'\"` so the overlay is rendered as a direct child of `document.body`. This is the same workaround already used for the AI assistant card overlay in this repo.

### Steps for Testing

Prerequisites:

1. Log in as an applicant on a fresh application.

Test 1 — small / zoomed viewport:

1. Resize the window to a short height (or browser zoom to ~150%).
2. Navigate to **Application Details** (page 3).
3. Click the **Desired Start Date** field.
4. The calendar should now render fully visible above the header (previously: clipped).

Test 2 — normal viewport (no regression):

1. Reset zoom to 100% on a desktop window.
2. Open the same field. The calendar opens downward / upward as before, no visual changes apart from being on the body layer.
3. Picking a date still updates the form value normally.

Automated:

- `npx vitest run src/test/webapp/app/shared/components/atoms/datepicker/ src/test/webapp/app/application/application-creation/application-creation-page3/` — all 37 tests pass.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — calendar visible on short / zoomed viewport
- [ ] Test 2 — calendar still works on normal viewport (no regression)