### PR TITLE
`General`: Side-by-side bulk exports with progress bar and slower polling

### DIFF
--- a/src/main/webapp/app/admin/exports/admin-exports.component.html
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.html
@@ -5,115 +5,148 @@
 
   <p class="text-text-secondary text-sm mb-6" jhiTranslate="adminExports.subtitle"></p>
 
-  @for (section of sections; track section.titleKey) {
+  @for (section of multiButtonSections(); track section.titleKey) {
     <section class="mb-8">
       <h2 class="text-lg font-semibold mb-3" jhiTranslate="{{ section.titleKey }}">{{ section.titleKey | translate }}</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         @for (btn of section.buttons; track btn.type) {
-          <div class="bg-background-surface border border-border-default rounded-lg p-5 flex flex-col gap-3">
-            <div class="flex items-start justify-between gap-3">
-              <h3 class="text-base font-semibold m-0" jhiTranslate="{{ btn.labelKey }}">{{ btn.labelKey | translate }}</h3>
-            </div>
-            <p class="text-sm text-text-secondary m-0" jhiTranslate="{{ btn.descriptionKey }}"></p>
-
-            @if (taskFor(btn.type); as task) {
-              <div class="text-xs text-text-secondary border-t border-border-default pt-2">
-                <div class="flex items-center justify-between mb-1">
-                  <span class="font-medium">
-                    @switch (task.status) {
-                      @case ('IN_PROGRESS') {
-                        <span jhiTranslate="adminExports.status.inProgress">Building…</span>
-                      }
-                      @case ('READY') {
-                        <span jhiTranslate="adminExports.status.ready">Ready</span>
-                      }
-                      @case ('FAILED') {
-                        <span jhiTranslate="adminExports.status.failed">Failed</span>
-                      }
-                    }
-                  </span>
-                  @if (task.durationSeconds !== undefined) {
-                    <span>{{ task.durationSeconds | number: '1.0-0' }}s</span>
-                  }
-                </div>
-                <ul class="list-none m-0 p-0 space-y-0.5">
-                  @if (task.schools && task.schools.expected) {
-                    <li>Schools: {{ task.schools.exported }}/{{ task.schools.expected }}</li>
-                  }
-                  @if (task.departments && task.departments.expected) {
-                    <li>Departments: {{ task.departments.exported }}/{{ task.departments.expected }}</li>
-                  }
-                  @if (task.researchGroups && task.researchGroups.expected) {
-                    <li>RG: {{ task.researchGroups.exported }}/{{ task.researchGroups.expected }}</li>
-                  }
-                  @if (task.jobs && task.jobs.expected) {
-                    <li>Jobs: {{ task.jobs.exported }}/{{ task.jobs.expected }}</li>
-                  }
-                  @if (task.applications && task.applications.expected) {
-                    <li>Applications: {{ task.applications.exported }}/{{ task.applications.expected }}</li>
-                  }
-                  @if (task.documents && task.documents.expected) {
-                    <li>Documents: {{ task.documents.exported }}/{{ task.documents.expected }}</li>
-                  }
-                  @if (task.users && task.users.expected) {
-                    <li>Users: {{ task.users.exported }}/{{ task.users.expected }}</li>
-                  }
-                  @if (task.userResearchGroupRoles && task.userResearchGroupRoles.expected) {
-                    <li>User ↔ RG roles: {{ task.userResearchGroupRoles.exported }}/{{ task.userResearchGroupRoles.expected }}</li>
-                  }
-                  @if (task.applicants && task.applicants.expected) {
-                    <li>Applicants: {{ task.applicants.exported }}/{{ task.applicants.expected }}</li>
-                  }
-                  @if (task.applicantSubjectAreaSubscriptions && task.applicantSubjectAreaSubscriptions.expected) {
-                    <li>
-                      Applicant subject subscriptions: {{ task.applicantSubjectAreaSubscriptions.exported }}/{{
-                        task.applicantSubjectAreaSubscriptions.expected
-                      }}
-                    </li>
-                  }
-                </ul>
-                @if (isDownloading(btn.type)) {
-                  <div class="mt-1">
-                    <span jhiTranslate="adminExports.status.downloading">Downloading…</span>
-                    <span class="ml-1">{{ downloadProgressLabel(btn.type) }}</span>
-                  </div>
-                }
-                @if (task.totalFailures && task.totalFailures > 0) {
-                  <div class="text-orange-600 mt-1">{{ task.totalFailures }} failure(s) — see manifest.json</div>
-                }
-                @if (task.error) {
-                  <div class="text-red-600 mt-1">{{ task.error }}</div>
-                }
-              </div>
-            }
-
-            <div class="mt-auto flex flex-col gap-2">
-              <jhi-button
-                severity="primary"
-                size="sm"
-                [icon]="btn.icon"
-                [label]="'adminExports.actions.start'"
-                [shouldTranslate]="true"
-                [disabled]="anyBusy()"
-                [loading]="isBusy(btn.type)"
-                (click)="start(btn.type)"
-              />
-              @if (taskFor(btn.type)?.status === 'READY') {
-                <jhi-button
-                  severity="secondary"
-                  size="sm"
-                  icon="download"
-                  [label]="'adminExports.actions.download'"
-                  [shouldTranslate]="true"
-                  [disabled]="isDownloading(btn.type)"
-                  [loading]="isDownloading(btn.type)"
-                  (click)="retryDownload(btn.type)"
-                />
-              }
-            </div>
-          </div>
+          <ng-container [ngTemplateOutlet]="exportCard" [ngTemplateOutletContext]="{ btn: btn }" />
         }
       </div>
     </section>
   }
+
+  @if (singleButtonSections().length > 0) {
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      @for (section of singleButtonSections(); track section.titleKey) {
+        <section class="flex flex-col gap-3">
+          <h2 class="text-lg font-semibold m-0" jhiTranslate="{{ section.titleKey }}">{{ section.titleKey | translate }}</h2>
+          @for (btn of section.buttons; track btn.type) {
+            <ng-container [ngTemplateOutlet]="exportCard" [ngTemplateOutletContext]="{ btn: btn }" />
+          }
+        </section>
+      }
+    </div>
+  }
 </div>
+
+<ng-template #exportCard let-btn="btn">
+  <div class="bg-background-surface border border-border-default rounded-lg p-5 flex flex-col gap-3 h-full">
+    <div class="flex items-start justify-between gap-3">
+      <h3 class="text-base font-semibold m-0" jhiTranslate="{{ btn.labelKey }}">{{ btn.labelKey | translate }}</h3>
+    </div>
+    <p class="text-sm text-text-secondary m-0" jhiTranslate="{{ btn.descriptionKey }}"></p>
+
+    @if (taskFor(btn.type); as task) {
+      <div class="text-xs text-text-secondary border-t border-border-default pt-2">
+        <div class="flex items-center justify-between mb-1">
+          <span class="font-medium">
+            @switch (task.status) {
+              @case ('IN_PROGRESS') {
+                <span jhiTranslate="adminExports.status.inProgress">Building…</span>
+              }
+              @case ('READY') {
+                <span jhiTranslate="adminExports.status.ready">Ready</span>
+              }
+              @case ('FAILED') {
+                <span jhiTranslate="adminExports.status.failed">Failed</span>
+              }
+            }
+          </span>
+          @if (task.durationSeconds !== undefined) {
+            <span>{{ task.durationSeconds | number: '1.0-0' }}s</span>
+          }
+        </div>
+
+        @if (task.status === 'IN_PROGRESS') {
+          <div class="my-2">
+            <div class="h-1.5 w-full bg-background-surface-alt rounded-pill overflow-hidden">
+              @if (buildProgressPercent(task); as percent) {
+                <div class="h-full bg-primary transition-all duration-300" [style.width.%]="percent"></div>
+              } @else {
+                <div class="h-full bg-primary animate-pulse w-1/3"></div>
+              }
+            </div>
+            @if (buildProgressPercent(task); as percent) {
+              <div class="mt-1 text-text-secondary">{{ percent }}%</div>
+            }
+          </div>
+        }
+
+        <ul class="list-none m-0 p-0 space-y-0.5">
+          @if (task.schools && task.schools.expected) {
+            <li>Schools: {{ task.schools.exported }}/{{ task.schools.expected }}</li>
+          }
+          @if (task.departments && task.departments.expected) {
+            <li>Departments: {{ task.departments.exported }}/{{ task.departments.expected }}</li>
+          }
+          @if (task.researchGroups && task.researchGroups.expected) {
+            <li>RG: {{ task.researchGroups.exported }}/{{ task.researchGroups.expected }}</li>
+          }
+          @if (task.jobs && task.jobs.expected) {
+            <li>Jobs: {{ task.jobs.exported }}/{{ task.jobs.expected }}</li>
+          }
+          @if (task.applications && task.applications.expected) {
+            <li>Applications: {{ task.applications.exported }}/{{ task.applications.expected }}</li>
+          }
+          @if (task.documents && task.documents.expected) {
+            <li>Documents: {{ task.documents.exported }}/{{ task.documents.expected }}</li>
+          }
+          @if (task.users && task.users.expected) {
+            <li>Users: {{ task.users.exported }}/{{ task.users.expected }}</li>
+          }
+          @if (task.userResearchGroupRoles && task.userResearchGroupRoles.expected) {
+            <li>User ↔ RG roles: {{ task.userResearchGroupRoles.exported }}/{{ task.userResearchGroupRoles.expected }}</li>
+          }
+          @if (task.applicants && task.applicants.expected) {
+            <li>Applicants: {{ task.applicants.exported }}/{{ task.applicants.expected }}</li>
+          }
+          @if (task.applicantSubjectAreaSubscriptions && task.applicantSubjectAreaSubscriptions.expected) {
+            <li>
+              Applicant subject subscriptions: {{ task.applicantSubjectAreaSubscriptions.exported }}/{{
+                task.applicantSubjectAreaSubscriptions.expected
+              }}
+            </li>
+          }
+        </ul>
+        @if (isDownloading(btn.type)) {
+          <div class="mt-1">
+            <span jhiTranslate="adminExports.status.downloading">Downloading…</span>
+            <span class="ml-1">{{ downloadProgressLabel(btn.type) }}</span>
+          </div>
+        }
+        @if (task.totalFailures && task.totalFailures > 0) {
+          <div class="text-orange-600 mt-1">{{ task.totalFailures }} failure(s) — see manifest.json</div>
+        }
+        @if (task.error) {
+          <div class="text-red-600 mt-1">{{ task.error }}</div>
+        }
+      </div>
+    }
+
+    <div class="mt-auto flex flex-col gap-2">
+      <jhi-button
+        severity="primary"
+        size="sm"
+        [icon]="btn.icon"
+        [label]="'adminExports.actions.start'"
+        [shouldTranslate]="true"
+        [disabled]="anyBusy()"
+        [loading]="isBusy(btn.type)"
+        (click)="start(btn.type)"
+      />
+      @if (taskFor(btn.type)?.status === 'READY') {
+        <jhi-button
+          severity="secondary"
+          size="sm"
+          icon="download"
+          [label]="'adminExports.actions.download'"
+          [shouldTranslate]="true"
+          [disabled]="isDownloading(btn.type)"
+          [loading]="isDownloading(btn.type)"
+          (click)="retryDownload(btn.type)"
+        />
+      }
+    </div>
+  </div>
+</ng-template>

--- a/src/main/webapp/app/admin/exports/admin-exports.component.html
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.html
@@ -7,7 +7,7 @@
 
   @for (section of multiButtonSections(); track section.titleKey) {
     <section class="mb-8">
-      <h2 class="text-lg font-semibold mb-3" jhiTranslate="{{ section.titleKey }}">{{ section.titleKey | translate }}</h2>
+      <h2 class="text-lg font-semibold mb-3" [jhiTranslate]="section.titleKey"></h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         @for (btn of section.buttons; track btn.type) {
           <ng-container [ngTemplateOutlet]="exportCard" [ngTemplateOutletContext]="{ btn: btn }" />
@@ -20,7 +20,7 @@
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       @for (section of singleButtonSections(); track section.titleKey) {
         <section class="flex flex-col gap-3">
-          <h2 class="text-lg font-semibold m-0" jhiTranslate="{{ section.titleKey }}">{{ section.titleKey | translate }}</h2>
+          <h2 class="text-lg font-semibold m-0" [jhiTranslate]="section.titleKey"></h2>
           @for (btn of section.buttons; track btn.type) {
             <ng-container [ngTemplateOutlet]="exportCard" [ngTemplateOutletContext]="{ btn: btn }" />
           }
@@ -33,7 +33,7 @@
 <ng-template #exportCard let-btn="btn">
   <div class="bg-background-surface border border-border-default rounded-lg p-5 flex flex-col gap-3 h-full">
     <div class="flex items-start justify-between gap-3">
-      <h3 class="text-base font-semibold m-0" jhiTranslate="{{ btn.labelKey }}">{{ btn.labelKey | translate }}</h3>
+      <h3 class="text-base font-semibold m-0" [jhiTranslate]="btn.labelKey"></h3>
     </div>
     <p class="text-sm text-text-secondary m-0" jhiTranslate="{{ btn.descriptionKey }}"></p>
 

--- a/src/main/webapp/app/admin/exports/admin-exports.component.ts
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.ts
@@ -179,6 +179,18 @@ export class AdminExportsComponent {
     },
   ];
 
+  /**
+   * Sections that render as a single full-width grid (currently only the
+   * Jobs section, which has multiple buttons).
+   */
+  readonly multiButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length > 1));
+
+  /**
+   * Sections that own a single button. They are rendered side-by-side as
+   * cards in one row instead of stacking on top of each other.
+   */
+  readonly singleButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length === 1));
+
   private readonly api = inject(AdminExportResourceApi);
   private readonly http = inject(HttpClient);
   private readonly toastService = inject(ToastService);
