### PR TITLE
`General`: Code cleanup imprint page

### DIFF
--- a/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.html
+++ b/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.html
@@ -1,26 +1,14 @@
 <div class="page-container">
-  <div class="max-w-[75rem] mr-auto">
+  <div class="max-w-[75rem] mx-auto">
     <h1 class="text-[2rem] font-bold" jhiTranslate="imprint.headline"></h1>
 
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.publisher.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line leading-8" jhiTranslate="imprint.publisher.contact"></span>
+    @for (section of sections; track section.titleKey) {
+      <section class="mt-8">
+        <h2 class="text-2xl font-semibold mb-4" [jhiTranslate]="section.titleKey"></h2>
 
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.authorized.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line" jhiTranslate="imprint.authorized.text"></span>
-
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.vat.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line" jhiTranslate="imprint.vat.text"></span>
-
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.responsibility.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line leading-8" jhiTranslate="imprint.responsibility.text"></span>
-
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.tou.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line" jhiTranslate="imprint.tou.text"></span>
-
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.liability.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line" jhiTranslate="imprint.liability.text"></span>
-
-    <h2 class="text-2xl font-semibold mt-8 mb-4" jhiTranslate="imprint.links.headline"></h2>
-    <span class="block text-base text-justify whitespace-pre-line" jhiTranslate="imprint.links.text"></span>
+        <span class="block text-base text-justify whitespace-pre-line" [class]="section.extraClasses" [jhiTranslate]="section.contentKey">
+        </span>
+      </section>
+    }
   </div>
 </div>

--- a/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.html
+++ b/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.html
@@ -1,9 +1,11 @@
 <div class="page-container">
   <div class="max-w-[75rem] mx-auto">
-    <h1 class="text-[2rem] font-bold" jhiTranslate="imprint.headline"></h1>
+    <div class="page-header mb-4">
+      <h1 class="text-4xl font-bold" jhiTranslate="imprint.headline"></h1>
+    </div>
 
     @for (section of sections; track section.titleKey) {
-      <section class="mt-8">
+      <section class="mb-8">
         <h2 class="text-2xl font-semibold mb-4" [jhiTranslate]="section.titleKey"></h2>
 
         <span class="block text-base text-justify whitespace-pre-line" [class]="section.extraClasses" [jhiTranslate]="section.contentKey">

--- a/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.ts
+++ b/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.ts
@@ -1,4 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
+
 import TranslateDirective from '../../language/translate.directive';
 
 interface ImprintSection {

--- a/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.ts
+++ b/src/main/webapp/app/shared/pages/imprint-page/imprint-page.component.ts
@@ -1,6 +1,11 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-
 import TranslateDirective from '../../language/translate.directive';
+
+interface ImprintSection {
+  titleKey: string;
+  contentKey: string;
+  extraClasses?: string;
+}
 
 @Component({
   selector: 'jhi-imprint-page',
@@ -9,4 +14,14 @@ import TranslateDirective from '../../language/translate.directive';
   templateUrl: './imprint-page.component.html',
   encapsulation: ViewEncapsulation.None,
 })
-export class ImprintPageComponent {}
+export class ImprintPageComponent {
+  readonly sections: ImprintSection[] = [
+    { titleKey: 'imprint.publisher.headline', contentKey: 'imprint.publisher.contact', extraClasses: 'leading-8' },
+    { titleKey: 'imprint.authorized.headline', contentKey: 'imprint.authorized.text' },
+    { titleKey: 'imprint.vat.headline', contentKey: 'imprint.vat.text' },
+    { titleKey: 'imprint.responsibility.headline', contentKey: 'imprint.responsibility.text', extraClasses: 'leading-8' },
+    { titleKey: 'imprint.tou.headline', contentKey: 'imprint.tou.text' },
+    { titleKey: 'imprint.liability.headline', contentKey: 'imprint.liability.text' },
+    { titleKey: 'imprint.links.headline', contentKey: 'imprint.links.text' },
+  ];
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #2566 

### Description

<!-- Describe your changes in detail -->
* Replaced multiple hardcoded `<h2>` and `<span>` pairs in `imprint-page.component.html` with a single `@for` loop that iterates over a new `sections` array, generating each section dynamically. This greatly reduces code duplication and simplifies future updates.
* Fixed the horizontal alignment of the page container by changing `mr-auto` to `mx-auto` in the outer div, ensuring the content is centered.
* Added `page-header` to be consistent with other pages
* Standardized text size to avoid using rem

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Check that the imprint page looks same except for being centered now

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
<img width="950" height="395" alt="image" src="https://github.com/user-attachments/assets/42e2bbe2-7200-4dcb-af26-b2cdc0703c88" />

After:
<img width="959" height="389" alt="image" src="https://github.com/user-attachments/assets/e14b6a92-241e-49b4-8f17-966bc280199a" />