### PR TITLE
`Bugfix`: Stop pnpm from erroring on core-js postinstall in the docs deploy

### DIFF
--- a/.github/workflows/deploy-user-documentation.yml
+++ b/.github/workflows/deploy-user-documentation.yml
@@ -36,10 +36,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        # --ignore-workspace stops pnpm from walking up to the repo-root
-        # `pnpm-workspace.yaml` (which scopes the main app, not the docs site)
-        # and silently no-op'ing the install for `docs/`.
-        run: pnpm install --frozen-lockfile --ignore-workspace
+        run: pnpm install --frozen-lockfile
 
       - name: Build Docusaurus site
         working-directory: docs

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: false
+  core-js-pure: false


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

After #2534 unblocked the docs install with \`--ignore-workspace\`, the next docs deploy still failed:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: core-js-pure@3.49.0, core-js@3.49.0
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: Process completed with exit code 1.
\`\`\`

\`--ignore-workspace\` solved the no-op install, but it also discards the root \`pnpm-workspace.yaml\`'s \`allowBuilds\` table, so pnpm 11 had no allow-list for the \`core-js\` / \`core-js-pure\` postinstall scripts and bailed out with the new fatal \`ERR_PNPM_IGNORED_BUILDS\` error. Trying to put the allow-list back via \`pnpm.onlyBuiltDependencies\` in \`docs/package.json\` had no effect — pnpm only honours the \`pnpm-workspace.yaml\` form here, and writing one to docs/ while \`--ignore-workspace\` was on caused pnpm to overwrite the file back to placeholders on every install.

### Description

- Added a tiny \`docs/pnpm-workspace.yaml\` that explicitly marks \`core-js\` and \`core-js-pure\` as **not** allowed to run scripts (\`false\`). Their postinstall just prints donation messages, so silently skipping them is what we want, and giving pnpm an explicit decision is what makes it stop erroring.
- This file also doubles as a "workspace anchor": pnpm stops walking up at the first \`pnpm-workspace.yaml\` it finds, so the docs install now reads \`docs/\` as its own project and actually populates \`docs/node_modules\`.
- Dropped \`--ignore-workspace\` from the \`pnpm install\` step in the workflow — it is now redundant *and* harmful, because the same flag was the reason the workspace file kept getting wiped on every install.

I reproduced the original CI failure locally (\`Already up to date\` no-op install + \`docusaurus: not found\`) and the second failure (\`ERR_PNPM_IGNORED_BUILDS\` exit 1) before this PR, then verified that with both changes applied a fresh \`pnpm install --frozen-lockfile\` in \`docs/\` installs all 1215 packages cleanly, exits 0, and leaves the workspace file intact.

### Steps for Testing

Prerequisites:

1. Wait for this PR's \`Deploy Docusaurus to GitHub Pages\` workflow run.
2. Confirm:
   - The \`Install dependencies\` step shows real package fetches (not \`Already up to date\`) and exits cleanly without the \`ERR_PNPM_IGNORED_BUILDS\` error.
   - The \`Build Docusaurus site\` step finds the \`docusaurus\` CLI.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Docusaurus deploy workflow installs clean and runs the build.