### PR TITLE
`Bugfix`: Stop running the combined testdata dump in the Lighthouse import

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -483,7 +483,7 @@ jobs:
           while IFS= read -r file; do
             echo "Running $file"
             docker exec -i "$MYSQL_CONTAINER" mysql -h 127.0.0.1 -P 3306 -u root --password="" tumapply < "$file"
-          done < <(find src/main/resources/testdata -type f -name "*.sql" ! -name "00_drop_all_tables.sql" | sort)
+          done < <(find src/main/resources/testdata -type f -name "*.sql" ! -name "00_drop_all_tables.sql" ! -path "*/combined/*" | sort)
 
       - name: Build Lighthouse URL List
         id: lighthouse-urls


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

Closes #2477.

The Lighthouse step in `pr-check.yml` started failing after `ab4373617` introduced `src/main/resources/testdata/combined/tumapply-testdata-combined.sql`. The workflow imports every SQL file under `testdata/` after the app starts, so it ends up running each individual seed file and then the combined dump on top. The combined dump's first statement re-runs the user cleanup from `01_users.sql`, which now fails with FK 1451 because `user_research_group_roles` already references those users from the prior `03_user_roles.sql` run.

Local `import-testdata.sh` already excludes `*/combined/*` for the same reason — the workflow just never got the same exclusion.

### Description

- One-line change to the `find` invocation in the "Import Lighthouse Test Data" step: add `! -path "*/combined/*"` so the combined dump is skipped, exactly like the local importer does.

### Steps for Testing

Prerequisites:

1. Watch the "Import Lighthouse Test Data" step on this PR and confirm it imports the individual seed files but skips `combined/tumapply-testdata-combined.sql`.
2. Confirm the step exits 0 and no FK 1451 error appears.
3. The downstream Lighthouse run should proceed as normal.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] PR check Lighthouse import step succeeds and skips the combined dump