### PR TITLE
`Bugfix`: Show no error when user refuses to use passkey

### DIFF
--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -389,6 +389,10 @@ export class AuthFacadeService {
       }
       return response;
     } catch (e) {
+      // Check if passkey had an error because user refused to use passkey
+      if (e instanceof DOMException && e.name === 'NotAllowedError') {
+        return undefined as unknown as T;
+      }
       this.authOrchestrator.setError(errorMessage);
       throw e;
     } finally {

--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -389,7 +389,7 @@ export class AuthFacadeService {
       }
       return response;
     } catch (e) {
-      // Check if passkey had an error because user refused to use passkey
+      // сheck if passkey had an error because user refused to use passkey
       if (e instanceof DOMException && e.name === 'NotAllowedError') {
         return undefined as unknown as T;
       }


### PR DESCRIPTION
### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [X] I tested **all** changes and their related features with **all** corresponding user types.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [X] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [X] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [X] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [X] I documented the TypeScript code using JSDoc style.
- [X] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #2543 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description

<!-- Describe your changes in detail -->
This PR fixes the issue that an "Passkey sign-in failed" error is shown when users refuse to use passkey after choosing the "Sign in with passkey" option.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Go to TUMApply Page. 
2. Choose "Sign in with passkey"
3. Don't pick any passkey and just click "cancel"
4. You should see no error anymore

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1061" height="480" alt="passkey-no-error" src="https://github.com/user-attachments/assets/7951afb1-0c44-49d8-bf75-285ff619fea4" />

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| auth-facade.service.ts | 86.15% | 276 | 58 | 21.0 |

_Last updated: 2026-05-18 15:08:56 UTC_

