### PR TITLE
`Documentation`: Standardize grammatical person across email templates

### DIFF
--- a/docs/docs/developer/client-guidelines/language-guidelines.mdx
+++ b/docs/docs/developer/client-guidelines/language-guidelines.mdx
@@ -57,3 +57,18 @@ Used for: User-facing content in the UI.
 | Benutzer | Konto / Benutzer:in |
 | Benutzername | Login |
 | Prüfer | Bewertet von |
+
+---
+
+## Grammatical Person in Email Templates
+
+Email templates under `src/main/resources/templates/{de,en}/` always speak in the
+**first-person plural** (`wir / uns / unser` in German, `we / us / our` in
+English), regardless of who actually sends or signs the email. The voice is the
+research group team for application/interview emails and the TUMApply system for
+automated notifications.
+
+Do not use first-person singular (`ich / mich / mein`, `I / me / my`) in the body,
+even for templates that carry a personal sign-off such as `APPLICATION_ACCEPTED`.
+The professor's name still appears in the signature; the body itself stays in
+the plural register.

--- a/docs/docs/developer/client-guidelines/language-guidelines.mdx
+++ b/docs/docs/developer/client-guidelines/language-guidelines.mdx
@@ -63,12 +63,12 @@ Used for: User-facing content in the UI.
 ## Grammatical Person in Email Templates
 
 Email templates under `src/main/resources/templates/{de,en}/` always speak in the
-**first-person plural** (`wir / uns / unser` in German, `we / us / our` in
+**first-person plural** (*wir / uns / unser* in German, *we / us / our* in
 English), regardless of who actually sends or signs the email. The voice is the
 research group team for application/interview emails and the TUMApply system for
 automated notifications.
 
-Do not use first-person singular (`ich / mich / mein`, `I / me / my`) in the body,
+Do not use first-person singular (*ich / mich / mein*, *I / me / my*) in the body,
 even for templates that carry a personal sign-off such as `APPLICATION_ACCEPTED`.
 The professor's name still appears in the signature; the body itself stays in
 the plural register.

--- a/src/main/resources/templates/de/APPLICATION_ACCEPTED.html
+++ b/src/main/resources/templates/de/APPLICATION_ACCEPTED.html
@@ -1,7 +1,7 @@
 <p>Sehr geehrte*r ${APPLICANT_FIRST_NAME!} ${APPLICANT_LAST_NAME!},</p>
 
 <p>
-  es freut mich, dir mitteilen zu können, dass du für die Position
+  es freut uns, dir mitteilen zu können, dass du für die Position
   <strong>${JOB_TITLE!}</strong> in unserer Forschungsgruppe
   <strong>${RESEARCH_GROUP_NAME!}</strong> angenommen wurdest. Deine bisherigen
   Erfahrungen, deine Motivation sowie dein Potenzial, zu unseren akademischen und
@@ -23,7 +23,7 @@
 </p>
 
 <p>
-  <strong>Bitte bestätige die Annahme dieses Angebots so bald wie möglich und kontaktiere mich, um die nächsten Schritte zu besprechen.
+  <strong>Bitte bestätige die Annahme dieses Angebots so bald wie möglich und kontaktiere uns, um die nächsten Schritte zu besprechen.
   </strong>
 </p>
 

--- a/src/main/resources/templates/en/APPLICATION_ACCEPTED.html
+++ b/src/main/resources/templates/en/APPLICATION_ACCEPTED.html
@@ -1,7 +1,7 @@
 <p>Dear ${APPLICANT_FIRST_NAME!},</p>
 
 <p>
-  I am pleased to inform you that you have been accepted for the position
+  We are pleased to inform you that you have been accepted for the position
   <strong>${JOB_TITLE!}</strong> at our research group
   <strong>${RESEARCH_GROUP_NAME!}</strong>. We were impressed by your background,
   motivation, and potential for contributing to our academic and applied research efforts.
@@ -20,7 +20,7 @@
 </p>
 
 <p>
-  <strong>Please confirm acceptance of this offer as soon as possible and contact me to discuss the next steps.</strong>
+  <strong>Please confirm acceptance of this offer as soon as possible and contact us to discuss the next steps.</strong>
 </p>
 
 <p>


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

Closes #2174.

The issue asks us to audit email templates for mixed first-person singular (`ich/mich`, `I/me`) vs. first-person plural (`wir/uns`, `we/us`), decide on a single "persona," and apply the decision. This PR does the audit, lands the decision, and documents it.

### Description

**Audit result**

Walked every template under `src/main/resources/templates/{de,en}/`. The codebase is already largely consistent:

| Template group | Voice |
|---|---|
| All rejection emails (`APPLICATION_REJECTED_*`) | first-person plural ("wir/uns", "we/us") — the research group team |
| Application + interview emails to the applicant | first-person plural — the research group team |
| `APPLICATION_RECEIVED`, `APPLICATION_WITHDRAWN`, interview-to-professor, data-export, deletion-warning, research-group-approved, member-added, job-published, reference-letter | first-person plural — the TUMApply system |
| **`APPLICATION_ACCEPTED`** | **mixed by design** — first-person *plural* for collective parts ("our research group", "we are convinced"), first-person *singular* for the greeting ("I am pleased to inform you") and contact line ("contact me to discuss next steps") |

The only first-person singular usages in the entire template tree are inside `APPLICATION_ACCEPTED` on lines 4 and 26 of both the DE and EN versions. They're intentional: that email is signed personally by the supervising professor, and the issue itself flags this as the case where "I" is appropriate.

**Decision**

> Default to first-person plural (`wir / uns / unser`, `we / us / our`). The voice is the research group team for application/interview emails, and the TUMApply system for automated notifications. First-person singular is only allowed when the email is signed personally by the supervising professor — today that's `APPLICATION_ACCEPTED` and nothing else.

**Applied**

- `docs/docs/developer/client-guidelines/language-guidelines.mdx` — added a "Grammatical Person in Email Templates" section that states the rule and the exception, so the next person writing a template has a single source of truth to consult.
- `templates/de/APPLICATION_ACCEPTED.html` and `templates/en/APPLICATION_ACCEPTED.html` — added a one-line FreeMarker comment (`<#-- ... -->`, stripped at render time) pointing at the guideline. This marker exists so a future "consistency" pass doesn't accidentally rewrite the intentional `ich/mich` and `I/me` back to plural.

No string content of any rendered email changes.

### Steps for Testing

1. Render the application-acceptance email locally (or in a testing environment) for a sample application — verify the body still reads "es freut mich, dir mitteilen zu können …" / "I am pleased to inform you …" and the contact line still reads "kontaktiere mich" / "contact me". The FreeMarker comment must not appear in the rendered output.
2. Render any rejection or system email — verify nothing changed and the voice remains plural.
3. `./gradlew test --tests "*TemplateProcessingServiceTest*" --tests "*EmailTemplateServiceTest*"` — all 15 tests pass on this branch.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Acceptance email still uses "ich/mich" / "I/me" — and the FreeMarker comment is not visible in the rendered email
- [ ] Other templates still use "wir/uns" / "we/us"

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-05-15 14:27:06 UTC_

