### PR TITLE
`General`: Bump Pages deploy actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/deploy-user-documentation.yml
+++ b/.github/workflows/deploy-user-documentation.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

The Docusaurus deploy currently warns:

\`\`\`
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/deploy-pages@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.
\`\`\`

Both Pages actions cut a v5 in 2026: \`actions/deploy-pages@v5.0.0\` declares \`using: 'node24'\`, and \`actions/upload-pages-artifact@v5.0.0\` is a composite action whose Node-based sub-steps are Node 24. Bumping both to v5 clears the deprecation warning before the September 2026 cutoff and avoids the rushed migration once Node 20 is removed.

### Description

- \`.github/workflows/deploy-user-documentation.yml\`: \`actions/upload-pages-artifact@v4\` → \`@v5\`, \`actions/deploy-pages@v4\` → \`@v5\`.

No other behavioural change; the workflow shape and inputs are identical between v4 and v5.

### Steps for Testing

- After merge, the next \`Deploy Docusaurus to GitHub Pages\` run on \`main\` should:
  - No longer print the Node 20 deprecation warning for \`actions/deploy-pages\`.
  - Still produce the same Pages deployment (same artifact, same URL).

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Deploy workflow green after merge with no Node 20 deprecation notice.