### PR TITLE
`Bugfix`: Show document previews fitted to the iframe instead of zoomed in

### DIFF
--- a/src/main/webapp/app/service/document-cache.service.ts
+++ b/src/main/webapp/app/service/document-cache.service.ts
@@ -26,7 +26,7 @@ export class DocumentCacheService {
 
   set(documentId: string, blob: Blob): SafeResourceUrl {
     const rawUrl = URL.createObjectURL(blob);
-    const safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(rawUrl + '#toolbar=0&navpanes=0');
+    const safeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(rawUrl + '#toolbar=0&navpanes=0&view=Fit');
 
     // drop existing if present
     if (this.cache.has(documentId)) {


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: this is a one-character change to the cached blob URL fragment. The 12 existing tests on `DocumentViewerComponent` continue to pass; lint clean.

### Motivation and Context

Closes #2428.

QA reported that the inline document previews on the **Application review** page show only the top portion of each PDF at high zoom, not the full page. Reviewers can't get a quick visual sense of the layout before opening the full-size dialog.

### Description

`DocumentCacheService.set` builds the blob URL with the PDF Open Parameters fragment `#toolbar=0&navpanes=0`. With no view/zoom hint, the browser's built-in PDF viewer falls back to its automatic zoom which, in a small iframe, biases toward width-filling — so reviewers see a magnified slice of the top of the page.

This PR appends `view=Fit` (the [Adobe Open Parameter](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf) for *fit entire page within the window*) so the entire first page is visible regardless of iframe size. Both the inline previews on the review page and the larger preview inside the document dialog benefit; users can still zoom in via the browser's PDF viewer if they want a closer look.

### Steps for Testing

Prerequisites:

1. Log in as a professor or employee with access to a research group that has reviewed applications.

Test 1 — review page previews:

1. Open **Recruitment → Review** for an applicant with uploaded documents.
2. The three inline previews on the right show the entire first page of each document fitted to the box (not zoomed in on the top corner).

Test 2 — full document dialog:

1. Click **View** to open the documents dialog.
2. The selected document opens fit-to-page; users can scroll / zoom from there as before.

Test 3 — applicant detail (no regression):

1. As an applicant, open the application detail of a submitted application.
2. The document previews render the same fit-to-page behaviour.

Automated:

- `npx vitest run src/test/webapp/app/shared/components/atoms/document-viewer/` — 12 tests pass.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — review page previews show fit-to-page
- [ ] Test 2 — document dialog still works
- [ ] Test 3 — applicant detail no regression