@@ -228,18 +240,6 @@ export class AdminExportsComponent {
   isDownloading(type: AdminExportType): boolean {
     return this.downloadProgress().has(type);
   }
-
-  /**
-   * Sections that render as a single full-width grid (currently only the
-   * Jobs section, which has multiple buttons).
-   */
-  readonly multiButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length > 1));
-
-  /**
-   * Sections that own a single button. They are rendered side-by-side as
-   * cards in one row instead of stacking on top of each other.
-   */
-  readonly singleButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length === 1));
 
   /**
    * Aggregate build progress across every counter the server reports for

--- a/src/main/webapp/app/admin/exports/admin-exports.component.ts
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.ts
@@ -1,7 +1,6 @@
 import { Component, DestroyRef, afterNextRender, computed, inject, signal } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { ButtonComponent } from 'app/shared/components/atoms/button/button.component';
 import { TranslateDirective } from 'app/shared/language';
@@ -89,7 +88,7 @@ interface DownloadProgress {
 @Component({
   selector: 'jhi-admin-exports',
   standalone: true,
-  imports: [CommonModule, TranslateModule, TranslateDirective, ButtonComponent],
+  imports: [CommonModule, TranslateDirective, ButtonComponent],
   templateUrl: './admin-exports.component.html',
 })
 export class AdminExportsComponent {

--- a/src/main/webapp/app/admin/exports/admin-exports.component.ts
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.ts
@@ -31,11 +31,13 @@ interface ExportSection {
 
 /**
  * How often we poll the status endpoint while a task is in progress.
- * Large exports take minutes — a slow cadence keeps the server load low
- * while still surfacing progress updates often enough to reassure the
- * admin that something is happening.
+ * Large exports take many minutes; a slow cadence keeps the server load
+ * low while still refreshing the in-card counters often enough that the
+ * admin sees progress. The live download progress bar inside the card
+ * is driven by chunk-level updates, not by polling, so a longer poll
+ * interval does not make the UI feel frozen.
  */
