### PR TITLE
`General`: Silence the JDK native-access warning from Netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,15 @@ springBoot {
   mainClass = "de.tum.cit.aet.TumApplyApp"
 }
 
+// Netty's NativeLibraryUtil calls System.loadLibrary at startup, which JDK 24+
+// flags as a restricted method when invoked from an unnamed module (Netty is
+// on the classpath, not on the module path). Explicitly enabling native access
+// for ALL-UNNAMED suppresses the warning the JDK itself recommends. The same
+// flag is added to test tasks in gradle/test.gradle.
+tasks.named("bootRun") {
+  jvmArgs += "--enable-native-access=ALL-UNNAMED"
+}
+
 test {
   useJUnitPlatform()
   exclude "**/*IT*", "**/*IntTest*"

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -9,6 +9,10 @@ tasks.withType(Test).configureEach {
   // See: https://github.com/weaviate/java-client?tab=readme-ov-file#gson-and-reflective-access-to-internal-jdk-classes
   // This is harmless: it only opens java.lang to classpath code within the same JVM process and does not expand the attack surface for remote exploits.
   jvmArgs += "--add-opens=java.base/java.lang=ALL-UNNAMED"
+  // Silences the JDK 24+ warning emitted by Netty's NativeLibraryUtil when it
+  // calls System.loadLibrary from the unnamed module. Same flag also added to
+  // the bootRun task in build.gradle.
+  jvmArgs += "--enable-native-access=ALL-UNNAMED"
 
   // Forward Gradle command-line -D properties to the test JVM for database type selection
   // (e.g. -Dzonky.test.database.type=MYSQL selects MySQL testcontainers instead of H2)


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

Every server startup (locally via \`./gradlew bootRun\` and inside test runs) currently emits this block of warnings on JDK 24+:

\`\`\`
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/…/netty-common-4.2.10.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
\`\`\`

The startup still succeeds, but the noise is confusing to anyone bootstrapping the project for the first time ("did something go wrong?") and the same lines pollute every \`gradle test\` run. The JDK message also explicitly notes that "Restricted methods will be blocked in a future release," so the warning is also a deadline: when the JDK flips the default, the server won't start at all without the flag.

The warning comes from Netty calling \`System.loadLibrary\` to bring in its native transport. Netty is on the classpath, not on the module path, so it counts as an "unnamed module" — and JDK 24+ requires those modules to declare native-access intent up front (JEP 472 / JEP 502).

### Description

Pass the exact flag the JDK itself recommends in the warning text — \`--enable-native-access=ALL-UNNAMED\` — to the two JVMs where the warning shows up:

- **\`bootRun\` (\`build.gradle\`):** added a \`tasks.named("bootRun") { jvmArgs += "--enable-native-access=ALL-UNNAMED" }\` block near the existing \`bootRun\` configuration. Applies to both dev and prod profiles since it lives in the root \`build.gradle\`.
- **All Test tasks (\`gradle/test.gradle\`):** appended the same flag to the existing \`tasks.withType(Test).configureEach { jvmArgs += … }\` block, alongside the Mockito agent and the Weaviate-related \`--add-opens\`. Comments cross-reference the other location so the duplication is intentional and discoverable.

No code change, no dependency bump — only Gradle JVM arg config.

### Steps for Testing

1. Run \`./gradlew test --tests "*TemplateProcessingServiceTest*"\` (or any small server test). Confirm no \`WARNING:\` lines about \`System::loadLibrary\` / \`NativeLibraryUtil\` / \`enable-native-access\` appear in stdout. Before this PR, you'd see four of them per JVM start.
2. Run \`./gradlew bootRun\` against a working dev stack. Confirm the same warning block is absent from the startup log.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] \`./gradlew test\` produces no native-access warnings
- [ ] \`./gradlew bootRun\` produces no native-access warnings

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-05-14 14:21:18 UTC_

