### PR TITLE
`Development`: Mark already-applied jobs visually on the overview cards

### DIFF
--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -1,21 +1,13 @@
 <div
-  class="group relative rounded-lg border border-border-default bg-background-default hover:scale-[1.02] hover:bg-background-surface focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
+  class="group rounded-lg border border-border-default bg-background-default hover:scale-[1.02] hover:bg-background-surface focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
   tabindex="0"
   role="button"
   [attr.aria-label]="'jobOverviewPage.ariaLabels.viewJobDetails' | translate: { title: jobTitle() }"
   (click)="onViewDetails()"
   (keydown)="onKeyDown($event)"
 >
-  @if (hasApplied()) {
-    <span
-      class="absolute top-3 right-3 z-10 px-3 py-1 text-xs font-semibold rounded-pill bg-positive-default text-text-on-primary shadow"
-      [pTooltip]="'jobOverviewPage.alreadyAppliedTooltip' | translate"
-      tooltipPosition="top"
-      jhiTranslate="jobOverviewPage.alreadyAppliedBadge"
-    ></span>
-  }
   <div
-    class="h-32 px-4 pb-3 bg-cover bg-center flex flex-shrink-0 items-end"
+    class="h-32 px-4 pt-3 pb-3 bg-cover bg-center flex flex-shrink-0 items-end justify-between"
     [style.background-image]="
       headerImageUrl() ? 'linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url(' + headerImageUrl() + ')' : 'none'
     "
@@ -39,6 +31,12 @@
         </span>
       </div>
     </div>
+    @if (hasApplied()) {
+      <span
+        class="self-start px-3 py-1 text-xs font-semibold rounded-pill bg-positive-default text-text-on-primary shadow"
+        jhiTranslate="jobOverviewPage.alreadyAppliedBadge"
+      ></span>
+    }
   </div>
 
   <!-- Content section -->

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -7,13 +7,18 @@
   (keydown)="onKeyDown($event)"
 >
   <div
-    class="h-32 px-4 py-3 bg-cover bg-center flex flex-shrink-0 items-end justify-between"
+    class="h-32 px-4 py-3 bg-cover bg-center flex flex-shrink-0 flex-col"
     [style.background-image]="
       headerImageUrl() ? 'linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url(' + headerImageUrl() + ')' : 'none'
     "
     [style.background-color]="headerImageUrl() ? 'transparent' : 'var(--p-secondary-color)'"
   >
-    <div class="-ml-2 translate-y-[1.6rem]">
+    @if (hasApplied()) {
+      <div class="flex justify-end">
+        <jhi-tag [text]="'jobOverviewPage.alreadyAppliedBadge' | translate" color="success" />
+      </div>
+    }
+    <div class="-ml-2 mt-auto translate-y-[1.6rem]">
       <div class="grid h-10 w-[15rem]">
         <div
           class="col-start-1 row-start-1 z-1 self-center"
@@ -31,12 +36,6 @@
         </span>
       </div>
     </div>
-    @if (hasApplied()) {
-      <span
-        class="self-start px-3 py-1 text-xs font-semibold rounded-pill bg-positive-default text-text-on-primary shadow"
-        jhiTranslate="jobOverviewPage.alreadyAppliedBadge"
-      ></span>
-    }
   </div>
 
   <!-- Content section -->

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -1,11 +1,23 @@
 <div
-  class="group rounded-lg border border-border-default bg-background-default hover:scale-[1.02] hover:bg-background-surface focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
+  class="group relative rounded-lg border border-border-default bg-background-default focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
+  [class.opacity-60]="hasApplied()"
+  [class.hover:scale-[1.02]]="!hasApplied()"
+  [class.hover:bg-background-surface]="!hasApplied()"
+  [class.hover:opacity-100]="hasApplied()"
   tabindex="0"
   role="button"
   [attr.aria-label]="'jobOverviewPage.ariaLabels.viewJobDetails' | translate: { title: jobTitle() }"
   (click)="onViewDetails()"
   (keydown)="onKeyDown($event)"
 >
