### PR TITLE
`Bugfix`: Render FAQ entries as separate cards on landing pages

### DIFF
--- a/src/main/webapp/app/shared/pages/landing-page/faq-section/faq-section.component.html
+++ b/src/main/webapp/app/shared/pages/landing-page/faq-section/faq-section.component.html
@@ -7,12 +7,12 @@
       <fa-icon class="external-icon" size="xs" [icon]="faArrowUpRightFromSquare" />
     </a>
   </div>
-  <p-accordion [value]="0">
+  <p-accordion class="flex flex-col gap-3 w-full max-w-3xl" [value]="0">
     @for (tab of tabs; track tab.value) {
-      <p-accordion-panel [value]="tab.value">
-        <p-accordion-header>{{ tab.title | translate }}</p-accordion-header>
+      <p-accordion-panel class="border border-border-default rounded-xl overflow-hidden" [value]="tab.value">
+        <p-accordion-header class="font-semibold">{{ tab.title | translate }}</p-accordion-header>
         <p-accordion-content>
-          <div [innerHTML]="tab.content | translate"></div>
+          <div class="leading-relaxed" [innerHTML]="tab.content | translate"></div>
         </p-accordion-content>
       </p-accordion-panel>
     }

--- a/src/main/webapp/app/shared/pages/landing-page/faq-section/faq-section.component.html
+++ b/src/main/webapp/app/shared/pages/landing-page/faq-section/faq-section.component.html
@@ -12,7 +12,7 @@
       <p-accordion-panel class="border border-border-default rounded-xl overflow-hidden" [value]="tab.value">
         <p-accordion-header class="font-semibold">{{ tab.title | translate }}</p-accordion-header>
         <p-accordion-content>
-          <div class="leading-relaxed" [innerHTML]="tab.content | translate"></div>
+          <div class="pt-2 leading-relaxed" [innerHTML]="tab.content | translate"></div>
         </p-accordion-content>
       </p-accordion-panel>
     }

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-faq-section/professor-faq-section.component.html
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-faq-section/professor-faq-section.component.html
@@ -7,13 +7,13 @@
       <fa-icon [icon]="faArrowUpRightFromSquare" class="external-icon" size="xs" />
     </a>
   </div>
