### PR TITLE
`Bugfix`: Stop pnpm from skipping the Docusaurus install on CI

### DIFF
--- a/.github/workflows/deploy-user-documentation.yml
+++ b/.github/workflows/deploy-user-documentation.yml
@@ -36,7 +36,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        run: pnpm install --frozen-lockfile
+        # --ignore-workspace stops pnpm from walking up to the repo-root
+        # `pnpm-workspace.yaml` (which scopes the main app, not the docs site)
+        # and silently no-op'ing the install for `docs/`.
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Build Docusaurus site
         working-directory: docs


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

After the previous CI fix (#2533) bumped the docs deploy to Node 24, the workflow now fails at the build step:

```
Run pnpm run build
Already up to date
Done in 284ms using pnpm v11.1.1
$ docusaurus build
sh: 1: docusaurus: not found
[ELIFECYCLE] Command failed.
```

The repo has `pnpm-workspace.yaml` at the root, but it only carries pnpm config (`nodeLinker`, `preferFrozenLockfile`, `allowBuilds`) and **no `packages:`** field. When `pnpm install --frozen-lockfile` runs with `working-directory: docs`, pnpm walks up, finds the workspace file at the repo root and treats THAT as the install root. The docs project is outside the (implicit, empty) workspace, so the install becomes a no-op — `node_modules/.bin/docusaurus` never lands and the build step crashes.

### Description

Added `--ignore-workspace` to the docs install command. This tells pnpm to ignore any parent `pnpm-workspace.yaml` and treat `docs/` as a standalone project, so `docs/pnpm-lock.yaml` is honoured and the docusaurus CLI is actually installed into `docs/node_modules/.bin`.

Left a short comment in the workflow explaining why the flag is there, since the failure mode is non-obvious.

### Steps for Testing

Prerequisites:

1. Wait for this PR's `Deploy Docusaurus to GitHub Pages` job (it triggers on `docs/**` pushes; trigger via `workflow_dispatch` after merge if you don't want to touch docs).
2. Confirm `Install dependencies` shows real package fetches (not "Already up to date"), and that `Build Docusaurus site` finds the `docusaurus` CLI and runs `docusaurus build` to completion.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Docs deploy workflow runs green after merge.