### PR TITLE
`Bugfix`: Block banner step until basic info is filled in

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -1773,8 +1773,8 @@ export class JobCreationFormComponent {
    * Defines 4 steps with their templates, navigation buttons, and validation states:
    *
    * 1. Basic Info - Back exits, Next requires basicInfoValid
-   * 2. Position Details - Optional fields, always navigable
-   * 3. Image Selection - Optional, always navigable
+   * 2. Position Details - Disabled until Step 1 is valid
+   * 3. Image Selection - Disabled until Steps 1 and 2 are valid
    * 4. Summary - Shows publish button instead of next
    *
    * @returns Array of StepData objects for the ProgressStepperComponent
@@ -1884,7 +1884,7 @@ export class JobCreationFormComponent {
             changePanel: true,
           },
         ],
-        disabled: !this.positionDetailsValid(),
+        disabled: !(this.basicInfoValid() && this.positionDetailsValid()),
         status: templates.status,
       });
     }

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -536,19 +536,22 @@ describe('JobCreationFormComponent', () => {
 
     it('should toggle image step disabled with form validity', () => {
       mockAllPanelTemplates(component);
+      const imageStepDisabled = (): boolean | undefined =>
+        getPrivate(component)
+          .buildStepData()
+          .find((s: Step) => s.name.includes('imageSelection'))?.disabled;
+
       component.basicInfoValid.set(false);
       component.positionDetailsValid.set(false);
-      let imageStep = getPrivate(component)
-        .buildStepData()
-        .find(s => s.name.includes('imageSelection'));
-      expect(imageStep?.disabled).toBe(true);
+      expect(imageStepDisabled()).toBe(true);
+
+      component.basicInfoValid.set(false);
+      component.positionDetailsValid.set(true);
+      expect(imageStepDisabled()).toBe(true);
 
       component.basicInfoValid.set(true);
       component.positionDetailsValid.set(true);
-      imageStep = getPrivate(component)
-        .buildStepData()
-        .find(s => s.name.includes('imageSelection'));
-      expect(imageStep?.disabled).toBe(false);
+      expect(imageStepDisabled()).toBe(false);
     });
   });
 


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2235.

In the job creation wizard, professors could click the *Banner Image* step (Step 3) before filling in the required fields in *Basic Information* (Step 1). The wizard's `disabled` flag on Step 3 was only gating on `positionDetailsValid`, but Step 2 has no required fields, so that signal is always `true` — the step was effectively always navigable. This caused the out-of-order navigation reported in the issue.

### Description

- `job-creation-form.component.ts`: Step 3's `disabled` now requires both `basicInfoValid && positionDetailsValid`, matching the existing Step 4 gating. The JSDoc above `buildStepData` is updated to reflect what each step actually gates on.
- `job-creation-form.component.spec.ts`: Tightened the existing `'should toggle image step disabled with form validity'` test so it also asserts the case where Step 1 is invalid but Step 2 is valid — the exact case that previously slipped through.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a professor.
2. Open *Create a new Doctorate Position*.

Test:

1. Without filling any Step 1 fields, try to click the *Banner Image* indicator (desktop) or the corresponding progress bar segment (mobile). The step should be disabled and the panel should not change.
2. Fill the required Step 1 fields (title, research area, subject area, supervising professor, location, description). Step 2 unlocks; Step 3 stays locked while only Step 1 is valid.
3. Advance to Step 2, then to Step 3 via the *Next* buttons. Both should now be reachable, and the banner picker renders as expected.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Step 3 cannot be reached with Step 1 empty
- [ ] Step 3 can be reached once Step 1 is valid

### Screenshots

_See linked issue for the original out-of-order navigation; UI itself is unchanged when steps are valid._

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| job-creation-form.component.ts | 68.74% | 1189 | 72 | 6.1 |

_Last updated: 2026-05-14 08:58:52 UTC_

