### PR TITLE
`General`: Update toggle button into red/green style

### DIFF
--- a/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.html
+++ b/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.html
@@ -2,6 +2,14 @@
   [ngModel]="model()"
   (ngModelChange)="onChange($event)"
   [disabled]="disabled()"
-  [class]="classStyling()"
+  [class]="toggleClass()"
   [ngModelOptions]="{ standalone: true }"
-/>
+>
+  <ng-template #handle let-checked="checked">
+    <fa-icon
+      class="jhi-toggle-switch__icon text-[0.55rem] leading-none"
+      [ngClass]="checked ? 'text-positive-default' : 'text-negative-default'"
+      [icon]="checked ? enabledIcon : disabledIcon"
+    />
+  </ng-template>
+</p-toggleSwitch>

--- a/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.html
+++ b/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.html
@@ -8,7 +8,8 @@
   <ng-template #handle let-checked="checked">
     <fa-icon
       class="jhi-toggle-switch__icon text-[0.55rem] leading-none"
-      [ngClass]="checked ? 'text-positive-default' : 'text-negative-default'"
+      [class.text-positive-strong]="checked"
+      [class.text-negative-strong]="!checked"
       [icon]="checked ? enabledIcon : disabledIcon"
     />
   </ng-template>

--- a/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
@@ -1,4 +1,6 @@
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -7,7 +9,7 @@ import { ToggleSwitchModule } from 'primeng/toggleswitch';
   selector: 'jhi-toggle-switch',
   standalone: true,
   templateUrl: './toggle-switch.component.html',