-  <p-accordion [value]="0">
+  <p-accordion class="flex flex-col gap-3 w-full max-w-3xl" [value]="0">
     @for (tab of tabs; track tab.value) {
       @if (tab.value !== 'registration' || (loggedIn() && isApplicant())) {
-        <p-accordion-panel [value]="tab.value">
-          <p-accordion-header>{{ tab.title | translate }}</p-accordion-header>
+        <p-accordion-panel class="border border-border-default rounded-xl overflow-hidden" [value]="tab.value">
+          <p-accordion-header class="font-semibold">{{ tab.title | translate }}</p-accordion-header>
           <p-accordion-content>
-            <div [innerHTML]="tab.content | translate"></div>
+            <div class="leading-relaxed" [innerHTML]="tab.content | translate"></div>
             <div class="registration-button">
               @if (tab.value === 'registration') {
                 <jhi-button (click)="openRegistrationForm()" [shouldTranslate]="true" [label]="translationKey + '.registration.button'" />

--- a/src/main/webapp/app/shared/pages/professor-landing-page/professor-faq-section/professor-faq-section.component.html
+++ b/src/main/webapp/app/shared/pages/professor-landing-page/professor-faq-section/professor-faq-section.component.html
@@ -13,7 +13,7 @@
         <p-accordion-panel class="border border-border-default rounded-xl overflow-hidden" [value]="tab.value">
           <p-accordion-header class="font-semibold">{{ tab.title | translate }}</p-accordion-header>
           <p-accordion-content>
-            <div class="leading-relaxed" [innerHTML]="tab.content | translate"></div>
+            <div class="pt-2 leading-relaxed" [innerHTML]="tab.content | translate"></div>
             <div class="registration-button">
               @if (tab.value === 'registration') {
                 <jhi-button (click)="openRegistrationForm()" [shouldTranslate]="true" [label]="translationKey + '.registration.button'" />

--- a/src/main/webapp/content/scss/prime-ng-overrides.scss
+++ b/src/main/webapp/content/scss/prime-ng-overrides.scss
@@ -72,6 +72,36 @@ p-step[data-p-active='true'] .p-step-title {
   background: var(--p-background-surface) !important;
 }
 
+/* -------------------------------
+   FAQ Section Accordion (landing pages)
+---------------------------------- */
+.faq-container {
+  .p-accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: 50rem;
+  }
+
+  .p-accordionpanel {
+    border: 1px solid var(--p-border-default);
+    border-radius: 0.75rem;
+    overflow: hidden;
+  }
+
+  .p-accordionheader {
+    padding: 1rem 1.25rem !important;
+    border-radius: 0.75rem !important;
+    font-weight: 600;
+  }
+
+  .p-accordioncontent-content {
+    padding: 0.25rem 1.5rem 1.25rem !important;
+    line-height: 1.6;
+  }
+}
+
 /* Disable all transitions and animations while switching theme */
 .theme-switching *,
 .theme-switching *::before,

--- a/src/main/webapp/content/scss/prime-ng-overrides.scss
+++ b/src/main/webapp/content/scss/prime-ng-overrides.scss
@@ -72,36 +72,6 @@ p-step[data-p-active='true'] .p-step-title {
   background: var(--p-background-surface) !important;
 }
 
-/* -------------------------------
-   FAQ Section Accordion (landing pages)
----------------------------------- */
-.faq-container {
-  .p-accordion {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    width: 100%;
-    max-width: 50rem;
-  }
-
-  .p-accordionpanel {
-    border: 1px solid var(--p-border-default);
-    border-radius: 0.75rem;
-    overflow: hidden;
-  }
-
-  .p-accordionheader {
-    padding: 1rem 1.25rem !important;
-    border-radius: 0.75rem !important;
-    font-weight: 600;
-  }
-
-  .p-accordioncontent-content {
-    padding: 0.25rem 1.5rem 1.25rem !important;
-    line-height: 1.6;
-  }
-}
-
 /* Disable all transitions and animations while switching theme */
 .theme-switching *,
 .theme-switching *::before,

--- a/src/main/webapp/i18n/de/landingPage.json
+++ b/src/main/webapp/i18n/de/landingPage.json
@@ -103,7 +103,7 @@
         },
         "otherJobs": {
           "title": "Sind das alle Stellenausschreibungen?",
-          "content": "Nein, auf TUMApply sind nur ausgewählte Ausschreibungen für die TUM School of Computation, Information and Technology zu finden. Weitere Stellenanzeigen findest du auf anderen Kanälen wie der <a href='https://portal.mytum.de/jobs/wissenschaftler' class='external-link'><strong><u>myTUM Jobplattform</u></strong></a> oder auf den Websites einzelner Forschungsgruppen."
+          "content": "Auf TUMApply findest du vor allem Ausschreibungen der TUM School of Computation, Information and Technology, aber auch andere Schools und Lehrstühle können hier veröffentlichen. Weitere Stellen findest du auf der <a href='https://portal.mytum.de/jobs/wissenschaftler' class='external-link'><strong><u>myTUM Jobplattform</u></strong></a> oder auf den Websites einzelner Forschungsgruppen."
         }
       }
     },

--- a/src/main/webapp/i18n/en/landingPage.json
+++ b/src/main/webapp/i18n/en/landingPage.json
@@ -103,7 +103,7 @@
         },
         "otherJobs": {
           "title": "Are these all available job postings?",
-          "content": "No, TUMApply only lists a selection of available positions for the TUM School of Computation, Information and Technology. You can find more job postings on other channels such as the <a href='https://portal.mytum.de/jobs/wissenschaftler' class='external-link'><strong><u>myTUM Job Platform</u></strong></a> or on individual research group websites."
+          "content": "TUMApply primarily features positions from the TUM School of Computation, Information and Technology, but other schools and departments may post here as well. For openings beyond this selection, check the <a href='https://portal.mytum.de/jobs/wissenschaftler' class='external-link'><strong><u>myTUM Job Platform</u></strong></a> or individual research-group websites."
         }
       }
     },


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The applicant and professor landing-page FAQs rendered the PrimeNG accordion with default styling: panels share borders and have no breathing room, so the questions look like one continuous block. Closes #1418.

### Description

- Added a scoped block in `src/main/webapp/content/scss/prime-ng-overrides.scss` under `.faq-container`:
  - `gap: 0.75rem` between panels so each FAQ stands on its own
  - `border` + `border-radius: 0.75rem` + `overflow: hidden` so each panel reads as a card
  - Header padding bumped, `font-weight: 600` for clearer hierarchy
  - Content padding tuned for comfortable reading line-height
  - `max-width: 50rem` on the accordion for readable line length on wide screens
- No template or component changes — PrimeNG's open animation (driven by `@angular/animations`) is untouched.

### Steps for Testing

Prerequisites:

1. Open the applicant landing page (`/`) while logged out and scroll to the FAQ
2. Confirm each question is rendered as its own card with spacing between cards
3. Click a question; the smooth open/close animation still works
4. Repeat on the professor landing page (`/professor`)

### Screenshots

<img width="842" height="664" alt="image" src="https://github.com/user-attachments/assets/12ad3084-89e6-4711-a0d9-e6e8553832fc" />
