### PR TITLE
`Bugfix`: Clarify the header role-switch button

### DIFF
--- a/src/main/webapp/i18n/de/header.json
+++ b/src/main/webapp/i18n/de/header.json
@@ -2,8 +2,8 @@
   "header": {
     "login": "Anmelden",
     "professorTitle": "Professor:in",
-    "professor": "Bist du Professor:in?",
-    "applicant": "Bist du Bewerber:in?",
+    "professor": "Für Professor:innen",
+    "applicant": "Für Bewerber:innen",
     "logout": "Abmelden",
     "settings": "Einstellungen",
     "profileMenu": "Profilmenü öffnen",

--- a/src/main/webapp/i18n/de/header.json
+++ b/src/main/webapp/i18n/de/header.json
@@ -2,8 +2,8 @@
   "header": {
     "login": "Anmelden",
     "professorTitle": "Professor:in",
-    "professor": "Für Professor:innen",
-    "applicant": "Für Bewerber:innen",
+    "professor": "Für Professoren",
+    "applicant": "Für Bewerbende",
     "logout": "Abmelden",
     "settings": "Einstellungen",
     "profileMenu": "Profilmenü öffnen",

--- a/src/main/webapp/i18n/en/header.json
+++ b/src/main/webapp/i18n/en/header.json
@@ -2,8 +2,8 @@
   "header": {
     "login": "Sign In",
     "professorTitle": "Professor",
-    "professor": "Are you a professor?",
-    "applicant": "Are you an applicant?",
+    "professor": "For Professors",
+    "applicant": "For Applicants",
     "logout": "Logout",
     "settings": "Settings",
     "profileMenu": "Open profile menu",


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).

### Motivation and Context

User feedback flagged the header role-switch button (\"Are you a professor?\" / \"Are you an applicant?\") as confusing — it reads like an identity quiz rather than a link to a different section. Closes #2436.

### Description

- EN: \`Are you a professor?\` → \`For Professors\`, \`Are you an applicant?\` → \`For Applicants\`
- DE: \`Bist du Professor:in?\` → \`Für Professor:innen\`, \`Bist du Bewerber:in?\` → \`Für Bewerber:innen\`

Only the i18n strings change; behaviour, navigation, and styling stay the same.

### Steps for Testing

Prerequisites:

1. Open the applicant landing page while logged out — the header button should read \"For Professors\" and link to the professor landing page.
2. Switch language to German — the same button should read \"Für Professor:innen\".
3. Repeat on the professor landing page (\"For Applicants\" / \"Für Bewerber:innen\").

### Screenshots

_Adding screenshots._