+  @if (hasApplied()) {
+    <span
+      class="absolute top-3 right-3 z-10 px-3 py-1 text-xs font-semibold rounded-pill bg-positive-default text-text-on-primary shadow"
+      [pTooltip]="'jobOverviewPage.alreadyAppliedTooltip' | translate"
+      tooltipPosition="top"
+      jhiTranslate="jobOverviewPage.alreadyAppliedBadge"
+    ></span>
+  }
   <div
     class="h-32 px-4 pb-3 bg-cover bg-center flex flex-shrink-0 items-end"
     [style.background-image]="

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -1,9 +1,5 @@
 <div
-  class="group relative rounded-lg border border-border-default bg-background-default focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
-  [class.opacity-60]="hasApplied()"
-  [class.hover:scale-[1.02]]="!hasApplied()"
-  [class.hover:bg-background-surface]="!hasApplied()"
-  [class.hover:opacity-100]="hasApplied()"
+  class="group relative rounded-lg border border-border-default bg-background-default hover:scale-[1.02] hover:bg-background-surface focus-within:ring-2 focus-within:ring-primary focus-within:outline-none transition-all duration-200 overflow-hidden cursor-pointer w-full h-full max-h-[26rem] flex flex-col"
   tabindex="0"
   role="button"
   [attr.aria-label]="'jobOverviewPage.ariaLabels.viewJobDetails' | translate: { title: jobTitle() }"

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.html
@@ -7,7 +7,7 @@
   (keydown)="onKeyDown($event)"
 >
   <div
-    class="h-32 px-4 pt-3 pb-3 bg-cover bg-center flex flex-shrink-0 items-end justify-between"
+    class="h-32 px-4 py-3 bg-cover bg-center flex flex-shrink-0 items-end justify-between"
     [style.background-image]="
       headerImageUrl() ? 'linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)), url(' + headerImageUrl() + ')' : 'none'
     "

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.ts
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.ts
@@ -70,6 +70,15 @@ export class JobCardComponent {
     return duration;
   });
 
