### PR TITLE
`Bugfix`: Unify the contact-us wording across toast error messages

### DIFF
--- a/src/main/webapp/i18n/de/evaluation.json
+++ b/src/main/webapp/i18n/de/evaluation.json
@@ -75,7 +75,7 @@
       },
       "error": {
         "summary": "Fehler",
-        "detail": "Fehler beim Hinzufügen des Bewerbers. Bitte versuche es später erneut oder kontaktiere einen Administrator."
+        "detail": "Fehler beim Hinzufügen des Bewerbers. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
       }
     },
     "education": {

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -543,11 +543,11 @@
         },
         "fetchApplicationFailed": {
           "summary": "Bewerbung nicht geladen",
-          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "fetchDocumentIdsFailed": {
           "summary": "Dokumente nicht geladen",
-          "detail": "Die Dokument-IDs für diese Bewerbung konnten nicht abgerufen werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Dokument-IDs für diese Bewerbung konnten nicht abgerufen werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "notEditable": {
           "summary": "Nicht bearbeitbar",
@@ -563,11 +563,11 @@
         },
         "loadFailed": {
           "summary": "Laden fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte aktualisiere die Seite oder kontaktiere einen Admin."
+          "detail": "Die Bewerbung konnte nicht geladen werden. Bitte lade die Seite neu, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "initLoadFailed": {
           "summary": "Laden fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht initial geladen werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Bewerbung konnte nicht initial geladen werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "missingJobIdUnauthenticated": {
           "summary": "Job-ID fehlt",
@@ -579,7 +579,7 @@
         },
         "errorDeletingApplication": {
           "summary": "Löschen fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht gelöscht werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Bewerbung konnte nicht gelöscht werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "applicationWithdrawn": {
           "summary": "Bewerbung zurückgezogen",
@@ -587,7 +587,7 @@
         },
         "errorWithdrawingApplication": {
           "summary": "Zurückziehen fehlgeschlagen",
-          "detail": "Die Bewerbung konnte nicht zurückgezogen werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Bewerbung konnte nicht zurückgezogen werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "jobIdNotAvailable": {
           "summary": "Fehler",

--- a/src/main/webapp/i18n/de/interview.json
+++ b/src/main/webapp/i18n/de/interview.json
@@ -70,7 +70,7 @@
       "error": {
         "loadFailed": {
           "summary": "Interview Termine konnten nicht geladen werden",
-          "detail": "Die Interview Termine konnten nicht geladen werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Die Interview Termine konnten nicht geladen werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         }
       },
       "status": {
@@ -173,7 +173,7 @@
         },
         "error": {
           "summary": "Löschen fehlgeschlagen",
-          "detail": "Der Termin konnte nicht gelöscht werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Der Termin konnte nicht gelöscht werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "errorBooked": {
           "summary": "Löschen fehlgeschlagen",
@@ -215,7 +215,7 @@
         },
         "error": {
           "summary": "Absage fehlgeschlagen",
-          "detail": "Das Interview konnte nicht abgesagt werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Das Interview konnte nicht abgesagt werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         }
       }
     },
@@ -297,7 +297,7 @@
         },
         "error": {
           "summary": "Senden fehlgeschlagen",
-          "detail": "Einladung konnte nicht gesendet werden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Einladung konnte nicht gesendet werden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "noSlots": {
           "summary": "Keine Termine verfügbar",

--- a/src/main/webapp/i18n/de/research-group.json
+++ b/src/main/webapp/i18n/de/research-group.json
@@ -8,7 +8,7 @@
     "imageHeader": "Bilder",
     "groupInfo": {
       "description": "Bearbeite die grundlegenden Informationen über deine Forschungsgruppe.",
-      "organizationInfo": "Um das Department und die School zu ändern, kontaktiere uns bitte.",
+      "organizationInfo": "Bitte kontaktiere uns, um das Department und die School zu ändern.",
       "noDepartment": "Kein Department",
       "noSchool": "Keine School",
       "fields": {

--- a/src/main/webapp/i18n/de/research-group.json
+++ b/src/main/webapp/i18n/de/research-group.json
@@ -8,7 +8,7 @@
     "imageHeader": "Bilder",
     "groupInfo": {
       "description": "Bearbeite die grundlegenden Informationen über deine Forschungsgruppe.",
-      "organizationInfo": "Um das Department und die School zu ändern, wende dich bitte an eine:n Administrator:in.",
+      "organizationInfo": "Um das Department und die School zu ändern, kontaktiere uns bitte.",
       "noDepartment": "Kein Department",
       "noSchool": "Keine School",
       "fields": {
@@ -42,9 +42,9 @@
       },
       "toasts": {
         "updated": "Forschungsgruppeninformationen erfolgreich aktualisiert.",
-        "saveFailed": "Fehler beim Speichern. Bitte versuche es erneut oder kontaktiere einen Admin.",
-        "loadFailed": "Fehler beim Laden. Bitte lade die Seite neu oder kontaktiere einen Admin.",
-        "noId": "Keine Forschungsgruppe gefunden. Kontaktiere deinen Admin."
+        "saveFailed": "Fehler beim Speichern. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht.",
+        "loadFailed": "Fehler beim Laden. Bitte lade die Seite neu, oder kontaktiere uns, wenn das Problem weiterhin besteht.",
+        "noId": "Keine Forschungsgruppe gefunden. Bitte kontaktiere uns."
       }
     },
     "emailTemplates": {
@@ -135,7 +135,7 @@
       "toastMessages": {
         "loadFailed": {
           "summary": "Fehler beim Laden",
-          "detail": "Fehler beim Laden. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Fehler beim Laden. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "loadUsersFailed": {
           "summary": "Fehler beim Laden",
@@ -167,7 +167,7 @@
         },
         "removeFailed": {
           "summary": "Fehler beim Entfernen",
-          "detail": "Fehler beim Entfernen. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Fehler beim Entfernen. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         }
       },
       "noRole": "Keine Rolle"
@@ -305,7 +305,7 @@
         },
         "save": {
           "summary": "Fehler",
-          "detail": "Fehler beim Speichern der Forschungsgruppeninformationen. Bitte versuche es erneut oder kontaktiere einen Admin."
+          "detail": "Fehler beim Speichern der Forschungsgruppeninformationen. Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht."
         },
         "loadDepartments": {
           "summary": "Fehler",

--- a/src/main/webapp/i18n/en/evaluation.json
+++ b/src/main/webapp/i18n/en/evaluation.json
@@ -75,7 +75,7 @@
       },
       "error": {
         "summary": "Error",
-        "detail": "Failed to add applicant to interview process. Please try again later or contact an administrator."
+        "detail": "Failed to add applicant to interview process. Please try again, or contact us if the problem persists."
       }
     },
     "education": {

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -543,11 +543,11 @@
         },
         "fetchApplicationFailed": {
           "summary": "Application not loaded",
-          "detail": "The application could not be loaded. Please try again or contact an admin."
+          "detail": "The application could not be loaded. Please try again, or contact us if the problem persists."
         },
         "fetchDocumentIdsFailed": {
           "summary": "Error",
-          "detail": "Failed to fetch document IDs for this application. Please try again or contact an admin."
+          "detail": "Failed to fetch document IDs for this application. Please try again, or contact us if the problem persists."
         },
         "notEditable": {
           "summary": "Error",
@@ -559,15 +559,15 @@
         },
         "saveFailed": {
           "summary": "Error",
-          "detail": "Failed to save application. Please try again or contact an admin."
+          "detail": "Failed to save application. Please try again, or contact us if the problem persists."
         },
         "loadFailed": {
           "summary": "Error",
-          "detail": "Failed to load application. Please try again or contact an admin."
+          "detail": "Failed to load application. Please try again, or contact us if the problem persists."
         },
         "initLoadFailed": {
           "summary": "Error",
-          "detail": "Failed to load application. Please try again or contact an admin."
+          "detail": "Failed to load application. Please try again, or contact us if the problem persists."
         },
         "missingJobIdUnauthenticated": {
           "summary": "Error",
@@ -579,7 +579,7 @@
         },
         "errorDeletingApplication": {
           "summary": "Delete failed",
-          "detail": "The application could not be deleted. Please try again or contact an admin."
+          "detail": "The application could not be deleted. Please try again, or contact us if the problem persists."
         },
         "applicationWithdrawn": {
           "summary": "Application withdrawn",
@@ -587,7 +587,7 @@
         },
         "errorWithdrawingApplication": {
           "summary": "Withdrawal failed",
-          "detail": "The application could not be withdrawn. Please try again or contact an admin."
+          "detail": "The application could not be withdrawn. Please try again, or contact us if the problem persists."
         },
         "jobIdNotAvailable": {
           "summary": "Error",

--- a/src/main/webapp/i18n/en/interview.json
+++ b/src/main/webapp/i18n/en/interview.json
@@ -70,7 +70,7 @@
       "error": {
         "loadFailed": {
           "summary": "Failed to load interview slots",
-          "detail": "The interview slots could not be loaded. Please refresh the page or contact an admin."
+          "detail": "The interview slots could not be loaded. Please refresh the page, or contact us if the problem persists."
         }
       },
       "status": {
@@ -173,7 +173,7 @@
         },
         "error": {
           "summary": "Delete failed",
-          "detail": "The slot could not be deleted. Please try again or contact an admin."
+          "detail": "The slot could not be deleted. Please try again, or contact us if the problem persists."
         },
         "errorBooked": {
           "summary": "Delete failed",
@@ -215,7 +215,7 @@
         },
         "error": {
           "summary": "Cancellation failed",
-          "detail": "The interview could not be cancelled. Please try again or contact an admin."
+          "detail": "The interview could not be cancelled. Please try again, or contact us if the problem persists."
         }
       }
     },
@@ -297,7 +297,7 @@
         },
         "error": {
           "summary": "Send Failed",
-          "detail": "Failed to send invitation. Please try again or contact an admin."
+          "detail": "Failed to send invitation. Please try again, or contact us if the problem persists."
         },
         "noSlots": {
           "summary": "No Slots Available",

--- a/src/main/webapp/i18n/en/research-group.json
+++ b/src/main/webapp/i18n/en/research-group.json
@@ -8,7 +8,7 @@
     "imageHeader": "Images",
     "groupInfo": {
       "description": "Edit the basic information about your research group.",
-      "organizationInfo": "To change the department and school, please contact us.",
+      "organizationInfo": "Please contact us to change the department and school.",
       "noDepartment": "No department",
       "noSchool": "No school",
       "fields": {

--- a/src/main/webapp/i18n/en/research-group.json
+++ b/src/main/webapp/i18n/en/research-group.json
@@ -8,7 +8,7 @@
     "imageHeader": "Images",
     "groupInfo": {
       "description": "Edit the basic information about your research group.",
-      "organizationInfo": "To change the department and school, please contact an administrator.",
+      "organizationInfo": "To change the department and school, please contact us.",
       "noDepartment": "No department",
       "noSchool": "No school",
       "fields": {
@@ -42,9 +42,9 @@
       },
       "toasts": {
         "updated": "Research group information successfully updated.",
-        "saveFailed": "Error saving. Please try again or contact an admin.",
-        "loadFailed": "Error loading. Please refresh the page or contact an admin.",
-        "noId": "No research group found. Contact an admin."
+        "saveFailed": "Error saving. Please try again, or contact us if the problem persists.",
+        "loadFailed": "Error loading. Please refresh the page, or contact us if the problem persists.",
+        "noId": "No research group found. Please contact us."
       }
     },
     "emailTemplates": {
@@ -135,7 +135,7 @@
       "toastMessages": {
         "loadFailed": {
           "summary": "Load Failed",
-          "detail": "Failed to load. Please try again or contact an admin."
+          "detail": "Failed to load. Please try again, or contact us if the problem persists."
         },
         "loadUsersFailed": {
           "summary": "Load Failed",
@@ -167,7 +167,7 @@
         },
         "removeFailed": {
           "summary": "Remove Failed",
-          "detail": "Failed to remove. Please try again or contact an admin."
+          "detail": "Failed to remove. Please try again, or contact us if the problem persists."
         }
       },
       "noRole": "No Role"
@@ -305,7 +305,7 @@
         },
         "save": {
           "summary": "Error",
-          "detail": "Error saving research group information. Please try again or contact an admin."
+          "detail": "Error saving research group information. Please try again, or contact us if the problem persists."
         },
         "loadDepartments": {
           "summary": "Error",


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Toast error wording was inconsistent: some messages said \"contact an admin\", others \"contact an administrator\", and another set already used the canonical \"contact us if the problem persists\". Users shouldn't be told to find an unspecified admin when the support model is just \"contact us\". Closes #2385.

### Description

Standardised every toast error message to one of two canonical forms (EN + DE):

- Action errors: \`… Please try again, or contact us if the problem persists.\` / \`… Bitte versuche es erneut, oder kontaktiere uns, wenn das Problem weiterhin besteht.\`
- Load errors: \`… Please refresh the page, or contact us if the problem persists.\` / \`… Bitte lade die Seite neu, oder kontaktiere uns, wenn das Problem weiterhin besteht.\`

For two non-toast inline labels (\`researchGroup.groupInfo.organizationInfo\`, \`researchGroup.groupInfo.toasts.noId\`), used the shorter \`please contact us\` since the persistence clause does not apply.

Files touched (EN + DE):

- \`global.json\` — apply-flow load/save/delete/withdraw failures
- \`research-group.json\` — group info, members, detail view
- \`interview.json\` — slot loading/deletion, interview cancellation, invitation
- \`evaluation.json\` — add-applicant-to-interview-process

No code changes, no key renames, no new keys.

### Steps for Testing

Prerequisites:

1. Trigger any of the affected error paths (e.g., disconnect network and try saving an application, deleting a job, or loading research-group members) in EN and DE.
2. Confirm the toast text uses \"contact us if the problem persists\" / \"kontaktiere uns, wenn das Problem weiterhin besteht\".
3. Confirm \"admin\" / \"Administrator\" no longer appears in any error toast.

### Screenshots

_Adding screenshots._