-const POLL_INTERVAL_MS = 30000;
+const POLL_INTERVAL_MS = 45000;
 
 /**
  * Size of each byte-range chunk the browser requests when downloading a
@@ -226,6 +228,52 @@ export class AdminExportsComponent {
   /** True while the browser is actively downloading a ready ZIP for this type. */
   isDownloading(type: AdminExportType): boolean {
     return this.downloadProgress().has(type);
+  }
+
+  /**
+   * Sections that render as a single full-width grid (currently only the
+   * Jobs section, which has multiple buttons).
+   */
+  readonly multiButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length > 1));
+
+  /**
+   * Sections that own a single button. They are rendered side-by-side as
+   * cards in one row instead of stacking on top of each other.
+   */
+  readonly singleButtonSections = computed<ExportSection[]>(() => this.sections.filter(section => section.buttons.length === 1));
+
+  /**
+   * Aggregate build progress across every counter the server reports for
+   * the given task (schools / departments / research groups / jobs /
+   * applications / documents / users / role assignments / applicants /
+   * subscriptions). Returns a number between 0 and 100, or {@code null}
+   * when the server has not yet reported any expected counts (e.g. the
+   * task just started). Drives the in-card progress bar so the admin
+   * sees concrete movement during the multi-minute build.
+   */
+  buildProgressPercent(task: AdminExportTaskDTO | undefined): number | null {
+    if (task === undefined) return null;
+    let exported = 0;
+    let expected = 0;
+    for (const counter of [
+      task.schools,
+      task.departments,
+      task.researchGroups,
+      task.jobs,
+      task.applications,
+      task.documents,
+      task.users,
+      task.userResearchGroupRoles,
+      task.applicants,
+      task.applicantSubjectAreaSubscriptions,
+    ]) {
+      if (counter?.expected !== undefined && counter.expected > 0) {
+        expected += counter.expected;
+        exported += counter.exported ?? 0;
+      }
+    }
+    if (expected === 0) return null;
+    return Math.min(100, Math.floor((exported / expected) * 100));
   }
 
   /**

--- a/src/main/webapp/app/admin/exports/admin-exports.component.ts
+++ b/src/main/webapp/app/admin/exports/admin-exports.component.ts
@@ -64,8 +64,8 @@ const STORAGE_KEY = 'tumapply.adminExports.tasks';
 interface DownloadProgress {
   /** Bytes received so far from the server. */
   loaded: number;