+  /**
+   * True when the applicant has already submitted an application for this job.
+   * Drafts (`SAVED`) are excluded so the user can still come back to a draft.
+   */
+  readonly hasApplied = computed(() => {
+    const state = this.applicationState();
+    return state !== ApplicationStatusExtended.NotYetApplied && state !== JobCardDTOApplicationStateEnum.Saved;
+  });
+
   private router = inject(Router);
 
   onViewDetails(): void {

--- a/src/main/webapp/app/job/job-overview/job-card/job-card.component.ts
+++ b/src/main/webapp/app/job/job-overview/job-card/job-card.component.ts
@@ -9,6 +9,7 @@ import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import LocalizedDatePipe from 'app/shared/pipes/localized-date.pipe';
 import { TranslateDirective } from 'app/shared/language';
 import { UserAvatarComponent } from 'app/shared/components/atoms/user-avatar/user-avatar.component';
+import { TagComponent } from 'app/shared/components/atoms/tag/tag.component';
 import { JobCardDTOApplicationStateEnum, JobCardDTOSubjectAreaEnum } from 'app/generated/model/job-card-dto';
 
 import * as DropDownOptions from '../../dropdown-options';
@@ -21,7 +22,16 @@ export const ApplicationStatusExtended = {
 @Component({
   selector: 'jhi-job-card',
   templateUrl: './job-card.component.html',
-  imports: [FontAwesomeModule, CardModule, TooltipModule, TranslateModule, TranslateDirective, LocalizedDatePipe, UserAvatarComponent],
+  imports: [
+    FontAwesomeModule,
+    CardModule,
+    TooltipModule,
+    TranslateModule,
+    TranslateDirective,
+    LocalizedDatePipe,
+    UserAvatarComponent,
+    TagComponent,
+  ],
 })
 export class JobCardComponent {
   jobId = input<string>('');

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -283,6 +283,8 @@
   "jobOverviewPage": {
     "title": "Finde deine passende Stelle",
     "noJobsFound": "Keine Stellen gefunden.",
+    "alreadyAppliedBadge": "Beworben",
+    "alreadyAppliedTooltip": "Du hast dich bereits auf diese Stelle beworben.",
     "searchFilterSortBar": {
       "searchText": "Stellen suchen...",
       "filterOptions": {

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -284,7 +284,6 @@
     "title": "Finde deine passende Stelle",
     "noJobsFound": "Keine Stellen gefunden.",
     "alreadyAppliedBadge": "Beworben",
-    "alreadyAppliedTooltip": "Du hast dich bereits auf diese Stelle beworben.",
     "searchFilterSortBar": {
       "searchText": "Stellen suchen...",
       "filterOptions": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -283,6 +283,8 @@
   "jobOverviewPage": {
     "title": "Find Your Perfect Position",
     "noJobsFound": "No Jobs Found.",
+    "alreadyAppliedBadge": "Applied",
+    "alreadyAppliedTooltip": "You have already applied to this position.",
     "searchFilterSortBar": {
       "searchText": "Search Positions...",
       "filterOptions": {

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -284,7 +284,6 @@
     "title": "Find Your Perfect Position",
     "noJobsFound": "No Jobs Found.",
     "alreadyAppliedBadge": "Applied",
-    "alreadyAppliedTooltip": "You have already applied to this position.",
     "searchFilterSortBar": {
       "searchText": "Search Positions...",
       "filterOptions": {


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

> Note on tests: existing 7 tests on `<jhi-job-card>` still pass. The change is purely visual / a single computed signal — `applicationState` is already an input that the parent list passes down, so no new API plumbing.

### Motivation and Context

Closes #2430.

Re-applying to a job you've already applied to isn't supported, but the overview cards rendered identically whether or not you'd already engaged with each position. Easy to waste time re-reading the same listing.

### Description

`<jhi-job-card>` already receives the applicant's `applicationState` as an input. Added a `hasApplied` computed (`true` for any non-draft application state) and used it on the root template:

- `[class.opacity-60]="hasApplied()"` — dims the whole card.
- Removes `hover:scale-[1.02]` and `hover:bg-background-surface` when applied (so the card doesn't read as inviting a click).
- `hover:opacity-100` on the applied state so the card lights up briefly when hovered, signalling you can still click through to view your application.
- Top-right pill `Applied` / `Beworben` with a tooltip explaining the state.

Drafts (`SAVED`) are excluded so the user can keep finishing them.

New i18n keys (EN + DE):

- `jobOverviewPage.alreadyAppliedBadge` — "Applied" / "Beworben"
- `jobOverviewPage.alreadyAppliedTooltip` — "You have already applied…" / "Du hast dich bereits…"

### Steps for Testing

Prerequisites:

1. Have one applicant account with at least one submitted application and at least one position they haven't applied to.

Test 1 — applied card visual:

1. Log in as the applicant and open the public job overview.
2. The card for the job you've applied to is dimmed and shows an "Applied" pill in the top-right.
3. Hover the card — it lights up to full opacity but doesn't grow.
4. Click — you land on the job detail page as before.

Test 2 — un-applied card unchanged:

1. The other cards render exactly as before: full opacity, hover scale, no badge.

Test 3 — draft applications unchanged:

1. Save (don't submit) an application for another job.
2. Reload the overview — that card is also rendered as normal (you're not done yet).

Test 4 — language switch:

1. Switch UI to German — pill reads "Beworben", tooltip is in German.

Automated:

- `npx vitest run src/test/webapp/app/job/job-overview/job-card/` — 7 tests pass.
- `npx ng build` — clean.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1 — applied card is dimmed + has pill, still navigable
- [ ] Test 2 — un-applied cards unchanged
- [ ] Test 3 — drafts (SAVED) still styled normally
- [ ] Test 4 — DE labels render correctly