### PR TITLE
`Development`: Bring back ICU plurals via an ESM-native compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "dayjs": "1.11.20",
         "esbuild": "0.27.7",
         "franc-min": "6.2.0",
-        "intl-messageformat": "^11.2.4",
+        "intl-messageformat": "11.2.4",
         "keycloak-js": "26.2.2",
         "ngx-image-cropper": "9.1.6",
         "ngx-quill": "30.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "dayjs": "1.11.20",
         "esbuild": "0.27.7",
         "franc-min": "6.2.0",
+        "intl-messageformat": "^11.2.4",
         "keycloak-js": "26.2.2",
         "ngx-image-cropper": "9.1.6",
         "ngx-quill": "30.0.1",
@@ -2301,6 +2302,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.4.tgz",
+      "integrity": "sha512-Lbke1aOrsygKKR09Ux0NrZgbTqpDmiwXOgzyDOJ8Owr1zd5qOKTauf62hH+Seeku3ju77rHWH9I5SfX2CN0vuA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.7.tgz",
+      "integrity": "sha512-wJxRZ+SiUCIMTL86bQlZU9bEKDQqqvgk2ezQ1BySUdWRfHqOzj4IKUVFeUZKS9w58M4e7wMSG0Sl86LAPb7Qww==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.7"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.7.tgz",
+      "integrity": "sha512-cIw1SFP0bi0CUBiJ2jzp99ws3OJNQDfStcHq9Z0iHWzItmiIikihFO+npR8C80yDlp7ZuBCLXCcKjgWjHicksA==",
+      "license": "MIT"
     },
     "node_modules/@fortawesome/angular-fontawesome": {
       "version": "4.0.0",
@@ -9351,6 +9373,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.4.tgz",
+      "integrity": "sha512-iKP6+uJXn+XcfRgYfGPE3+mqCoODV2vATrXDLo/YkYgIdelJHJPBEbc0GZThipAYPuk+8QJFiPgOfblU085ABg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.4",
+        "@formatjs/icu-messageformat-parser": "3.5.7"
       }
     },
     "node_modules/ip-address": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "dayjs": "1.11.20",
     "esbuild": "0.27.7",
     "franc-min": "6.2.0",
+    "intl-messageformat": "^11.2.4",
     "keycloak-js": "26.2.2",
     "ngx-image-cropper": "9.1.6",
     "ngx-quill": "30.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "dayjs": "1.11.20",
     "esbuild": "0.27.7",
     "franc-min": "6.2.0",
-    "intl-messageformat": "^11.2.4",
+    "intl-messageformat": "11.2.4",
     "keycloak-js": "26.2.2",
     "ngx-image-cropper": "9.1.6",
     "ngx-quill": "30.0.1",

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -12,7 +12,7 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { NgbDateAdapter } from '@ng-bootstrap/ng-bootstrap';
 import './config/dayjs';
