### PR TITLE
`Bugfix`: Fix Docusaurus deploy workflow after the pnpm migration

### DIFF
--- a/.github/workflows/deploy-user-documentation.yml
+++ b/.github/workflows/deploy-user-documentation.yml
@@ -16,6 +16,9 @@ concurrency:
   group: 'pages'
   cancel-in-progress: false
 
+env:
+  NODE_VERSION: 24
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '${{ env.node }}'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
           cache-dependency-path: docs/pnpm-lock.yaml
 


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

After #2509 migrated the docs project from npm to pnpm, the `Deploy Docusaurus to GitHub Pages` workflow started failing on every push to `main` with:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

`actions/setup-node` was being passed `node-version: '${{ env.node }}'` — an env var that was never defined — so it silently fell back to Node 20. pnpm 11 needs Node ≥ 22.13 (it imports the `node:sqlite` built-in introduced in Node 22.5+), hence the crash.

### Description

- Added a workflow-level `env: NODE_VERSION: 24` block — same convention already used by `pr-check.yml`.
- Switched the `setup-node` step to reference `${{ env.NODE_VERSION }}` instead of the undefined `${{ env.node }}` placeholder.

No other workflow file references `env.node`, so this is the only location that needs the fix.

### Steps for Testing

Prerequisites:

1. Wait for this PR's `Deploy Docusaurus to GitHub Pages` workflow to run (it triggers on `docs/**` pushes; alternatively trigger via `workflow_dispatch` once merged).
2. Confirm the run picks Node 24 in the `Setup pnpm` / `Setup Node` step and the `pnpm install --frozen-lockfile` + `pnpm run build` steps both complete successfully.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Docusaurus deploy workflow runs green after merge to `main`.

### Test Coverage

<!-- N/A: pure CI workflow change. -->