-  imports: [CommonModule, ToggleSwitchModule, FormsModule],
+  imports: [CommonModule, ToggleSwitchModule, FormsModule, FontAwesomeModule],
 })
 export class ToggleSwitchComponent {
   /**
@@ -29,6 +31,27 @@ export class ToggleSwitchComponent {
    * Optional style class passed to PrimeNG ToggleSwitch.
    */
   classStyling = input<string>('');
+
+  readonly enabledIcon = faCheck;
+  readonly disabledIcon = faXmark;
+
+  readonly toggleClass = computed(() =>
+    [
+      'jhi-toggle-switch',
+      '[&_.p-toggleswitch-slider]:border-negative-default',
+      '[&_.p-toggleswitch-slider]:bg-negative-default',
+      '[&_.p-toggleswitch-slider]:transition-colors',
+      '[&_.p-toggleswitch-handle]:flex',
+      '[&_.p-toggleswitch-handle]:items-center',
+      '[&_.p-toggleswitch-handle]:justify-center',
+      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:border-positive-default',
+      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:bg-positive-default',
+      '[&.p-disabled]:opacity-70',
+      this.classStyling(),
+    ]
+      .filter(Boolean)
+      .join(' '),
+  );
 
   onChange(value: boolean): void {
     this.modelChange.emit(value);

--- a/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
@@ -47,7 +47,6 @@ export class ToggleSwitchComponent {
       '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:bg-positive-strong',
       '[&.p-disabled_.p-toggleswitch-slider]:!bg-background-disabled',
       '[&.p-disabled_.p-toggleswitch-slider]:!border-border-default',
-      '[&.p-disabled]:opacity-70',
       this.classStyling(),
     ]
       .filter(Boolean)

--- a/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/toggle-switch/toggle-switch.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, input, output } from '@angular/core';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
@@ -9,7 +8,7 @@ import { ToggleSwitchModule } from 'primeng/toggleswitch';
   selector: 'jhi-toggle-switch',
   standalone: true,
   templateUrl: './toggle-switch.component.html',
-  imports: [CommonModule, ToggleSwitchModule, FormsModule, FontAwesomeModule],
+  imports: [ToggleSwitchModule, FormsModule, FontAwesomeModule],
 })
 export class ToggleSwitchComponent {
   /**
@@ -38,14 +37,16 @@ export class ToggleSwitchComponent {
   readonly toggleClass = computed(() =>
     [
       'jhi-toggle-switch',
-      '[&_.p-toggleswitch-slider]:border-negative-default',
-      '[&_.p-toggleswitch-slider]:bg-negative-default',
+      '[&_.p-toggleswitch-slider]:border-negative-strong',
+      '[&_.p-toggleswitch-slider]:bg-negative-strong',
       '[&_.p-toggleswitch-slider]:transition-colors',
       '[&_.p-toggleswitch-handle]:flex',
       '[&_.p-toggleswitch-handle]:items-center',
       '[&_.p-toggleswitch-handle]:justify-center',
-      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:border-positive-default',
-      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:bg-positive-default',
+      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:border-positive-strong',
+      '[&.p-toggleswitch-checked_.p-toggleswitch-slider]:bg-positive-strong',
+      '[&.p-disabled_.p-toggleswitch-slider]:!bg-background-disabled',
+      '[&.p-disabled_.p-toggleswitch-slider]:!border-border-default',
       '[&.p-disabled]:opacity-70',
       this.classStyling(),
     ]

--- a/src/main/webapp/content/scss/_tokens.scss
+++ b/src/main/webapp/content/scss/_tokens.scss
@@ -51,7 +51,7 @@
   --color-positive-active: var(--p-success-active-color);
   --color-positive-disabled: var(--p-success-disabled-color);
   // Darker variant for state indicators on light surfaces (>=3:1 contrast)
-  --color-positive-strong: var(--p-success-600);
+  --color-positive-strong: var(--p-success-hover-color);
 
   // Warning Semantic Colors
   --color-warning-DEFAULT: var(--p-warn-color);
@@ -67,7 +67,7 @@
   --color-negative-active: var(--p-danger-active-color);
   --color-negative-disabled: var(--p-danger-disabled-color);
   // Darker variant for state indicators on light surfaces (>=3:1 contrast)
-  --color-negative-strong: var(--p-danger-600);
+  --color-negative-strong: var(--p-danger-hover-color);
 
   // Accent Semantic Colors (TUM accent / contrast palette)
   --color-accent-DEFAULT: var(--p-accent-color);

--- a/src/main/webapp/content/scss/_tokens.scss
+++ b/src/main/webapp/content/scss/_tokens.scss
@@ -50,6 +50,8 @@
   --color-positive-hover: var(--p-success-hover-color);
   --color-positive-active: var(--p-success-active-color);
   --color-positive-disabled: var(--p-success-disabled-color);
+  // Darker variant for state indicators on light surfaces (>=3:1 contrast)
+  --color-positive-strong: var(--p-success-600);
 
   // Warning Semantic Colors
   --color-warning-DEFAULT: var(--p-warn-color);
@@ -64,6 +66,8 @@
   --color-negative-hover: var(--p-danger-hover-color);
   --color-negative-active: var(--p-danger-active-color);
   --color-negative-disabled: var(--p-danger-disabled-color);
+  // Darker variant for state indicators on light surfaces (>=3:1 contrast)
+  --color-negative-strong: var(--p-danger-600);
 
   // Accent Semantic Colors (TUM accent / contrast palette)
   --color-accent-DEFAULT: var(--p-accent-color);

--- a/src/main/webapp/content/theming/shared-theme-config.ts
+++ b/src/main/webapp/content/theming/shared-theme-config.ts
@@ -403,6 +403,16 @@ export const sharedComponentConfig = {
     handle: {
       size: '0.8rem',
     },
+    colorScheme: {
+      dark: {
+        handle: {
+          background: '{surface.900}',
+          hoverBackground: '{surface.900}',
+          checkedBackground: '{surface.900}',
+          checkedHoverBackground: '{surface.900}',
+        },
+      },
+    },
   },
   popover: {
     root: {

--- a/src/main/webapp/content/theming/shared-theme-config.ts
+++ b/src/main/webapp/content/theming/shared-theme-config.ts
@@ -391,8 +391,8 @@ export const sharedComponentConfig = {
   },
   toggleswitch: {
     root: {
-      width: '2rem',
-      height: '1rem',
+      width: '2.5rem',
+      height: '1.25rem',
       focusRing: {
         width: '0',
         color: 'transparent',
@@ -401,7 +401,7 @@ export const sharedComponentConfig = {
       },
     },
     handle: {
-      size: '0.6rem',
+      size: '0.8rem',
     },
   },
   popover: {


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #2542 

### Description

This PR updates the settings toggle to communicate state more clearly by using red for disabled, green for enabled, and thicker on/off icons inside the handle.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to as an applicant
2. Go to settings general and notifications
3. Verify the toggle buttons are now in a red green style
4. Verify the toggle buttons work

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| toggle-switch.component.ts | 90.90% | 40 | ? | ? |

_Last updated: 2026-05-18 01:06:50 UTC_

