### PR TITLE
`General`: Bump pnpm/action-setup to v6 (Node 24)

### DIFF
--- a/.github/workflows/deploy-user-documentation.yml
+++ b/.github/workflows/deploy-user-documentation.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -266,7 +266,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -394,7 +394,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

### Motivation and Context

After #2539 silenced the Node 20 warning for the Pages deploy job, the docs build job (and \`pr-check\`) still emit:

\`\`\`
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: pnpm/action-setup@v4.
\`\`\`

\`pnpm/action-setup@v4\` is hard-coded to \`using: node20\`. The maintainers cut **v6.x** (latest: 6.0.8, May 2026) which declares \`using: node24\`. Bumping to v6 clears the warning before the 2026-09-16 runner cutoff.

### Description

- \`.github/workflows/deploy-user-documentation.yml\`: \`pnpm/action-setup@v4 → @v6\`.
- \`.github/workflows/pr-check.yml\`: same bump applied to all three usages in the file so CI is consistent.

No input / output changes between v4 and v6 for how we use the action (we don't pass a \`version:\` input — it reads \`packageManager\` from \`package.json\`, which still resolves to the same pinned pnpm@11.1.1).

### Steps for Testing

- After merge, the next run of \`Deploy Docusaurus to GitHub Pages\` and \`PR check\` should no longer print the \`pnpm/action-setup@v4\` Node 20 deprecation warning.
- pnpm should still resolve to 11.1.1 in the install logs.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Docs deploy run on \`main\` shows no Node 20 deprecation warning.
- [ ] PR check on this PR shows no \`pnpm/action-setup\` Node 20 deprecation warning.