-  /** Total bytes expected, or {@code null} if the server did not set {@code Content-Length}. */
-  total: number | null;
+  /** Total bytes expected, or {@code undefined} if the server did not set {@code Content-Length}. */
+  total: number | undefined;
 }
 
 /**
@@ -245,13 +245,13 @@ export class AdminExportsComponent {
    * Aggregate build progress across every counter the server reports for
    * the given task (schools / departments / research groups / jobs /
    * applications / documents / users / role assignments / applicants /
-   * subscriptions). Returns a number between 0 and 100, or {@code null}
+   * subscriptions). Returns a number between 0 and 100, or {@code undefined}
    * when the server has not yet reported any expected counts (e.g. the
    * task just started). Drives the in-card progress bar so the admin
    * sees concrete movement during the multi-minute build.
    */
-  buildProgressPercent(task: AdminExportTaskDTO | undefined): number | null {
-    if (task === undefined) return null;
+  buildProgressPercent(task: AdminExportTaskDTO | undefined): number | undefined {
+    if (task === undefined) return undefined;
     let exported = 0;
     let expected = 0;
     for (const counter of [
@@ -271,7 +271,7 @@ export class AdminExportsComponent {
         exported += counter.exported ?? 0;
       }
     }
-    if (expected === 0) return null;
+    if (expected === 0) return undefined;
     return Math.min(100, Math.floor((exported / expected) * 100));
   }
 
@@ -284,7 +284,7 @@ export class AdminExportsComponent {
   downloadProgressLabel(type: AdminExportType): string {
     const progress = this.downloadProgress().get(type);
     if (progress === undefined) return '';
-    if (progress.total === null || progress.total === 0) {
+    if (progress.total === undefined || progress.total === 0) {
       return this.formatBytes(progress.loaded);
     }
     const percent = Math.floor((progress.loaded / progress.total) * 100);
@@ -460,37 +460,38 @@ export class AdminExportsComponent {
     const taskId = task.taskId;
     const url = `/api/admin/exports/download/${encodeURIComponent(taskId)}`;
 
-    this.setDownloadProgress(type, 0, null);
+    this.setDownloadProgress(type, 0, undefined);
 
     const chunks: Blob[] = [];
     let nextOffset = 0;
-    let total: number | null = null;
-    let filename: string | null = null;
+    let total: number | undefined = undefined;
+    let filename: string | undefined = undefined;
 
     try {
-      while (total === null || nextOffset < total) {
+      while (total === undefined || nextOffset < total) {
         if (this.downloadGeneration.get(type) !== generation) return;
-        const chunkEndExclusive = total === null ? nextOffset + DOWNLOAD_CHUNK_SIZE : Math.min(nextOffset + DOWNLOAD_CHUNK_SIZE, total);
+        const chunkEndExclusive =
+          total === undefined ? nextOffset + DOWNLOAD_CHUNK_SIZE : Math.min(nextOffset + DOWNLOAD_CHUNK_SIZE, total);
         // HTTP Range header end is inclusive, so we subtract 1.
         const rangeHeader = `bytes=${nextOffset}-${chunkEndExclusive - 1}`;
         const response = await this.fetchChunkWithRetry(url, rangeHeader, type, generation);
         if (this.downloadGeneration.get(type) !== generation) return;
-        const chunk = response.body;
-        if (chunk === null) {
+        const chunk = response.body ?? undefined;
+        if (chunk === undefined) {
           throw new Error('Empty chunk body');
         }
         chunks.push(chunk);
         nextOffset += chunk.size;
 
-        if (total === null) {
+        if (total === undefined) {
           // First chunk — parse the total size from Content-Range
           // ("bytes start-end/total") so we know how many more chunks to
           // request. Fall back to Content-Length when the server did not
           // return a 206 (treating the response as the whole file).
           total =
-            this.parseTotalFromContentRange(response.headers.get('Content-Range')) ??
-            this.parseContentLength(response.headers.get('Content-Length'));
-          filename = this.parseFilename(response.headers.get('Content-Disposition')) ?? null;
+            this.parseTotalFromContentRange(response.headers.get('Content-Range') ?? undefined) ??
+            this.parseContentLength(response.headers.get('Content-Length') ?? undefined);
+          filename = this.parseFilename(response.headers.get('Content-Disposition') ?? undefined);
         }
         this.setDownloadProgress(type, nextOffset, total);
 
@@ -575,26 +576,26 @@ export class AdminExportsComponent {
 
   /**
    * Parses the total file size out of an HTTP {@code Content-Range} header
-   * value like {@code "bytes 0-32767/102400"}. Returns {@code null} for
+   * value like {@code "bytes 0-32767/102400"}. Returns {@code undefined} for
    * malformed or missing headers, or when the server sent an unknown
    * total (indicated by {@code *}).
    */
-  private parseTotalFromContentRange(header: string | null): number | null {
-    if (header === null) return null;
-    const match = /\/(\d+)$/.exec(header);
-    if (match === null) return null;
+  private parseTotalFromContentRange(header: string | undefined): number | undefined {
+    if (header === undefined) return undefined;
+    const match = /\/(\d+)$/.exec(header) ?? undefined;
+    if (match === undefined) return undefined;
     const parsed = parseInt(match[1], 10);
-    return Number.isFinite(parsed) ? parsed : null;
+    return Number.isFinite(parsed) ? parsed : undefined;
   }
 
-  /** Parses a numeric {@code Content-Length} header, or {@code null} when absent/malformed. */
-  private parseContentLength(header: string | null): number | null {
-    if (header === null) return null;
+  /** Parses a numeric {@code Content-Length} header, or {@code undefined} when absent/malformed. */
+  private parseContentLength(header: string | undefined): number | undefined {
+    if (header === undefined) return undefined;
     const parsed = parseInt(header, 10);
-    return Number.isFinite(parsed) ? parsed : null;
+    return Number.isFinite(parsed) ? parsed : undefined;
   }
 
-  private setDownloadProgress(type: AdminExportType, loaded: number, total: number | null): void {
+  private setDownloadProgress(type: AdminExportType, loaded: number, total: number | undefined): void {
     this.downloadProgress.update(prev => {
       const next = new Map(prev);
       next.set(type, { loaded, total });
@@ -652,8 +653,8 @@ export class AdminExportsComponent {
 
   private loadFromStorage(): Map<AdminExportType, string> {
     try {
-      const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (raw === null) return new Map();
+      const raw = sessionStorage.getItem(STORAGE_KEY) ?? undefined;
+      if (raw === undefined) return new Map();
       const parsed = JSON.parse(raw) as Partial<Record<AdminExportType, string>>;
       const result = new Map<AdminExportType, string>();
       for (const key of Object.keys(parsed) as AdminExportType[]) {
@@ -683,8 +684,8 @@ export class AdminExportsComponent {
 
   // ---------------- misc helpers ----------------
 
-  private parseFilename(contentDisposition: string | null | undefined): string | undefined {
-    if (contentDisposition === null || contentDisposition === undefined) return undefined;
+  private parseFilename(contentDisposition: string | undefined): string | undefined {
+    if (contentDisposition === undefined) return undefined;
     return /filename="([^"]+)"/.exec(contentDisposition)?.[1];
   }
 


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2458

Three small follow-up UX improvements to the admin bulk export page, all from QA testing feedback. The page works, but: the three single-button sections waste vertical space by stacking, the multi-minute build feels frozen because there is no aggregate progress bar (only per-entity counters), and status polling at 30 s is more aggressive than needed since the chunk-level download progress already gives near-real-time feedback during the actual download.

### Description

Layout

- Single-button sections (Full Admin Export / Users & Organisation / Applications) now render side by side as cards in one row instead of stacking. The Jobs section keeps its own grid since it has multiple buttons.
- The card markup is shared via a single \`<ng-template #exportCard>\` in the same file so the card body stays in lockstep across the two layouts.

Build progress

- Each in-progress card now shows a \`Tailwind\`-only progress bar with a percent label.
- Percent is computed by \`buildProgressPercent(task)\` from the sum of \`exported\` and \`expected\` across all per-entity counters the server already reports.
- When the server has not yet reported any expected counts (right after the task starts), the bar falls back to an indeterminate pulsing animation so the admin still sees motion.

Polling

- \`POLL_INTERVAL_MS\` 30000 → 45000. Halves status traffic during long builds. The download progress bar inside the card is driven by chunk-level updates rather than polling, so a slower poll cadence does not make the UI feel frozen.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as an admin.
2. Navigate to the admin bulk export page.

Steps:

1. On a wide viewport, verify Full Admin Export / Users & Organisation / Applications now sit in one row, each card under its own section title.
2. Verify the Jobs section still renders multiple cards in its own grid.
3. Resize down — single-button cards should stack on narrower viewports.
4. Start an export. Watch the in-card progress bar — it should be a pulsing indeterminate bar at first, then transition to a percent that advances as counters arrive.
5. Let an export finish, hit Download, verify the file streams to disk and the in-card download progress label still shows MB / total.
6. While one export is running, try to start another — the buttons should be disabled and the existing 409-already-running toast should still appear from another tab.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Side-by-side layout on wide viewport, stacked on mobile.
- [ ] Progress bar renders for IN_PROGRESS tasks.
- [ ] Download still works end to end.

### Screenshots

<!-- TODO: add a before/after screenshot of the page layout once the dev server is up. -->