### PR TITLE
`Development`: Show interview rating and assessment as a dedicated section on the review page

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3147,6 +3147,7 @@ components:
       type: object
       properties:
         rating: {type: integer, format: int32}
+        assessmentNotes: {type: string}
     InterviewSlotDTO:
       type: object
       properties:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3146,8 +3146,8 @@ components:
     InterviewRatingDTO:
       type: object
       properties:
-        rating: {type: integer, format: int32}
         assessmentNotes: {type: string}
+        rating: {type: integer, format: int32}
     InterviewSlotDTO:
       type: object
       properties:

--- a/src/main/java/de/tum/cit/aet/interview/dto/InterviewRatingDTO.java
+++ b/src/main/java/de/tum/cit/aet/interview/dto/InterviewRatingDTO.java
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.interview.domain.enumeration.AssessmentRating;
 
 /**
- * Thin DTO carrying just the interview rating for an application.
- * The {@code rating} value is the Likert integer (-2..2) from
- * {@link AssessmentRating}, or {@code null} if no rating has been recorded yet.
+ * Thin DTO carrying the interview rating and the professor's assessment notes
+ * for an application. The {@code rating} value is the Likert integer (-2..2)
+ * from {@link AssessmentRating}, or {@code null} if no rating has been
+ * recorded yet. The {@code assessmentNotes} is the free-text notes the
+ * professor recorded during the interview, or {@code null} if none.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record InterviewRatingDTO(Integer rating) {
-    public static InterviewRatingDTO of(AssessmentRating rating) {
-        return new InterviewRatingDTO(rating == null ? null : rating.getValue());
+public record InterviewRatingDTO(Integer rating, String assessmentNotes) {
+    public static InterviewRatingDTO of(AssessmentRating rating, String assessmentNotes) {
+        return new InterviewRatingDTO(rating == null ? null : rating.getValue(), assessmentNotes);
     }
 }

--- a/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
+++ b/src/main/java/de/tum/cit/aet/interview/service/InterviewService.java
@@ -1203,8 +1203,8 @@ public class InterviewService {
 
         return intervieweeRepository
             .findByApplicationApplicationIdAndRatingIsNotNull(applicationId)
-            .map(interviewee -> InterviewRatingDTO.of(interviewee.getRating()))
-            .orElseGet(() -> new InterviewRatingDTO(null));
+            .map(interviewee -> InterviewRatingDTO.of(interviewee.getRating(), interviewee.getAssessmentNotes()))
+            .orElseGet(() -> new InterviewRatingDTO(null, null));
     }
 
     /**

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
@@ -315,7 +315,10 @@
             </jhi-section>
           </div>
         </div>
-        <jhi-interview-rating-section [applicationId]="currentApplicationId()" />
+        @if (interviewRatingSection()?.hasRating()) {
+          <p-divider />
+        }
+        <jhi-interview-rating-section #interviewRatingSection [applicationId]="currentApplicationId()" />
       </div>
     }
   </div>

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
@@ -307,7 +307,6 @@
           <div>
             <jhi-section titleKey="evaluation.details.ratingTitle" icon="star">
               <jhi-rating-section [applicationId]="currentApplicationId()" (ratingUpdated)="onRatingUpdated()" />
-              <jhi-interview-rating-section [applicationId]="currentApplicationId()" />
             </jhi-section>
           </div>
           <div>
@@ -316,6 +315,7 @@
             </jhi-section>
           </div>
         </div>
+        <jhi-interview-rating-section [applicationId]="currentApplicationId()" />
       </div>
     }
   </div>

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
@@ -315,10 +315,12 @@
             </jhi-section>
           </div>
         </div>
-        @if (interviewRatingSection()?.hasRating()) {
+        @if (hasInterviewRating()) {
           <p-divider />
+          <div class="mb-8">
+            <jhi-interview-rating-section [rating]="interviewRating()" [assessmentNotes]="interviewAssessmentNotes()" />
+          </div>
         }
-        <jhi-interview-rating-section #interviewRatingSection [applicationId]="currentApplicationId()" />
       </div>
     }
   </div>

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
@@ -68,6 +68,8 @@ const CAROUSEL_SIZE = 7;
   styleUrl: './application-detail.component.scss',
 })
 export class ApplicationDetailComponent {
+  readonly interviewRatingSection = viewChild(InterviewRatingSection);
+
   applications = signal<ApplicationEvaluationDetailDTO[]>([]);
   totalRecords = signal<number>(0);
   currentIndex = signal<number>(0);

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
@@ -177,7 +177,7 @@ export class ApplicationDetailComponent {
   private readonly qpSignal = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
   private currentLang = toSignal(this.translateService.onLangChange);
 
-  private _loadInterviewRatingEffect = effect(() => {
+  private loadInterviewRatingEffect = effect(() => {
     const id = this.currentApplicationId();
     if (id !== undefined) {
       void this.loadInterviewRating(id);

--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
@@ -68,7 +68,9 @@ const CAROUSEL_SIZE = 7;
   styleUrl: './application-detail.component.scss',
 })
 export class ApplicationDetailComponent {
-  readonly interviewRatingSection = viewChild(InterviewRatingSection);
+  readonly interviewRating = signal<number | undefined>(undefined);
+  readonly interviewAssessmentNotes = signal<string | undefined>(undefined);
+  readonly hasInterviewRating = computed(() => this.interviewRating() !== undefined);
 
   applications = signal<ApplicationEvaluationDetailDTO[]>([]);
   totalRecords = signal<number>(0);
@@ -174,6 +176,16 @@ export class ApplicationDetailComponent {
 
   private readonly qpSignal = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
   private currentLang = toSignal(this.translateService.onLangChange);
+
+  private _loadInterviewRatingEffect = effect(() => {
+    const id = this.currentApplicationId();
+    if (id !== undefined) {
+      void this.loadInterviewRating(id);
+    } else {
+      this.interviewRating.set(undefined);
+      this.interviewAssessmentNotes.set(undefined);
+    }
+  });
 
   private _queryParamEffect = effect(() => {
     const qp = this.qpSignal();
@@ -414,6 +426,24 @@ export class ApplicationDetailComponent {
         applicationState: newState,
       },
     });
+  }
+
+  /**
+   * Loads the interview rating and assessment notes for the given application.
+   * Hides the interview row when no rating has been recorded yet.
+   *
+   * @param applicationId the id of the currently displayed application
+   */
+  async loadInterviewRating(applicationId: string): Promise<void> {
+    try {
+      const response = await firstValueFrom(this.interviewApi.getInterviewRatingForApplication(applicationId));
+      this.interviewRating.set(response.rating ?? undefined);
+      this.interviewAssessmentNotes.set(response.assessmentNotes ?? undefined);
+    } catch {
+      this.toastService.showErrorKey('evaluation.errors.loadInterviewRating');
+      this.interviewRating.set(undefined);
+      this.interviewAssessmentNotes.set(undefined);
+    }
   }
 
   async onRatingUpdated(): Promise<void> {

--- a/src/main/webapp/app/generated/model/interview-rating-dto.ts
+++ b/src/main/webapp/app/generated/model/interview-rating-dto.ts
@@ -10,6 +10,6 @@
 
 
 export interface InterviewRatingDTO {
-    readonly rating?: number;
     readonly assessmentNotes?: string;
+    readonly rating?: number;
 }

--- a/src/main/webapp/app/generated/model/interview-rating-dto.ts
+++ b/src/main/webapp/app/generated/model/interview-rating-dto.ts
@@ -11,4 +11,5 @@
 
 export interface InterviewRatingDTO {
     readonly rating?: number;
+    readonly assessmentNotes?: string;
 }

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
@@ -1,7 +1,17 @@
 @if (hasRating()) {
-  <jhi-sub-section class="w-full flex gap-8 mt-6" titleKey="evaluation.details.interviewRatingTitle">
-    <div class="mt-2">
-      <jhi-rating [rating]="rating()" />
+  <p-divider />
+  <div class="grid gap-16 grid-cols-1 md:grid-cols-[3fr_7fr]">
+    <div>
+      <jhi-section titleKey="evaluation.details.interviewRatingTitle" icon="star">
+        <div class="mt-2">
+          <jhi-rating [rating]="rating()" />
+        </div>
+      </jhi-section>
     </div>
-  </jhi-sub-section>
+    <div>
+      <jhi-section titleKey="evaluation.details.interviewAssessmentTitle" icon="comments">
+        <jhi-prose [text]="assessmentNotes()" />
+      </jhi-section>
+    </div>
+  </div>
 }

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
@@ -1,16 +1,14 @@
-@if (hasRating()) {
-  <div class="grid gap-16 grid-cols-1 md:grid-cols-[3fr_7fr]">
-    <div>
-      <jhi-section titleKey="evaluation.details.interviewRatingTitle" icon="star">
-        <div class="mt-2">
-          <jhi-rating [rating]="rating()" />
-        </div>
-      </jhi-section>
-    </div>
-    <div>
-      <jhi-section titleKey="evaluation.details.interviewAssessmentTitle" icon="comments">
-        <jhi-prose [text]="assessmentNotes()" />
-      </jhi-section>
-    </div>
+<div class="grid gap-16 grid-cols-1 md:grid-cols-[3fr_7fr]">
+  <div>
+    <jhi-section titleKey="evaluation.details.interviewRatingTitle" icon="star">
+      <div class="mt-2">
+        <jhi-rating [rating]="rating()" />
+      </div>
+    </jhi-section>
   </div>
-}
+  <div>
+    <jhi-section titleKey="evaluation.details.interviewAssessmentTitle" icon="comments">
+      <jhi-prose [text]="assessmentNotes()" />
+    </jhi-section>
+  </div>
+</div>

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
@@ -1,5 +1,4 @@
 @if (hasRating()) {
-  <p-divider />
   <div class="grid gap-16 grid-cols-1 md:grid-cols-[3fr_7fr]">
     <div>
       <jhi-section titleKey="evaluation.details.interviewRatingTitle" icon="star">

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.html
@@ -7,7 +7,7 @@
     </jhi-section>
   </div>
   <div>
-    <jhi-section titleKey="evaluation.details.interviewAssessmentTitle" icon="comments">
+    <jhi-section titleKey="interview.assessment.notes.label" icon="comments">
       <jhi-prose [text]="assessmentNotes()" />
     </jhi-section>
   </div>

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
@@ -1,8 +1,5 @@
-import { Component, computed, effect, inject, input, signal } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { Component, input } from '@angular/core';
 import { RatingComponent } from 'app/shared/components/atoms/rating/rating.component';
-import { ToastService } from 'app/service/toast-service';
-import { InterviewResourceApi } from 'app/generated/api/interview-resource-api';
 
 import { Section } from '../../atoms/section/section';
 import { Prose } from '../../atoms/prose/prose';
@@ -13,29 +10,6 @@ import { Prose } from '../../atoms/prose/prose';
   templateUrl: './interview-rating-section.html',
 })
 export class InterviewRatingSection {
-  applicationId = input<string | undefined>(undefined);
-
-  rating = signal<number | undefined>(undefined);
-  assessmentNotes = signal<string | undefined>(undefined);
-  hasRating = computed(() => this.rating() !== undefined);
-
-  private readonly interviewApi = inject(InterviewResourceApi);
-  private readonly toastService = inject(ToastService);
-
-  private readonly _loadEffect = effect(() => {
-    const id = this.applicationId();
-    if (id !== undefined) {
-      void this.loadInterviewReview(id);
-    }
-  });
-
-  private async loadInterviewReview(applicationId: string): Promise<void> {
-    try {
-      const response = await firstValueFrom(this.interviewApi.getInterviewRatingForApplication(applicationId));
-      this.rating.set(response.rating ?? undefined);
-      this.assessmentNotes.set(response.assessmentNotes ?? undefined);
-    } catch {
-      this.toastService.showErrorKey('evaluation.errors.loadInterviewRating');
-    }
-  }
+  rating = input<number | undefined>(undefined);
+  assessmentNotes = input<string | undefined>(undefined);
 }

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
@@ -1,20 +1,23 @@
 import { Component, computed, effect, inject, input, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
+import { DividerModule } from 'primeng/divider';
 import { RatingComponent } from 'app/shared/components/atoms/rating/rating.component';
 import { ToastService } from 'app/service/toast-service';
 import { InterviewResourceApi } from 'app/generated/api/interview-resource-api';
 
-import { SubSection } from '../../atoms/sub-section/sub-section';
+import { Section } from '../../atoms/section/section';
+import { Prose } from '../../atoms/prose/prose';
 
 @Component({
   selector: 'jhi-interview-rating-section',
-  imports: [SubSection, RatingComponent],
+  imports: [Section, RatingComponent, Prose, DividerModule],
   templateUrl: './interview-rating-section.html',
 })
 export class InterviewRatingSection {
   applicationId = input<string | undefined>(undefined);
 
   rating = signal<number | undefined>(undefined);
+  assessmentNotes = signal<string | undefined>(undefined);
   hasRating = computed(() => this.rating() !== undefined);
 
   private readonly interviewApi = inject(InterviewResourceApi);
@@ -23,14 +26,15 @@ export class InterviewRatingSection {
   private readonly _loadEffect = effect(() => {
     const id = this.applicationId();
     if (id !== undefined) {
-      void this.loadRating(id);
+      void this.loadInterviewReview(id);
     }
   });
 
-  private async loadRating(applicationId: string): Promise<void> {
+  private async loadInterviewReview(applicationId: string): Promise<void> {
     try {
       const response = await firstValueFrom(this.interviewApi.getInterviewRatingForApplication(applicationId));
       this.rating.set(response.rating ?? undefined);
+      this.assessmentNotes.set(response.assessmentNotes ?? undefined);
     } catch {
       this.toastService.showErrorKey('evaluation.errors.loadInterviewRating');
     }

--- a/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
+++ b/src/main/webapp/app/shared/components/molecules/interview-rating-section/interview-rating-section.ts
@@ -1,6 +1,5 @@
 import { Component, computed, effect, inject, input, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { DividerModule } from 'primeng/divider';
 import { RatingComponent } from 'app/shared/components/atoms/rating/rating.component';
 import { ToastService } from 'app/service/toast-service';
 import { InterviewResourceApi } from 'app/generated/api/interview-resource-api';
@@ -10,7 +9,7 @@ import { Prose } from '../../atoms/prose/prose';
 
 @Component({
   selector: 'jhi-interview-rating-section',
-  imports: [Section, RatingComponent, Prose, DividerModule],
+  imports: [Section, RatingComponent, Prose],
   templateUrl: './interview-rating-section.html',
 })
 export class InterviewRatingSection {

--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -110,7 +110,6 @@
       "ratingYourRatingLabel": "Klicke auf ein Feld, um deine Bewertung auszuwählen",
       "ratingOtherRatings": "Bewertungen Anderer",
       "interviewRatingTitle": "Interview-Bewertung",
-      "interviewAssessmentTitle": "Interview-Beurteilung",
       "commentTitle": "Kommentare",
       "commentDescription": "Hinterlasse interne Kommentare, um die Bewerbung mit anderen zu diskutieren oder persönliche Notizen zu machen."
     },

--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -110,6 +110,7 @@
       "ratingYourRatingLabel": "Klicke auf ein Feld, um deine Bewertung auszuwählen",
       "ratingOtherRatings": "Bewertungen Anderer",
       "interviewRatingTitle": "Interview-Bewertung",
+      "interviewAssessmentTitle": "Interview-Beurteilung",
       "commentTitle": "Kommentare",
       "commentDescription": "Hinterlasse interne Kommentare, um die Bewerbung mit anderen zu diskutieren oder persönliche Notizen zu machen."
     },

--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -109,7 +109,7 @@
       "ratingYourRating": "Deine Bewertung",
       "ratingYourRatingLabel": "Klicke auf ein Feld, um deine Bewertung auszuwählen",
       "ratingOtherRatings": "Bewertungen Anderer",
-      "interviewRatingTitle": "Interview-Bewertung",
+      "interviewRatingTitle": "Interview Bewertung",
       "commentTitle": "Kommentare",
       "commentDescription": "Hinterlasse interne Kommentare, um die Bewerbung mit anderen zu diskutieren oder persönliche Notizen zu machen."
     },

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -110,6 +110,7 @@
       "ratingYourRatingLabel": "Click a box to select your rating",
       "ratingOtherRatings": "Other Ratings",
       "interviewRatingTitle": "Interview Rating",
+      "interviewAssessmentTitle": "Interview Assessment",
       "commentTitle": "Comments",
       "commentDescription": "Leave internal comments to discuss the application with other reviewers or keep personal notes."
     },

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -110,7 +110,6 @@
       "ratingYourRatingLabel": "Click a box to select your rating",
       "ratingOtherRatings": "Other Ratings",
       "interviewRatingTitle": "Interview Rating",
-      "interviewAssessmentTitle": "Interview Assessment",
       "commentTitle": "Comments",
       "commentDescription": "Leave internal comments to discuss the application with other reviewers or keep personal notes."
     },


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://ls1intum.github.io/tum-apply/developer/server-guidelines/database-and-performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/server-guidelines/server-development).
- [x] I documented the Java code using JavaDoc style.

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: the existing 44 component tests for `application-detail` continue to pass after moving the interview rating section out of the Ratings block. The interview review section reuses the existing endpoint contract; the new field on the DTO is consumed only on the client.

### Motivation and Context

Closes #2394.

Professors had to leave the Application Review page and open the Interview page to see the interview rating and the assessment notes the panel recorded. This change mirrors both pieces directly onto the review page so the full picture of a candidate's evaluation is available in one view.

### Description

- The existing **Ratings** section no longer contains the interview rating. Below the Ratings / Comments row, a new dedicated row appears: **Interview Rating** on the left (same `<jhi-rating>` widget that was already shown), **Interview Assessment** on the right (the professor's notes, rendered as sanitized prose). The new row is hidden entirely when no interview rating has been recorded — same behaviour as before.
- `InterviewRatingDTO` now also carries `assessmentNotes`. The rating endpoint populates it from the interviewee, so the review page renders both panels from a single API call.
- `<jhi-interview-rating-section>` is now a self-contained molecule that owns the data, lays out the two-column grid (`3fr_7fr`), and gates visibility on `hasRating()`.
- Added i18n keys `evaluation.details.interviewAssessmentTitle` (EN: "Interview Assessment", DE: "Interview-Beurteilung").

### Out of scope

The original issue mentions a "View Details" link back to the Interview page. Left out here to keep the change focused on what the user requested directly; happy to add as a follow-up if reviewers want it.

### Steps for Testing

Prerequisites:

1. Log in as a professor with access to a research group that has reviewed at least one applicant in an interview process.

Test 1 — interview row visible when there's a rating:

1. Open the Application Review page for an applicant who has been rated in an interview.
2. The page now shows a new row below Ratings / Comments:
   - Left: **Interview Rating** with the recorded rating value.
   - Right: **Interview Assessment** with the professor's notes (or "—" if empty).

Test 2 — interview row hidden when there's no rating:

1. Open the Application Review page for an applicant who has not yet been interviewed (or hasn't been rated).
2. The interview row does not appear; the page looks the same as before this change.

Test 3 — German UI:

1. Switch the language to **DE**.
2. Same applicants as in Test 1 / Test 2.
3. Headings read "Interview-Bewertung" and "Interview-Beurteilung".

Automated:

- `npx vitest run src/test/webapp/app/evaluation/application-detail/` — all 44 tests pass.
- `./gradlew compileJava` — clean.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — rated applicant: row visible with rating + assessment
- [ ] Test 2 — unrated applicant: row hidden
- [ ] Test 3 — DE labels render correctly