-import { MissingTranslationHandler, provideTranslateService } from '@ngx-translate/core';
+import { MissingTranslationHandler, TranslateCompiler, provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { DatePipe } from '@angular/common';
@@ -36,6 +36,7 @@ import { AuthInterceptor } from './core/interceptor/auth.interceptor';
 import { ErrorHandlerInterceptor } from './core/interceptor/error-handler.interceptor';
 import { NotificationInterceptor } from './core/interceptor/notification.interceptor';
 import { AuthFacadeService } from './core/auth/auth-facade.service';
+import { IcuTranslateCompiler } from './shared/language/icu-translate-compiler';
 import { PrimengTranslationService } from './shared/language/primeng-translation.service';
 
 /**
@@ -87,6 +88,10 @@ export const appConfig: ApplicationConfig = {
         useFactory: missingTranslationHandler,
       },
     }),
+    {
+      provide: TranslateCompiler,
+      useClass: IcuTranslateCompiler,
+    },
     provideHttpClient(withInterceptorsFromDi()),
     Title,
     { provide: LOCALE_ID, useValue: 'en' },

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -472,7 +472,11 @@
           <jhi-message
             [severity]="hasCriticalCompliance() ? 'error' : 'warn'"
             classStyling="py-1"
-            [message]="complianceBannerKey()"
+            [message]="
+              hasCriticalCompliance()
+                ? 'jobCreationForm.reviewPageSection.complianceBanner.critical'
+                : 'jobCreationForm.reviewPageSection.complianceBanner.warning'
+            "
             [translationParams]="{
               criticalCount: complianceCriticalCount(),
               othersCount: complianceCount() - complianceCriticalCount(),

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -295,25 +295,6 @@ export class JobCreationFormComponent {
   /** Whether any critical compliance issue exists */
   readonly hasCriticalCompliance = computed(() => this.complianceCriticalCount() > 0);
 
-  /**
-   * Translation key for the compliance banner message, picked by cardinality of the
-   * critical and non-critical counts. Uses discrete keys instead of ICU plural syntax
-   * so the default ngx-translate compiler can render the strings.
-   * @returns the i18n key under jobCreationForm.reviewPageSection.complianceBanner
-   */
-  readonly complianceBannerKey = computed(() => {
-    const critical = this.complianceCriticalCount();
-    const others = this.complianceCount() - critical;
-    const base = 'jobCreationForm.reviewPageSection.complianceBanner';
-    if (critical > 0) {
-      const c = critical === 1 ? 'one' : 'other';
-      if (others === 0) return `${base}.critical.${c}Alone`;
-      const o = others === 1 ? 'OneOther' : 'OtherOthers';
-      return `${base}.critical.${c}With${o}`;
-    }
-    return `${base}.warning.${others === 1 ? 'one' : 'other'}`;
-  });
-
   /** The compliance issue currently shown in the popover (undefined = none is hovered). */
   readonly activePopoverIssue = signal<ComplianceIssue | undefined>(undefined);
 

--- a/src/main/webapp/app/shared/language/icu-translate-compiler.ts
+++ b/src/main/webapp/app/shared/language/icu-translate-compiler.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@angular/core';
+import {
+  InterpolatableTranslation,
+  InterpolatableTranslationObject,
+  TranslateCompiler,
+  TranslationObject,
+} from '@ngx-translate/core';
+import { IntlMessageFormat } from 'intl-messageformat';
+
+/**
+ * ngx-translate compiler that delegates to intl-messageformat (formatjs) so
+ * translation strings can use ICU MessageFormat syntax — `{count, plural, ...}`,
+ * `{gender, select, ...}`, etc. — on top of the default `{paramName}` interpolation.
+ *
+ * Replaces ngx-translate-messageformat-compiler, whose @messageformat/core
+ * dependency is CommonJS-only and broke prod-build bootstrap.
+ */
+type Renderer = (params?: Record<string, unknown>) => string;
+
+@Injectable({ providedIn: 'root' })
+export class IcuTranslateCompiler extends TranslateCompiler {
+  private readonly cache = new Map<string, Renderer>();
+
+  /**
+   * Compile one translation string. Strings without ICU placeholders are
+   * returned untouched so simple lookups stay zero-overhead. Strings with
+   * placeholders are wrapped in a renderer function that ngx-translate calls
+   * with the parameter map at lookup time. Renderers are cached per (lang, value)
+   * so repeated lookups don't re-parse the ICU source.
+   * @param value - the raw translation string
+   * @param lang - the target locale (e.g. `en`, `de`)
+   * @returns the original string, or a cached renderer function accepting params
+   */
+  compile(value: string, lang: string): InterpolatableTranslation {
+    if (!value.includes('{')) {
+      return value;
+    }
+    const key = `${lang}::${value}`;
+    let renderer = this.cache.get(key);
+    if (!renderer) {
+      const mf = new IntlMessageFormat(value, lang);
+      renderer = (params): string => String(mf.format(params ?? {}));
+      this.cache.set(key, renderer);
+    }
+    return renderer;
+  }
+
+  /**
+   * Walk a translations payload and compile every string leaf. Non-string
+   * leaves are returned as-is, preserving the input tree shape.
+   * @param translations - the translation tree (string or nested object)
+   * @param lang - the target locale
+   * @returns the compiled tree, structurally identical to the input
+   */
+  compileTranslations(translations: TranslationObject, lang: string): InterpolatableTranslationObject {
+    const out: InterpolatableTranslationObject = {};
+    for (const key of Object.keys(translations)) {
+      out[key] = this.compileLeaf(translations[key], lang);
+    }
+    return out;
+  }
+
+  /**
+   * Compile a single translation leaf (string, array, or nested object).
+   * @param value - the leaf value to compile
+   * @param lang - the target locale
+   * @returns the compiled leaf, structurally identical to the input
+   */
+  private compileLeaf(value: unknown, lang: string): InterpolatableTranslation {
+    if (typeof value === 'string') {
+      return this.compile(value, lang);
+    }
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(item => this.compileLeaf(item, lang));
+    }
+    if (typeof value === 'object') {
+      return this.compileTranslations(value as TranslationObject, lang);
+    }
+    return value as InterpolatableTranslation;
+  }
+}

