### PR TITLE
`General`: Restore the 20 testdata professors in the realm config

### DIFF
--- a/docker/local-setup/realm-config/tumapply-realm.json
+++ b/docker/local-setup/realm-config/tumapply-realm.json
@@ -132,6 +132,294 @@
       ]
     },
     {
+      "id": "00000000-0000-0000-0000-000000000109",
+      "username": "professor3",
+      "enabled": true,
+      "email": "professor3@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor3",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000110",
+      "username": "professor4",
+      "enabled": true,
+      "email": "professor4@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor4",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000111",
+      "username": "professor5",
+      "enabled": true,
+      "email": "professor5@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor5",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000112",
+      "username": "professor6",
+      "enabled": true,
+      "email": "professor6@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor6",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000113",
+      "username": "professor7",
+      "enabled": true,
+      "email": "professor7@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor7",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000114",
+      "username": "professor8",
+      "enabled": true,
+      "email": "professor8@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor8",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000115",
+      "username": "professor9",
+      "enabled": true,
+      "email": "professor9@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor9",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000116",
+      "username": "professor10",
+      "enabled": true,
+      "email": "professor10@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor10",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000117",
+      "username": "professor11",
+      "enabled": true,
+      "email": "professor11@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor11",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000118",
+      "username": "professor12",
+      "enabled": true,
+      "email": "professor12@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor12",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000119",
+      "username": "professor13",
+      "enabled": true,
+      "email": "professor13@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor13",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000120",
+      "username": "professor14",
+      "enabled": true,
+      "email": "professor14@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor14",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000121",
+      "username": "professor15",
+      "enabled": true,
+      "email": "professor15@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor15",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000122",
+      "username": "professor16",
+      "enabled": true,
+      "email": "professor16@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor16",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000123",
+      "username": "professor17",
+      "enabled": true,
+      "email": "professor17@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor17",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000124",
+      "username": "professor18",
+      "enabled": true,
+      "email": "professor18@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor18",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000125",
+      "username": "professor19",
+      "enabled": true,
+      "email": "professor19@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor19",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000126",
+      "username": "professor20",
+      "enabled": true,
+      "email": "professor20@tumapply.local",
+      "emailVerified": true,
+      "firstName": "Professor20",
+      "lastName": "TUM",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "professor",
+          "temporary": false
+        }
+      ]
+    },
+    {
       "username": "service-account-tumapply-otp-admin",
       "enabled": true,
       "emailVerified": true,


### PR DESCRIPTION
### Checklist

#### General

- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

The revert PR #2491 restored `tumapply-realm.json` to its pre-#2368 contents. As a side effect, the test users `professor3..professor20` that the post-#2368 testdata commit `d39496b05` had appended to the renamed realm file were dropped. The matching SQL testdata still references those professors, so without this PR local Keycloak setups can't resolve them.

### Description

Narrow change to `docker/local-setup/realm-config/tumapply-realm.json`:

- Adds back only the 18 missing user entries (`professor3..professor20`, IDs `...0109` through `...0126`).
- Inserted right before the existing `service-account-tumapply-otp-admin` entry, matching the formatting of the other professor entries already in the file.
- **Realm name (`tumapply`), `displayName` (`TUMApply Realm`), every client, and the existing service account are left exactly as they are on main.** No structural changes that could break local setups.

### Steps for Testing

Prerequisites:

1. Pull this branch.
2. Bounce the local Keycloak container so it re-imports the realm.
3. In the Keycloak admin UI for the `tumapply` realm, confirm `professor3..professor20` are present and enabled.
4. Log in to TUMApply as `professor5` (password `professor`) and confirm the test research-group assignment from the SQL testdata resolves.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Local Keycloak realm import succeeds
- [ ] `professor3..professor20` log in

### Screenshots

N/A — config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)