--- a/src/main/webapp/app/shared/language/icu-translate-compiler.ts
+++ b/src/main/webapp/app/shared/language/icu-translate-compiler.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  InterpolatableTranslation,
-  InterpolatableTranslationObject,
-  TranslateCompiler,
-  TranslationObject,
-} from '@ngx-translate/core';
+import { InterpolatableTranslation, InterpolatableTranslationObject, TranslateCompiler, TranslationObject } from '@ngx-translate/core';
 import { IntlMessageFormat } from 'intl-messageformat';
 
 /**
@@ -38,7 +33,7 @@ export class IcuTranslateCompiler extends TranslateCompiler {
     const key = `${lang}::${value}`;
     let renderer = this.cache.get(key);
     if (!renderer) {
-      const mf = new IntlMessageFormat(value, lang);
+      const mf = new IntlMessageFormat(value, lang, undefined, { ignoreTag: true });
       renderer = (params): string => String(mf.format(params ?? {}));
       this.cache.set(key, renderer);
     }

--- a/src/main/webapp/i18n/de/job.json
+++ b/src/main/webapp/i18n/de/job.json
@@ -265,18 +265,8 @@
       "title": "Übersicht",
       "complianceBanner": {
         "complianceCheckOngoing": "<b>Laufende Compliance-Prüfung:</b> Deine Stelle wird auf die Einhaltung rechtlicher Standards und universitärer Vorgaben geprüft. Dies kann einen Moment dauern.",
-        "critical": {
-          "oneAlone": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannten kritischen AGG-Verstoß, um Compliance sicherzustellen.",
-          "otherAlone": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannte kritische AGG-Verstöße, um Compliance sicherzustellen.",
-          "oneWithOneOther": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannten kritischen AGG-Verstoß und {othersCount} weiteres Problem, um Compliance sicherzustellen.",
-          "oneWithOtherOthers": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannten kritischen AGG-Verstoß und {othersCount} weitere Probleme, um Compliance sicherzustellen.",
-          "otherWithOneOther": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannte kritische AGG-Verstöße und {othersCount} weiteres Problem, um Compliance sicherzustellen.",
-          "otherWithOtherOthers": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} erkannte kritische AGG-Verstöße und {othersCount} weitere Probleme, um Compliance sicherzustellen."
-        },
-        "warning": {
-          "one": "<b>Verbesserungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {othersCount} festgestelltes Compliance-Problem.",
-          "other": "<b>Verbesserungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {othersCount} festgestellte Compliance-Probleme."
-        },
+        "critical": "<b>Handlungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {criticalCount} {criticalCount, plural, =1 {erkannten kritischen AGG-Verstoß} other {erkannte kritische AGG-Verstöße}}{othersCount, plural, =0 {} other { und {othersCount} {othersCount, plural, =1 {weiteres Problem} other {weitere Probleme}}}}, um Compliance sicherzustellen.",
+        "warning": "<b>Verbesserungsbedarf:</b> Bitte <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">überprüfe</a> {othersCount} {othersCount, plural, =1 {festgestelltes Compliance-Problem} other {festgestellte Compliance-Probleme}}.",
         "default": "Bitte überprüfe deine Eingaben, bevor du die Doktorandenstelle veröffentlichst."
       }
     },

--- a/src/main/webapp/i18n/en/job.json
+++ b/src/main/webapp/i18n/en/job.json
@@ -265,18 +265,8 @@
       "title": "Overview",
       "complianceBanner": {
         "complianceCheckOngoing": "<b>Compliance Check Ongoing:</b> Your job is being analyzed for compliance with legal and university standards. This may take a moment.",
-        "critical": {
-          "oneAlone": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violation to ensure compliance.",
-          "otherAlone": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violations to ensure compliance.",
-          "oneWithOneOther": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violation and {othersCount} further issue to ensure compliance.",
-          "oneWithOtherOthers": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violation and {othersCount} further issues to ensure compliance.",
-          "otherWithOneOther": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violations and {othersCount} further issue to ensure compliance.",
-          "otherWithOtherOthers": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG violations and {othersCount} further issues to ensure compliance."
-        },
-        "warning": {
-          "one": "<b>Improvement Needed:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {othersCount} identified compliance issue.",
-          "other": "<b>Improvement Needed:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {othersCount} identified compliance issues."
-        },
+        "critical": "<b>Action Required:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {criticalCount} detected critical AGG {criticalCount, plural, =1 {violation} other {violations}}{othersCount, plural, =0 {} other { and {othersCount} further {othersCount, plural, =1 {issue} other {issues}}}} to ensure compliance.",
+        "warning": "<b>Improvement Needed:</b> Please <a tabindex=\"0\" class=\"underline cursor-pointer stepper-link\">review</a> {othersCount} identified compliance {othersCount, plural, =1 {issue} other {issues}}.",
         "default": "Please review your entries before publishing the doctorate position."
       }
     },

--- a/src/test/webapp/app/shared/language/icu-translate-compiler.spec.ts
+++ b/src/test/webapp/app/shared/language/icu-translate-compiler.spec.ts
@@ -1,0 +1,58 @@
+import { IcuTranslateCompiler } from 'app/shared/language/icu-translate-compiler';
+
+describe('IcuTranslateCompiler', () => {
+  let compiler: IcuTranslateCompiler;
+
+  beforeEach(() => {
+    compiler = new IcuTranslateCompiler();
+  });
+
+  it('should return plain strings without placeholders unchanged', () => {
+    expect(compiler.compile('Plain text', 'en')).toBe('Plain text');
+  });
+
+  it('should interpolate simple parameters', () => {
+    const result = compiler.compile('Hello {name}', 'en');
+    expect(typeof result).toBe('function');
+    expect((result as (p: Record<string, unknown>) => string)({ name: 'Anna' })).toBe('Hello Anna');
+  });
+
+  it('should select singular form for English plural at count=1', () => {
+    const result = compiler.compile('{count, plural, =1 {issue} other {issues}}', 'en');
+    expect((result as (p: Record<string, unknown>) => string)({ count: 1 })).toBe('issue');
+  });
+
+  it('should select plural form for English plural at count=5', () => {
+    const result = compiler.compile('{count, plural, =1 {issue} other {issues}}', 'en');
+    expect((result as (p: Record<string, unknown>) => string)({ count: 5 })).toBe('issues');
+  });
+
+  it('should select German singular form at count=1', () => {
+    const result = compiler.compile('{n, plural, =1 {ein Problem} other {{n} Probleme}}', 'de');
+    expect((result as (p: Record<string, unknown>) => string)({ n: 1 })).toBe('ein Problem');
+  });
+
+  it('should compile a translations tree recursively', () => {
+    const tree = {
+      title: 'Plain',
+      nested: {
+        greeting: 'Hi {name}',
+        leafNumber: 42,
+      },
+    };
+    const compiled = compiler.compileTranslations(tree, 'en') as {
+      title: string;
+      nested: { greeting: (p: Record<string, unknown>) => string; leafNumber: number };
+    };
+    expect(compiled.title).toBe('Plain');
+    expect(typeof compiled.nested.greeting).toBe('function');
+    expect(compiled.nested.greeting({ name: 'Anna' })).toBe('Hi Anna');
+    expect(compiled.nested.leafNumber).toBe(42);
+  });
+
+  it('should cache compiled message instances per locale and source', () => {
+    const a = compiler.compile('{n, plural, =1 {x} other {y}}', 'en');
+    const b = compiler.compile('{n, plural, =1 {x} other {y}}', 'en');
+    expect(a).toBe(b);
+  });
+});

--- a/src/test/webapp/app/shared/language/icu-translate-compiler.spec.ts
+++ b/src/test/webapp/app/shared/language/icu-translate-compiler.spec.ts
@@ -39,8 +39,8 @@ describe('IcuTranslateCompiler', () => {
         greeting: 'Hi {name}',
         leafNumber: 42,
       },
-    };
-    const compiled = compiler.compileTranslations(tree, 'en') as {
+    } as unknown as Parameters<IcuTranslateCompiler['compileTranslations']>[0];
+    const compiled = compiler.compileTranslations(tree, 'en') as unknown as {
       title: string;
       nested: { greeting: (p: Record<string, unknown>) => string; leafNumber: number };
     };


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2473. Builds on top of #2471. That PR removed ICU plural syntax from the compliance banner translations because the previous compiler dependency (`ngx-translate-messageformat-compiler` + the CommonJS-only `@messageformat/core`) crashed prod-build bootstrap on the test server with `TypeError: Yi is not a function` thrown from a vendor static initializer. The interim fix was correct but loses general-purpose ICU pluralization support across the whole app.

This PR restores ICU plural support — and unlocks `select`/`selectordinal`/`number`/`date` formatting for any future use — by swapping in an ESM-native compiler.

### Description

- New file `src/main/webapp/app/shared/language/icu-translate-compiler.ts` — `IcuTranslateCompiler` extends ngx-translate's `TranslateCompiler` and delegates to `intl-messageformat` (formatjs, `"type": "module"`, pure ESM, all transitive deps ESM). Renderers are cached per (lang, value) so repeated lookups don't re-parse the ICU source.
- New unit test `src/test/webapp/app/shared/language/icu-translate-compiler.spec.ts` — covers plain strings, simple interpolation, English plural (singular/plural branches), German plural at count=1, recursive tree compilation, and renderer caching.
- Registered the compiler in `src/main/webapp/app/app.config.ts` via `{ provide: TranslateCompiler, useClass: IcuTranslateCompiler }`.
- Restored the original ICU plural strings in `i18n/{en,de}/job.json` for `complianceBanner.critical` and `complianceBanner.warning`.
- Reverted the cardinality-key picker (`complianceBannerKey`) and the matching template binding from #2471 — the inline ternary is sufficient again because the compiler handles the plural cases.
- Added `intl-messageformat@11.2.4` to `package.json`.

### Why this works where the previous library didn't

`@messageformat/core@3.x` ships only CJS (`"main": "lib/messageformat.js"`) plus a UMD `"browser"` build. When esbuild's CJS-interop wrapper kicks in, chunk composition shifts in a way that leaves Angular core symbols undefined at the time PrimeNG's `static ɵmod`/`static ɵinj` blocks run during module evaluation — only reproducible in the deployed prod artifact, not local prod builds. `intl-messageformat@11.2.4` is `"type": "module"` with ESM-only dependencies, so esbuild treats it as a normal ESM import and chunk evaluation order stays consistent with what the Angular linker emits. The `ngx-translate-messageformat-compiler` package itself is removed.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a professor
2. Open the job creation form and reach Step 4 (Review)
3. With AI enabled, trigger compliance issues with these count combinations and confirm the banner reads grammatically in both EN and DE:
    - 1 critical, 0 others → singular violation, no "and..." clause
    - 2+ critical, 0 others → plural violations, no "and..." clause
    - 1 critical, 1 other → singular violation + "and 1 further issue"
    - 1 critical, 2+ others → singular violation + "and N further issues"
    - 2+ critical, 1 other → plural violations + "and 1 further issue"
    - 2+ critical, 2+ others → plural violations + "and N further issues"
    - 0 critical, 1 other → "1 identified compliance issue"
    - 0 critical, 2+ others → "N identified compliance issues"
4. Confirm the analyzing state still shows the `complianceCheckOngoing` message and the no-issues state still shows the `default` message.
5. Confirm the deployed test server bootstraps cleanly (no `Yi is not a function` in the console).
6. Run `npm run test -- icu-translate-compiler` and confirm 7 tests pass.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] All eight cardinality combinations render correctly in EN
- [ ] All eight cardinality combinations render correctly in DE
- [ ] Test server bootstraps without console errors
- [ ] Vitest unit suite for `IcuTranslateCompiler` passes

### Screenshots

<!-- Add screenshots demonstrating each cardinality variant. -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 0.00% | 1166 | 130 | 11.1 |
| icu-translate-compiler.ts | 92.30% | 43 | 11 | 25.6 |

_Last updated: 2026-05-07 18:11:18 UTC_

