### PR TITLE
`Development`: Internal user management for applicant authentication (Keycloak external-realm removal)

### DIFF
--- a/src/main/java/de/tum/cit/aet/core/config/AppTokenKeyConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/core/config/AppTokenKeyConfiguration.java
@@ -1,0 +1,162 @@
+package de.tum.cit.aet.core.config;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.util.StringUtils;
+
+/**
+ * Wires the signing material that lets TUMApply mint its own JWTs for applicants.
+ * <p>
+ * The RSA keypair is loaded from configuration (PEM via environment/secret). When no key is configured
+ * an ephemeral keypair is generated at startup — acceptable for local development only; the production
+ * profile fails fast if {@code app.token.rsa-private-key} is missing, because an ephemeral key would
+ * invalidate every session on restart and break a multi-instance deployment.
+ */
+@Slf4j
+@Configuration
+public class AppTokenKeyConfiguration {
+
+    private final String privateKeyPem;
+    private final String publicKeyPem;
+    private final String kid;
+    private final String issuer;
+
+    public AppTokenKeyConfiguration(
+        @Value("${app.token.rsa-private-key:}") String privateKeyPem,
+        @Value("${app.token.rsa-public-key:}") String publicKeyPem,
+        @Value("${app.token.kid:tumapply}") String kid,
+        @Value("${app.token.issuer}") String issuer,
+        Environment environment
+    ) {
+        this.privateKeyPem = privateKeyPem;
+        this.publicKeyPem = publicKeyPem;
+        this.kid = kid;
+        this.issuer = issuer;
+        if (!StringUtils.hasText(privateKeyPem) && environment.acceptsProfiles(Profiles.of("prod"))) {
+            throw new IllegalStateException(
+                "app.token.rsa-private-key (APP_TOKEN_RSA_PRIVATE_KEY) must be set in the prod profile; " +
+                "an ephemeral signing key would invalidate all sessions on restart."
+            );
+        }
+    }
+
+    /**
+     * The RSA JWK used to sign and verify app-issued tokens. Built from the configured PEM keypair,
+     * or generated ephemerally when none is configured (dev only).
+     *
+     * @return the RSA signing key (with private key material) and a stable key id
+     */
+    @Bean
+    public RSAKey appSigningRsaKey() {
+        try {
+            RSAPublicKey publicKey;
+            RSAPrivateKey privateKey;
+            if (StringUtils.hasText(privateKeyPem) && StringUtils.hasText(publicKeyPem)) {
+                publicKey = parsePublicKey(publicKeyPem);
+                privateKey = parsePrivateKey(privateKeyPem);
+            } else {
+                log.warn(
+                    "No app.token RSA keypair configured - generating an EPHEMERAL signing key. " +
+                    "Tokens will not survive a restart. Configure APP_TOKEN_RSA_PRIVATE_KEY/PUBLIC_KEY for any shared environment."
+                );
+                KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+                generator.initialize(2048);
+                KeyPair keyPair = generator.generateKeyPair();
+                publicKey = (RSAPublicKey) keyPair.getPublic();
+                privateKey = (RSAPrivateKey) keyPair.getPrivate();
+            }
+            return new RSAKey.Builder(publicKey)
+                .privateKey(privateKey)
+                .keyID(kid)
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .build();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize app token signing key", e);
+        }
+    }
+
+    /**
+     * JWK source backing both the encoder and the published JWKS. Returns a {@link JWKSet} (list) so a
+     * future key rotation only needs to add the new key here while old public keys remain trusted.
+     *
+     * @param appSigningRsaKey the application's RSA signing key
+     * @return an immutable JWK source containing the signing key
+     */
+    @Bean
+    public JWKSource<SecurityContext> appJwkSource(RSAKey appSigningRsaKey) {
+        return new ImmutableJWKSet<>(new JWKSet(appSigningRsaKey));
+    }
+
+    /**
+     * Encoder used by {@code AppTokenService} to sign access and refresh tokens.
+     *
+     * @param appJwkSource the JWK source holding the signing key
+     * @return a Nimbus-backed JWT encoder
+     */
+    @Bean
+    public JwtEncoder appJwtEncoder(JWKSource<SecurityContext> appJwkSource) {
+        return new NimbusJwtEncoder(appJwkSource);
+    }
+
+    /**
+     * Decoder for app-issued tokens. Verifies the signature against the local public key (no network)
+     * and validates the issuer and timestamps. Wired into {@code MultiRealmJwtDecoder} for the app issuer.
+     *
+     * @param appSigningRsaKey the application's RSA signing key (its public part is used to verify)
+     * @return a local decoder for app-issued tokens
+     * @throws JOSEException if the public key cannot be derived from the JWK
+     */
+    @Bean("appJwtDecoder")
+    public JwtDecoder appJwtDecoder(RSAKey appSigningRsaKey) throws JOSEException {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(appSigningRsaKey.toRSAPublicKey())
+            .signatureAlgorithm(SignatureAlgorithm.RS256)
+            .build();
+        decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(issuer));
+        return decoder;
+    }
+
+    private static RSAPrivateKey parsePrivateKey(String pem) throws Exception {
+        byte[] der = Base64.getDecoder().decode(stripPem(pem));
+        return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(der));
+    }
+
+    private static RSAPublicKey parsePublicKey(String pem) throws Exception {
+        byte[] der = Base64.getDecoder().decode(stripPem(pem));
+        return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(der));
+    }
+
+    /**
+     * Normalizes a PEM string (env vars often carry literal {@code \n}) and strips the armor + whitespace,
+     * leaving only the base64 body.
+     */
+    private static String stripPem(String pem) {
+        return pem.replace("\\n", "\n").replaceAll("-----[^-]+-----", "").replaceAll("\\s+", "");
+    }
+}

--- a/src/main/java/de/tum/cit/aet/core/config/JwtDecoderConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/core/config/JwtDecoderConfiguration.java
@@ -1,28 +1,34 @@
 package de.tum.cit.aet.core.config;
 
 import de.tum.cit.aet.core.security.MultiRealmJwtDecoder;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 @Configuration
 public class JwtDecoderConfiguration {
 
     /**
-     * Provides a JwtDecoder that accepts tokens from both Keycloak realms used by the application.
+     * Provides the resource-server {@link JwtDecoder} that accepts tokens from the TUM Keycloak realm
+     * (validated remotely) and from TUMApply's own issuer (validated locally via {@code appJwtDecoder}).
      *
      * @param keycloakUrl base URL of the Keycloak instance
      * @param tumLoginRealm name of the TUM IDP/LDAP realm
-     * @param externalLoginRealm name of the external login realm
-     * @return a decoder that selects the matching realm decoder per token issuer
+     * @param appIssuer issuer URI used by TUMApply for self-issued tokens
+     * @param appJwtDecoder local decoder for app-issued tokens
+     * @return a decoder that selects the matching decoder per token issuer
      */
     @Bean
+    @Primary
     public JwtDecoder jwtDecoder(
         @Value("${keycloak.url}") String keycloakUrl,
         @Value("${keycloak.tum-login-realm}") String tumLoginRealm,
-        @Value("${keycloak.external-login-realm}") String externalLoginRealm
+        @Value("${app.token.issuer}") String appIssuer,
+        @Qualifier("appJwtDecoder") JwtDecoder appJwtDecoder
     ) {
-        return new MultiRealmJwtDecoder(keycloakUrl, tumLoginRealm, externalLoginRealm);
+        return new MultiRealmJwtDecoder(keycloakUrl, tumLoginRealm, appIssuer, appJwtDecoder);
     }
 }

--- a/src/main/java/de/tum/cit/aet/core/config/PasswordEncoderConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/core/config/PasswordEncoderConfiguration.java
@@ -1,0 +1,18 @@
+package de.tum.cit.aet.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Provides the {@link PasswordEncoder} used to hash and verify local user passwords.
+ */
+@Configuration
+public class PasswordEncoderConfiguration {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/core/config/SecurityConfiguration.java
@@ -6,7 +6,7 @@ import de.tum.cit.aet.core.security.CustomJwtAuthenticationConverter;
 import de.tum.cit.aet.core.security.SpaWebFilter;
 import de.tum.cit.aet.core.util.CookieUtils;
 import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
-import de.tum.cit.aet.usermanagement.service.KeycloakAuthenticationService;
+import de.tum.cit.aet.usermanagement.service.TokenRefreshDispatcher;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.text.ParseException;
@@ -38,21 +38,21 @@ public class SecurityConfiguration {
 
     private final CustomJwtAuthenticationConverter customJwtAuthenticationConverter;
     private final CorsFilter corsFilter;
-    private final KeycloakAuthenticationService keycloakAuthenticationService;
+    private final TokenRefreshDispatcher tokenRefreshDispatcher;
     private final Set<String> trustedIssuers;
 
     public SecurityConfiguration(
         CustomJwtAuthenticationConverter customJwtAuthenticationConverter,
         CorsFilter corsFilter,
-        KeycloakAuthenticationService keycloakAuthenticationService,
+        TokenRefreshDispatcher tokenRefreshDispatcher,
         @Value("${keycloak.url}") String keycloakUrl,
         @Value("${keycloak.tum-login-realm}") String tumLoginRealm,
-        @Value("${keycloak.external-login-realm}") String externalLoginRealm
+        @Value("${app.token.issuer}") String appIssuer
     ) {
         this.customJwtAuthenticationConverter = customJwtAuthenticationConverter;
         this.corsFilter = corsFilter;
-        this.keycloakAuthenticationService = keycloakAuthenticationService;
-        this.trustedIssuers = Set.of(realmIssuer(keycloakUrl, tumLoginRealm), realmIssuer(keycloakUrl, externalLoginRealm));
+        this.tokenRefreshDispatcher = tokenRefreshDispatcher;
+        this.trustedIssuers = Set.of(realmIssuer(keycloakUrl, tumLoginRealm), appIssuer);
     }
 
     /**
@@ -219,7 +219,7 @@ public class SecurityConfiguration {
                     !refreshCookie.getValue().isBlank() &&
                     hasUntrustedIssuer(accessCookie.getValue())
                 ) {
-                    AuthResponseDTO tokens = keycloakAuthenticationService.refreshTokens(accessCookie.getValue(), refreshCookie.getValue());
+                    AuthResponseDTO tokens = tokenRefreshDispatcher.refresh(accessCookie.getValue(), refreshCookie.getValue());
                     writeAuthCookies(tokens);
                     return tokens.accessToken();
                 }
@@ -227,7 +227,7 @@ public class SecurityConfiguration {
             } else if (
                 (accessCookie == null || accessCookie.getValue() == null || accessCookie.getValue().isBlank()) && refreshCookie != null
             ) {
-                AuthResponseDTO tokens = keycloakAuthenticationService.refreshTokens(null, refreshCookie.getValue());
+                AuthResponseDTO tokens = tokenRefreshDispatcher.refresh(null, refreshCookie.getValue());
                 writeAuthCookies(tokens);
                 return tokens.accessToken();
             }

--- a/src/main/java/de/tum/cit/aet/core/security/MultiRealmJwtDecoder.java
+++ b/src/main/java/de/tum/cit/aet/core/security/MultiRealmJwtDecoder.java
@@ -16,28 +16,40 @@ import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * Decodes JWTs from multiple trusted Keycloak issuers by selecting the matching decoder from the token's {@code iss}
- * claim before validating the token.
+ * Decodes JWTs from multiple trusted issuers by selecting the matching decoder from the token's {@code iss}
+ * claim before validating the token. Trusts the TUM Keycloak realm (validated remotely against its JWKS) and
+ * TUMApply's own issuer (validated in-process against the application's public key).
  */
 public class MultiRealmJwtDecoder implements JwtDecoder {
 
     private final Set<String> trustedIssuers;
+    private final String appIssuer;
+    private final JwtDecoder appDecoder;
     private final Function<String, JwtDecoder> decoderFactory;
     private final ConcurrentMap<String, JwtDecoder> decoders = new ConcurrentHashMap<>();
 
     /**
-     * Creates a decoder that trusts JWTs issued by the given Keycloak realms.
+     * Creates a decoder that trusts the TUM Keycloak realm and the application's own issuer.
      *
      * @param keycloakUrl base URL of the Keycloak instance
      * @param tumLoginRealm name of the TUM IDP/LDAP realm
-     * @param externalLoginRealm name of the external login realm
+     * @param appIssuer issuer URI used by TUMApply for its self-issued tokens
+     * @param appDecoder decoder that validates app-issued tokens locally (no network)
      */
-    public MultiRealmJwtDecoder(String keycloakUrl, String tumLoginRealm, String externalLoginRealm) {
-        this(keycloakUrl, tumLoginRealm, externalLoginRealm, JwtDecoders::fromIssuerLocation);
+    public MultiRealmJwtDecoder(String keycloakUrl, String tumLoginRealm, String appIssuer, JwtDecoder appDecoder) {
+        this(keycloakUrl, tumLoginRealm, appIssuer, appDecoder, JwtDecoders::fromIssuerLocation);
     }
 
-    MultiRealmJwtDecoder(String keycloakUrl, String tumLoginRealm, String externalLoginRealm, Function<String, JwtDecoder> decoderFactory) {
-        this.trustedIssuers = trustedIssuers(keycloakUrl, tumLoginRealm, externalLoginRealm);
+    MultiRealmJwtDecoder(
+        String keycloakUrl,
+        String tumLoginRealm,
+        String appIssuer,
+        JwtDecoder appDecoder,
+        Function<String, JwtDecoder> decoderFactory
+    ) {
+        this.appIssuer = appIssuer;
+        this.appDecoder = appDecoder;
+        this.trustedIssuers = trustedIssuers(keycloakUrl, tumLoginRealm, appIssuer);
         this.decoderFactory = decoderFactory;
     }
 
@@ -46,6 +58,9 @@ public class MultiRealmJwtDecoder implements JwtDecoder {
         String issuer = extractIssuer(token);
         if (!trustedIssuers.contains(issuer)) {
             throw new BadJwtException("Untrusted token issuer");
+        }
+        if (issuer.equals(appIssuer)) {
+            return appDecoder.decode(token);
         }
         return decoders.computeIfAbsent(issuer, decoderFactory).decode(token);
     }
@@ -63,10 +78,12 @@ public class MultiRealmJwtDecoder implements JwtDecoder {
         }
     }
 
-    private static Set<String> trustedIssuers(String keycloakUrl, String tumLoginRealm, String externalLoginRealm) {
+    private static Set<String> trustedIssuers(String keycloakUrl, String tumLoginRealm, String appIssuer) {
         LinkedHashSet<String> issuers = new LinkedHashSet<>();
         addIssuer(issuers, keycloakUrl, tumLoginRealm);
-        addIssuer(issuers, keycloakUrl, externalLoginRealm);
+        if (appIssuer != null && !appIssuer.isBlank()) {
+            issuers.add(appIssuer);
+        }
         return Set.copyOf(issuers);
     }
 

--- a/src/main/java/de/tum/cit/aet/core/service/AppTokenService.java
+++ b/src/main/java/de/tum/cit/aet/core/service/AppTokenService.java
@@ -1,0 +1,220 @@
+package de.tum.cit.aet.core.service;
+
+import de.tum.cit.aet.core.exception.UnauthorizedException;
+import de.tum.cit.aet.usermanagement.domain.AppRefreshToken;
+import de.tum.cit.aet.usermanagement.domain.User;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import de.tum.cit.aet.usermanagement.repository.AppRefreshTokenRepository;
+import de.tum.cit.aet.usermanagement.repository.UserRepository;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Mints and validates the JWTs that TUMApply issues for applicants (replacing Keycloak token exchange
+ * for the external-login realm). Access and refresh tokens are RS256-signed with the application's own
+ * key; refresh tokens are additionally tracked in {@link AppRefreshTokenRepository} so they can be
+ * revoked on logout and rotated (with replay detection) on use.
+ * <p>
+ * Access-token claims are kept compatible with the existing resource-server pipeline: {@code sub} is the
+ * local {@link User#getUserId()} (consumed by {@code CurrentUserService} and {@code AuthenticationService}),
+ * plus {@code email}, {@code given_name}, {@code family_name} and {@code azp}.
+ */
+@Slf4j
+@Service
+public class AppTokenService {
+
+    private static final String CLAIM_TYPE = "typ";
+    private static final String CLAIM_AZP = "azp";
+    private static final String TYPE_ACCESS = "access";
+    private static final String TYPE_REFRESH = "refresh";
+
+    private final JwtEncoder appJwtEncoder;
+    private final JwtDecoder appJwtDecoder;
+    private final AppRefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    private final String issuer;
+    private final String kid;
+    private final String azp;
+    private final long accessTtlSeconds;
+    private final long refreshTtlSeconds;
+
+    public AppTokenService(
+        JwtEncoder appJwtEncoder,
+        @Qualifier("appJwtDecoder") JwtDecoder appJwtDecoder,
+        AppRefreshTokenRepository refreshTokenRepository,
+        UserRepository userRepository,
+        @Value("${app.token.issuer}") String issuer,
+        @Value("${app.token.kid:tumapply}") String kid,
+        @Value("${app.token.azp:tumapply-internal}") String azp,
+        @Value("${app.token.access-ttl-seconds:300}") long accessTtlSeconds,
+        @Value("${app.token.refresh-ttl-seconds:2592000}") long refreshTtlSeconds
+    ) {
+        this.appJwtEncoder = appJwtEncoder;
+        this.appJwtDecoder = appJwtDecoder;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.userRepository = userRepository;
+        this.issuer = issuer;
+        this.kid = kid;
+        this.azp = azp;
+        this.accessTtlSeconds = accessTtlSeconds;
+        this.refreshTtlSeconds = refreshTtlSeconds;
+    }
+
+    /**
+     * Issues a fresh access + refresh token pair for the given (already-provisioned) user and records the
+     * refresh token's id so it can later be revoked.
+     *
+     * @param user the local user to authenticate; must have a {@code userId}
+     * @return tokens and their lifetimes, shaped for {@code CookieUtils.setAuthCookies}
+     */
+    @Transactional
+    public AuthResponseDTO issueFor(User user) {
+        Instant now = Instant.now();
+        String accessToken = mintAccessToken(user, now);
+        String refreshJti = UUID.randomUUID().toString();
+        String refreshToken = mintRefreshToken(user, refreshJti, now);
+
+        AppRefreshToken record = new AppRefreshToken();
+        record.setJti(refreshJti);
+        record.setUserId(user.getUserId());
+        record.setCreatedAt(now);
+        record.setExpiresAt(now.plusSeconds(refreshTtlSeconds));
+        refreshTokenRepository.save(record);
+
+        return new AuthResponseDTO(accessToken, refreshToken, accessTtlSeconds, refreshTtlSeconds);
+    }
+
+    /**
+     * Validates a refresh token and rotates it: the presented token is revoked and a new pair is issued.
+     * Reuse of an already-revoked token is treated as theft and revokes every active token for that user.
+     *
+     * @param refreshToken the refresh token from the client's cookie
+     * @return a freshly issued token pair
+     * @throws UnauthorizedException if the token is invalid, expired, unknown, or revoked
+     */
+    @Transactional
+    public AuthResponseDTO refresh(String refreshToken) {
+        Jwt jwt = decodeRefreshToken(refreshToken);
+        String jti = jwt.getId();
+        UUID userId = parseSubject(jwt);
+
+        AppRefreshToken record = refreshTokenRepository.findById(jti).orElseThrow(() -> new UnauthorizedException("Unknown refresh token"));
+
+        if (record.isRevoked()) {
+            // Replay of a rotated/revoked token: revoke the whole family.
+            refreshTokenRepository.revokeAllForUser(userId);
+            log.warn("Refresh token replay detected for user {}; revoked all sessions", userId);
+            throw new UnauthorizedException("Refresh token already used");
+        }
+
+        refreshTokenRepository.revokeIfActive(jti);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new UnauthorizedException("User no longer exists"));
+        return issueFor(user);
+    }
+
+    /**
+     * Revokes the given refresh token (logout). No-op if the token is invalid or already revoked.
+     *
+     * @param refreshToken the refresh token to revoke
+     */
+    @Transactional
+    public void revoke(String refreshToken) {
+        try {
+            Jwt jwt = decodeRefreshToken(refreshToken);
+            refreshTokenRepository.revokeIfActive(jwt.getId());
+        } catch (UnauthorizedException ex) {
+            log.debug("Ignoring revoke of invalid refresh token: {}", ex.getMessage());
+        }
+    }
+
+    /**
+     * Revokes every active refresh token for a user (e.g. global sign-out).
+     *
+     * @param userId the user whose tokens should be revoked
+     */
+    @Transactional
+    public void revokeAllForUser(UUID userId) {
+        refreshTokenRepository.revokeAllForUser(userId);
+    }
+
+    /**
+     * @return the configured issuer URI used for app-minted tokens
+     */
+    public String getIssuer() {
+        return issuer;
+    }
+
+    private String mintAccessToken(User user, Instant now) {
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+            .issuer(issuer)
+            .subject(user.getUserId().toString())
+            .issuedAt(now)
+            .expiresAt(now.plusSeconds(accessTtlSeconds))
+            .id(UUID.randomUUID().toString())
+            .claim(CLAIM_AZP, azp)
+            .claim(CLAIM_TYPE, TYPE_ACCESS)
+            .claim("email", Objects.requireNonNullElse(user.getEmail(), ""))
+            .claim("given_name", Objects.requireNonNullElse(user.getFirstName(), ""))
+            .claim("family_name", Objects.requireNonNullElse(user.getLastName(), ""))
+            .build();
+        return encode(claims);
+    }
+
+    private String mintRefreshToken(User user, String jti, Instant now) {
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+            .issuer(issuer)
+            .subject(user.getUserId().toString())
+            .issuedAt(now)
+            .expiresAt(now.plusSeconds(refreshTtlSeconds))
+            .id(jti)
+            .claim(CLAIM_AZP, azp)
+            .claim(CLAIM_TYPE, TYPE_REFRESH)
+            .build();
+        return encode(claims);
+    }
+
+    private String encode(JwtClaimsSet claims) {
+        JwsHeader header = JwsHeader.with(SignatureAlgorithm.RS256).keyId(kid).build();
+        return appJwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+    }
+
+    private Jwt decodeRefreshToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new UnauthorizedException("Missing refresh token");
+        }
+        Jwt jwt;
+        try {
+            jwt = appJwtDecoder.decode(refreshToken);
+        } catch (JwtException ex) {
+            throw new UnauthorizedException("Invalid refresh token", ex);
+        }
+        if (!TYPE_REFRESH.equals(jwt.getClaimAsString(CLAIM_TYPE))) {
+            throw new UnauthorizedException("Token is not a refresh token");
+        }
+        return jwt;
+    }
+
+    private UUID parseSubject(Jwt jwt) {
+        try {
+            return UUID.fromString(jwt.getSubject());
+        } catch (IllegalArgumentException | NullPointerException ex) {
+            throw new UnauthorizedException("Refresh token has an invalid subject", ex);
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/core/web/JwksResource.java
+++ b/src/main/java/de/tum/cit/aet/core/web/JwksResource.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.core.web;
+
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Publishes the public JSON Web Key Set used to verify app-issued JWTs, so external/native clients and
+ * future token consumers can validate TUMApply's tokens. The resource server itself verifies app tokens
+ * in-process via the {@code appJwtDecoder} bean and does not call this endpoint.
+ */
+@RestController
+public class JwksResource {
+
+    private final JWKSource<SecurityContext> appJwkSource;
+
+    public JwksResource(JWKSource<SecurityContext> appJwkSource) {
+        this.appJwkSource = appJwkSource;
+    }
+
+    /**
+     * @return the JWK set containing only public key parameters
+     * @throws KeySourceException if the key set cannot be read
+     */
+    @GetMapping("/.well-known/jwks.json")
+    public Map<String, Object> jwks() throws KeySourceException {
+        JWKSet publicKeys = new JWKSet(appJwkSource.get(new JWKSelector(new JWKMatcher.Builder().build()), null));
+        return publicKeys.toJSONObject(); // public parameters only
+    }
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/domain/AppRefreshToken.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/domain/AppRefreshToken.java
@@ -1,0 +1,57 @@
+package de.tum.cit.aet.usermanagement.domain;
+
+import de.tum.cit.aet.core.domain.export.NoUserDataExportRequired;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+
+/**
+ * Tracks a refresh token issued by {@code AppTokenService} so it can be revoked on logout and
+ * rotated on use. Refresh tokens are self-contained signed JWTs; this table records their {@code jti}
+ * (token id) and revocation state to give the otherwise-stateless tokens server-side revocation and
+ * replay detection.
+ */
+@Getter
+@Setter
+@Entity
+@NoUserDataExportRequired(reason = "Security session tokens are not exported to users")
+@Table(
+    name = "app_refresh_token",
+    indexes = { @Index(name = "idx_art_user", columnList = "user_id"), @Index(name = "idx_art_expires_at", columnList = "expires_at") }
+)
+public class AppRefreshToken implements Serializable {
+
+    @Id
+    @Column(name = "jti", nullable = false, updatable = false, length = 36)
+    private String jti;
+
+    @JdbcTypeCode(Types.VARCHAR)
+    @Column(name = "user_id", nullable = false, length = 36)
+    private UUID userId;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked", nullable = false)
+    private boolean revoked = false;
+
+    @PrePersist
+    void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/domain/User.java
@@ -38,6 +38,21 @@ public class User extends AbstractAuditingEntity {
     @Column(name = "email", nullable = false)
     private String email;
 
+    /**
+     * BCrypt hash of the user's password for local (in-app) authentication.
+     * {@code null} for users who only authenticate via OTP, a federated provider or a passkey,
+     * and for TUM staff who authenticate through Keycloak.
+     */
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    /**
+     * Whether the user's email address has been verified (e.g. via an OTP or a federated provider
+     * that asserts a verified email). Local password login requires a verified email.
+     */
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified = false;
+
     @Column(name = "avatar", length = 512)
     private String avatar;
 

--- a/src/main/java/de/tum/cit/aet/usermanagement/repository/AppRefreshTokenRepository.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/repository/AppRefreshTokenRepository.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.usermanagement.repository;
+
+import de.tum.cit.aet.usermanagement.domain.AppRefreshToken;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for {@link AppRefreshToken} records used to revoke and rotate app-issued refresh tokens.
+ */
+@Repository
+public interface AppRefreshTokenRepository extends JpaRepository<AppRefreshToken, String> {
+    /**
+     * Marks a single refresh-token id as revoked if it is currently active (exists and not yet revoked).
+     *
+     * @param jti the refresh token id to revoke
+     * @return the number of rows updated (0 if the token is unknown or already revoked)
+     */
+    @Modifying
+    @Query("update AppRefreshToken t set t.revoked = true where t.jti = :jti and t.revoked = false")
+    int revokeIfActive(@Param("jti") String jti);
+
+    /**
+     * Revokes every active refresh token belonging to the given user (used on logout and on replay detection).
+     *
+     * @param userId the user whose tokens should be revoked
+     * @return the number of rows updated
+     */
+    @Modifying
+    @Query("update AppRefreshToken t set t.revoked = true where t.userId = :userId and t.revoked = false")
+    int revokeAllForUser(@Param("userId") UUID userId);
+
+    /**
+     * Deletes all refresh-token records that expired before the given instant (scheduled cleanup).
+     *
+     * @param now the cutoff instant
+     * @return the number of rows deleted
+     */
+    @Modifying
+    @Query("delete from AppRefreshToken t where t.expiresAt < :now")
+    int deleteExpired(@Param("now") Instant now);
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/LocalAuthenticationService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/LocalAuthenticationService.java
@@ -1,0 +1,43 @@
+package de.tum.cit.aet.usermanagement.service;
+
+import de.tum.cit.aet.core.exception.UnauthorizedException;
+import de.tum.cit.aet.core.service.AppTokenService;
+import de.tum.cit.aet.usermanagement.domain.User;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Authenticates applicants with email and a locally stored password hash, replacing the Keycloak password
+ * grant for the decommissioned external-login realm. On success it mints app-issued tokens via
+ * {@link AppTokenService}. TUM staff continue to authenticate through Keycloak and never use this path.
+ */
+@Service
+public class LocalAuthenticationService {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final AppTokenService appTokenService;
+
+    public LocalAuthenticationService(UserService userService, PasswordEncoder passwordEncoder, AppTokenService appTokenService) {
+        this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
+        this.appTokenService = appTokenService;
+    }
+
+    /**
+     * Verifies the given credentials and issues an app session on success.
+     *
+     * @param email       the user's email
+     * @param rawPassword the plaintext password
+     * @return app-issued access and refresh tokens
+     * @throws UnauthorizedException if the user does not exist, has no local password, or the password is wrong
+     */
+    public AuthResponseDTO loginWithCredentials(String email, String rawPassword) {
+        User user = userService.findByEmail(email).orElseThrow(() -> new UnauthorizedException("Invalid username or password"));
+        if (user.getPasswordHash() == null || rawPassword == null || !passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
+            throw new UnauthorizedException("Invalid username or password");
+        }
+        return appTokenService.issueFor(user);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/OtpFlowService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/OtpFlowService.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.usermanagement.service;
 
 import de.tum.cit.aet.core.exception.EmailVerificationFailedException;
+import de.tum.cit.aet.core.service.AppTokenService;
 import de.tum.cit.aet.core.util.CookieUtils;
 import de.tum.cit.aet.core.util.StringUtil;
 import de.tum.cit.aet.usermanagement.constants.OtpPurpose;
@@ -12,33 +13,25 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 
 /**
- * Service that orchestrates the OTP completion flows, including user login, registration,
- * and application email verification, with integration to Keycloak for user management
- * and authentication token handling.
+ * Orchestrates the OTP completion flows (login and registration) using TUMApply's internal user
+ * management. The OTP itself is verified by {@link EmailVerificationService}; this service then provisions
+ * the local user and mints app-issued tokens via {@link AppTokenService} (no Keycloak involvement).
  */
 @Service
 public class OtpFlowService {
 
     private final UserService userService;
-    private final KeycloakUserService keycloakUserService;
-    private final KeycloakAuthenticationService keycloakAuthService;
+    private final AppTokenService appTokenService;
     private final EmailVerificationService emailVerificationService;
 
-    public OtpFlowService(
-        UserService userService,
-        KeycloakUserService keycloakUserService,
-        KeycloakAuthenticationService keycloakAuthService,
-        EmailVerificationService emailVerificationService
-    ) {
+    public OtpFlowService(UserService userService, AppTokenService appTokenService, EmailVerificationService emailVerificationService) {
         this.userService = userService;
-        this.keycloakUserService = keycloakUserService;
-        this.keycloakAuthService = keycloakAuthService;
+        this.appTokenService = appTokenService;
         this.emailVerificationService = emailVerificationService;
     }
 
     /**
-     * Orchestrates the OTP completion: first verifies the OTP, then executes the requested purpose.
-     * This method is the single entry point used by the controller.
+     * Verifies the OTP, then executes the requested purpose and sets authentication cookies.
      *
      * @param body     the OTP completion request including email, code, purpose and optional profile
      * @param ip       client IP address used for audit and rate limiting
@@ -57,59 +50,44 @@ public class OtpFlowService {
     }
 
     /**
-     * /**
-     * /**
-     * Handles the OTP completion flow for user login.
-     * <p>
-     * Ensures the user exists, marks their email as verified in Keycloak, and returns token lifetimes.
-     * Authentication cookies will be attached via Keycloak token exchange.
-     * No new user is created; if the user is not found, validation fails and an
-     * {@link EmailVerificationFailedException} is thrown.
+     * Handles the OTP completion flow for user login. The user must already exist; no new user is created.
      *
      * @param body     the OTP completion request
-     * @param response the HTTP response to which authentication cookies will be added via Keycloak token exchange
+     * @param response the HTTP response to which authentication cookies will be added
      * @return an {@link AuthSessionInfoDTO} with token lifetimes
      * @throws EmailVerificationFailedException if the user is not found
      */
     private AuthSessionInfoDTO handleLogin(OtpCompleteDTO body, HttpServletResponse response) {
-        userService.findByEmail(body.email()).orElseThrow(EmailVerificationFailedException::new);
-        String keycloakUserId = keycloakUserService.ensureUser(body);
-        return getTokens(keycloakUserId, response);
+        User user = userService.findByEmail(body.email()).orElseThrow(EmailVerificationFailedException::new);
+        return getTokens(user, response, false);
     }
 
     /**
-     * Handles the OTP completion flow for user registration.
-     * <p>
-     * Creates a verified user if one does not exist, sets the user's first and last name,
-     * ensures the user exists in Keycloak and marks the email as verified.
-     * Returns whether the user needs to complete their profile.
+     * Handles the OTP completion flow for user registration: provisions a verified local user (creating one
+     * if needed), applies the optional profile name, and reports whether profile completion is still needed.
      *
      * @param body     the OTP completion request containing optional profile
      * @param response the HTTP response to which authentication cookies may be added
      * @return an {@link AuthSessionInfoDTO} with token lifetimes and a flag indicating if profile completion is needed
      */
     private AuthSessionInfoDTO handleRegister(OtpCompleteDTO body, HttpServletResponse response) {
-        String keycloakUserId = keycloakUserService.ensureUser(body);
         String firstName = body.profile() != null ? body.profile().firstName() : null;
         String lastName = body.profile() != null ? body.profile().lastName() : null;
-        User user = userService.upsertUser(keycloakUserId, body.email(), firstName, lastName);
+        User user = userService.provisionExternalUser(body.email(), firstName, lastName);
         boolean profileRequired = StringUtil.isBlank(user.getFirstName()) || StringUtil.isBlank(user.getLastName());
-        return getTokens(keycloakUserId, response, profileRequired);
+        return getTokens(user, response, profileRequired);
     }
 
     /**
-     * Exchanges Keycloak tokens for the given user ID and sets authentication cookies in the response.
+     * Mints app-issued tokens for the given user and sets authentication cookies in the response.
      *
-     * @param keycloakUserId the Keycloak user ID
-     * @param response       the HTTP response to which cookies will be added
+     * @param user            the authenticated local user
+     * @param response        the HTTP response to which cookies will be added
+     * @param profileRequired whether the client should prompt for profile completion
      * @return an {@link AuthSessionInfoDTO} with token lifetimes
      */
-    private AuthSessionInfoDTO getTokens(String keycloakUserId, HttpServletResponse response) {
-        return getTokens(keycloakUserId, response, false);
-    }
-
-    private AuthSessionInfoDTO getTokens(String keycloakUserId, HttpServletResponse response, boolean profileRequired) {
-        AuthResponseDTO tokens = keycloakAuthService.exchangeForUserTokens(keycloakUserId);
+    private AuthSessionInfoDTO getTokens(User user, HttpServletResponse response, boolean profileRequired) {
+        AuthResponseDTO tokens = appTokenService.issueFor(user);
         CookieUtils.setAuthCookies(response, tokens);
         return new AuthSessionInfoDTO(tokens.expiresIn(), tokens.refreshExpiresIn(), profileRequired);
     }

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/TokenRefreshDispatcher.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/TokenRefreshDispatcher.java
@@ -1,0 +1,79 @@
+package de.tum.cit.aet.usermanagement.service;
+
+import com.nimbusds.jwt.JWTParser;
+import de.tum.cit.aet.core.service.AppTokenService;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import java.text.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Routes token refresh and logout to the correct backend based on the token's issuer:
+ * app-issued tokens are handled by {@link AppTokenService}, while TUM Keycloak tokens are handled by
+ * {@link KeycloakAuthenticationService}. This lets the cookie-based session model serve both applicant
+ * (self-issued) sessions and TUM staff (Keycloak) sessions transparently.
+ */
+@Service
+public class TokenRefreshDispatcher {
+
+    private final AppTokenService appTokenService;
+    private final KeycloakAuthenticationService keycloakAuthenticationService;
+    private final String appIssuer;
+
+    public TokenRefreshDispatcher(
+        AppTokenService appTokenService,
+        KeycloakAuthenticationService keycloakAuthenticationService,
+        @Value("${app.token.issuer}") String appIssuer
+    ) {
+        this.appTokenService = appTokenService;
+        this.keycloakAuthenticationService = keycloakAuthenticationService;
+        this.appIssuer = appIssuer;
+    }
+
+    /**
+     * Refreshes a session, choosing the issuer-appropriate mechanism.
+     *
+     * @param accessToken  the current (possibly absent/expired) access token
+     * @param refreshToken the refresh token
+     * @return a freshly issued token pair
+     */
+    public AuthResponseDTO refresh(String accessToken, String refreshToken) {
+        if (isAppToken(accessToken) || (isBlank(accessToken) && isAppToken(refreshToken))) {
+            return appTokenService.refresh(refreshToken);
+        }
+        return keycloakAuthenticationService.refreshTokens(accessToken, refreshToken);
+    }
+
+    /**
+     * Invalidates a session, choosing the issuer-appropriate mechanism.
+     *
+     * @param accessToken  the current access token (used only to determine the issuer)
+     * @param refreshToken the refresh token to invalidate
+     */
+    public void logout(String accessToken, String refreshToken) {
+        if (isAppToken(accessToken) || isAppToken(refreshToken)) {
+            appTokenService.revoke(refreshToken);
+            return;
+        }
+        keycloakAuthenticationService.invalidateRefreshToken(refreshToken);
+    }
+
+    private boolean isAppToken(String token) {
+        return appIssuer.equals(issuerOf(token));
+    }
+
+    private String issuerOf(String token) {
+        if (isBlank(token)) {
+            return null;
+        }
+        try {
+            return JWTParser.parse(token).getJWTClaimsSet().getIssuer();
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/usermanagement/service/UserService.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/service/UserService.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,16 +33,60 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserResearchGroupRoleRepository userResearchGroupRoleRepository;
     private final ImageService imageService;
+    private final PasswordEncoder passwordEncoder;
     private static final Duration LAST_ACTIVITY_UPDATE_THRESHOLD = Duration.ofHours(24);
 
     public UserService(
         UserRepository userRepository,
         UserResearchGroupRoleRepository userResearchGroupRoleRepository,
-        ImageService imageService
+        ImageService imageService,
+        PasswordEncoder passwordEncoder
     ) {
         this.userRepository = userRepository;
         this.userResearchGroupRoleRepository = userResearchGroupRoleRepository;
         this.imageService = imageService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Provisions a local (applicant) user identified by email, generating a fresh app-owned {@code userId}
+     * for new users and reusing the existing id otherwise. Marks the email as verified, since this is only
+     * called after an out-of-band proof of email ownership (OTP or a federated provider asserting a verified
+     * email). Assigns the APPLICANT role when the user has no roles.
+     *
+     * @param email     the verified email address
+     * @param firstName optional first name (only applied when creating the user)
+     * @param lastName  optional last name (only applied when creating the user)
+     * @return the managed {@link User}
+     */
+    @Transactional
+    public User provisionExternalUser(String email, String firstName, String lastName) {
+        Optional<User> existing = findByEmail(email);
+        String userId = existing.map(user -> user.getUserId().toString()).orElseGet(() -> UUID.randomUUID().toString());
+        User user = upsertUser(userId, email, firstName, lastName);
+        if (!user.isEmailVerified()) {
+            user.setEmailVerified(true);
+            user = userRepository.save(user);
+        }
+        return user;
+    }
+
+    /**
+     * Sets (or replaces) the local password for the given user, storing only a BCrypt hash.
+     *
+     * @param userId      the user id (UUID string)
+     * @param rawPassword the new plaintext password
+     * @return {@code true} if the password was updated, {@code false} if the input was blank
+     */
+    @Transactional
+    public boolean setLocalPassword(String userId, String rawPassword) {
+        if (rawPassword == null || rawPassword.isBlank()) {
+            return false;
+        }
+        User user = userRepository.findById(UUID.fromString(userId)).orElseThrow(() -> EntityNotFoundException.forId("User", userId));
+        user.setPasswordHash(passwordEncoder.encode(rawPassword));
+        userRepository.save(user);
+        return true;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/usermanagement/web/AuthenticationResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/AuthenticationResource.java
@@ -12,7 +12,9 @@ import de.tum.cit.aet.usermanagement.dto.auth.OtpCompleteDTO;
 import de.tum.cit.aet.usermanagement.dto.auth.PasskeyActionTokenDTO;
 import de.tum.cit.aet.usermanagement.dto.auth.PasskeyDTO;
 import de.tum.cit.aet.usermanagement.service.KeycloakAuthenticationService;
+import de.tum.cit.aet.usermanagement.service.LocalAuthenticationService;
 import de.tum.cit.aet.usermanagement.service.OtpFlowService;
+import de.tum.cit.aet.usermanagement.service.TokenRefreshDispatcher;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -39,6 +41,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthenticationResource {
 
     private final KeycloakAuthenticationService keycloakAuthenticationService;
+    private final LocalAuthenticationService localAuthenticationService;
+    private final TokenRefreshDispatcher tokenRefreshDispatcher;
     private final OtpFlowService otpFlowService;
 
     /**
@@ -52,7 +56,7 @@ public class AuthenticationResource {
     @Public
     @PostMapping("/login")
     public AuthSessionInfoDTO login(@Valid @RequestBody LoginRequestDTO loginRequest, HttpServletResponse response) {
-        AuthResponseDTO tokens = keycloakAuthenticationService.loginWithCredentials(loginRequest.email(), loginRequest.password());
+        AuthResponseDTO tokens = localAuthenticationService.loginWithCredentials(loginRequest.email(), loginRequest.password());
         CookieUtils.setAuthCookies(response, tokens);
         return new AuthSessionInfoDTO(tokens.expiresIn(), tokens.refreshExpiresIn());
     }
@@ -68,17 +72,19 @@ public class AuthenticationResource {
     @Authenticated
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = null;
         String refreshToken = null;
         if (request.getCookies() != null) {
             for (Cookie c : request.getCookies()) {
-                if ("refresh_token".equals(c.getName())) {
+                if ("access_token".equals(c.getName())) {
+                    accessToken = c.getValue();
+                } else if ("refresh_token".equals(c.getName())) {
                     refreshToken = c.getValue();
-                    break;
                 }
             }
         }
         if (refreshToken != null && !refreshToken.isBlank()) {
-            keycloakAuthenticationService.invalidateRefreshToken(refreshToken);
+            tokenRefreshDispatcher.logout(accessToken, refreshToken);
         }
 
         CookieUtils.setAuthCookies(response, null);
@@ -121,7 +127,7 @@ public class AuthenticationResource {
         }
 
         try {
-            AuthResponseDTO tokens = keycloakAuthenticationService.refreshTokens(accessToken, refreshToken);
+            AuthResponseDTO tokens = tokenRefreshDispatcher.refresh(accessToken, refreshToken);
             CookieUtils.setAuthCookies(response, tokens);
             return new AuthSessionInfoDTO(tokens.expiresIn(), tokens.refreshExpiresIn());
         } catch (UnauthorizedException ex) {

--- a/src/main/java/de/tum/cit/aet/usermanagement/web/UserResource.java
+++ b/src/main/java/de/tum/cit/aet/usermanagement/web/UserResource.java
@@ -72,7 +72,9 @@ public class UserResource {
     }
 
     /**
-     * Allows the currently authenticated user to set or change their password in Keycloak.
+     * Allows the currently authenticated user to set or change their local (in-app) password.
+     * Passwords are stored as a BCrypt hash in the application database; TUM staff continue to authenticate
+     * via login.tum.de and do not use this endpoint.
      *
      * @param jwt of the authenticated user
      * @param dto contains the new password
@@ -82,7 +84,7 @@ public class UserResource {
     @PutMapping("/password")
     public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal Jwt jwt, @Valid @RequestBody UpdatePasswordDTO dto) {
         log.info("PUT /api/users/password - Updating password for subject={}", jwt.getSubject());
-        boolean updated = keycloakUserService.setPassword(jwt.getSubject(), dto.newPassword(), jwt.getIssuer());
+        boolean updated = userService.setLocalPassword(jwt.getSubject(), dto.newPassword());
         return updated ? ResponseEntity.noContent().build() : ResponseEntity.badRequest().build();
     }
 

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -388,3 +388,22 @@ security:
     max-attempts: ${OTP_MAX_ATTEMPTS:6}
     resend-cooldown-seconds: ${OTP_RESEND_COOLDOWN_SECONDS:60}
     hmac-secret: ${OTP_HMAC_SECRET:3vWK1lE1FnrjAovOmWwn8O9xqq5WTtNOY/NUdSAKmoQ=}
+
+# ===================================================================
+# Application-issued JWTs (internal user management for applicants)
+# - TUMApply signs its own access/refresh tokens for applicants; Keycloak is only used for TUM staff.
+# - issuer: stable issuer URI embedded in app tokens and trusted by the resource server
+# - kid: key id placed in the JWT header (enables future key rotation)
+# - access/refresh-ttl-seconds: token lifetimes
+# - rsa-private-key / rsa-public-key: PKCS#8 / X.509 PEM signing keypair.
+#   REQUIRED in the prod profile; when blank (dev only) an ephemeral key is generated at startup.
+# ===================================================================
+app:
+  token:
+    issuer: ${APP_TOKEN_ISSUER:https://tumapply.aet.cit.tum.de}
+    kid: ${APP_TOKEN_KID:tumapply}
+    azp: ${APP_TOKEN_AZP:tumapply-internal}
+    access-ttl-seconds: ${APP_TOKEN_ACCESS_TTL_SECONDS:300}
+    refresh-ttl-seconds: ${APP_TOKEN_REFRESH_TTL_SECONDS:2592000}
+    rsa-private-key: ${APP_TOKEN_RSA_PRIVATE_KEY:}
+    rsa-public-key: ${APP_TOKEN_RSA_PUBLIC_KEY:}

--- a/src/main/resources/config/liquibase/changelog/00000000000044_internal_user_management.xml
+++ b/src/main/resources/config/liquibase/changelog/00000000000044_internal_user_management.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <!--
+    Internal user management: TUMApply issues its own JWTs for applicants instead of Keycloak.
+    - users.password_hash / users.email_verified: local credential + verification state
+    - app_refresh_token: tracks issued refresh-token JTIs so logout/rotation can revoke them
+  -->
+  <changeSet id="044-add-local-credentials-to-users" author="krusche">
+    <addColumn tableName="users">
+      <column name="password_hash" type="VARCHAR(255)">
+        <constraints nullable="true"/>
+      </column>
+      <column name="email_verified" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="044-add-app-refresh-token" author="krusche">
+    <createTable tableName="app_refresh_token">
+      <column name="jti" type="VARCHAR(36)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="user_id" type="VARCHAR(36)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="created_at" type="TIMESTAMP(3)" defaultValueComputed="CURRENT_TIMESTAMP(3)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="expires_at" type="TIMESTAMP(3)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="revoked" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <!-- Revoke-all-for-user (logout) and rotation lookups. -->
+    <createIndex tableName="app_refresh_token" indexName="idx_art_user">
+      <column name="user_id"/>
+    </createIndex>
+
+    <!-- Scheduled purge of expired refresh tokens. -->
+    <createIndex tableName="app_refresh_token" indexName="idx_art_expires_at">
+      <column name="expires_at"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -53,6 +53,7 @@
   <include file="changelog/00000000000041_add_reference_letter_document.xml" relativeToChangelogFile="true"/>
   <include file="changelog/00000000000042_drop_contract_extendable_from_jobs.xml" relativeToChangelogFile="true"/>
   <include file="changelog/00000000000043_remove_pending_application_state.xml" relativeToChangelogFile="true"/>
+  <include file="changelog/00000000000044_internal_user_management.xml" relativeToChangelogFile="true"/>
 
   <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
   <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints

--- a/src/test/java/de/tum/cit/aet/core/security/MultiRealmJwtDecoderTest.java
+++ b/src/test/java/de/tum/cit/aet/core/security/MultiRealmJwtDecoderTest.java
@@ -18,10 +18,10 @@ class MultiRealmJwtDecoderTest {
 
     private static final String KEYCLOAK_URL = "http://localhost:9080";
     private static final String TUM_REALM = "tumidpldap";
-    private static final String EXTERNAL_REALM = "external-login";
+    private static final String APP_ISSUER = "https://tumapply.test";
 
     @Test
-    void decodeShouldUseDecoderForTrustedTumIssuer() {
+    void decodeShouldUseRemoteDecoderForTrustedTumIssuer() {
         String tumIssuer = KEYCLOAK_URL + "/realms/" + TUM_REALM;
         String token = jwtWithIssuer(tumIssuer);
 
@@ -29,7 +29,7 @@ class MultiRealmJwtDecoderTest {
         AtomicReference<String> decodedToken = new AtomicReference<>();
         Jwt expectedJwt = sampleJwt("decoded-subject");
 
-        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(KEYCLOAK_URL, TUM_REALM, EXTERNAL_REALM, issuer -> {
+        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(KEYCLOAK_URL, TUM_REALM, APP_ISSUER, appDecoderThatFails(), issuer -> {
             factoryIssuer.set(issuer);
             return rawToken -> {
                 decodedToken.set(rawToken);
@@ -45,14 +45,38 @@ class MultiRealmJwtDecoderTest {
     }
 
     @Test
-    void decodeShouldReuseCachedDecoderPerIssuer() {
-        String externalIssuer = KEYCLOAK_URL + "/realms/" + EXTERNAL_REALM;
-        String token = jwtWithIssuer(externalIssuer);
+    void decodeShouldUseLocalAppDecoderForAppIssuer() {
+        String token = jwtWithIssuer(APP_ISSUER);
+        Jwt expectedJwt = sampleJwt("app-subject");
+        AtomicInteger remoteFactoryCalls = new AtomicInteger(0);
+
+        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(
+            KEYCLOAK_URL,
+            TUM_REALM,
+            APP_ISSUER,
+            rawToken -> expectedJwt,
+            issuer -> {
+                remoteFactoryCalls.incrementAndGet();
+                return rawToken -> sampleJwt("should-not-be-used");
+            }
+        );
+
+        Jwt result = decoder.decode(token);
+
+        assertThat(result).isSameAs(expectedJwt);
+        // The app issuer must be validated locally, never via the remote (network) factory.
+        assertThat(remoteFactoryCalls.get()).isZero();
+    }
+
+    @Test
+    void decodeShouldReuseCachedRemoteDecoderPerIssuer() {
+        String tumIssuer = KEYCLOAK_URL + "/realms/" + TUM_REALM;
+        String token = jwtWithIssuer(tumIssuer);
 
         AtomicInteger factoryCalls = new AtomicInteger(0);
         JwtDecoder fixedDecoder = rawToken -> sampleJwt("cached");
 
-        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(KEYCLOAK_URL, TUM_REALM, EXTERNAL_REALM, issuer -> {
+        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(KEYCLOAK_URL, TUM_REALM, APP_ISSUER, appDecoderThatFails(), issuer -> {
             factoryCalls.incrementAndGet();
             return fixedDecoder;
         });
@@ -64,14 +88,20 @@ class MultiRealmJwtDecoderTest {
     }
 
     @Test
+    void decodeShouldRejectDecommissionedExternalRealmIssuer() {
+        String externalIssuer = KEYCLOAK_URL + "/realms/external-login";
+        String token = jwtWithIssuer(externalIssuer);
+        MultiRealmJwtDecoder decoder = newDecoder();
+
+        assertThatThrownBy(() -> decoder.decode(token))
+            .isInstanceOf(BadJwtException.class)
+            .hasMessageContaining("Untrusted token issuer");
+    }
+
+    @Test
     void decodeShouldRejectUntrustedIssuer() {
         String token = jwtWithIssuer("http://malicious.example/realms/evil");
-        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(
-            KEYCLOAK_URL,
-            TUM_REALM,
-            EXTERNAL_REALM,
-            issuer -> rawToken -> sampleJwt("x")
-        );
+        MultiRealmJwtDecoder decoder = newDecoder();
 
         assertThatThrownBy(() -> decoder.decode(token))
             .isInstanceOf(BadJwtException.class)
@@ -80,31 +110,27 @@ class MultiRealmJwtDecoderTest {
 
     @Test
     void decodeShouldRejectMalformedToken() {
-        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(
-            KEYCLOAK_URL,
-            TUM_REALM,
-            EXTERNAL_REALM,
-            issuer -> rawToken -> sampleJwt("x")
-        );
+        MultiRealmJwtDecoder decoder = newDecoder();
 
-        assertThatThrownBy(() -> decoder.decode("not-a-jwt"))
-            .isInstanceOf(BadJwtException.class)
-            .hasMessageContaining("Invalid JWT");
+        assertThatThrownBy(() -> decoder.decode("not-a-jwt")).isInstanceOf(BadJwtException.class).hasMessageContaining("Invalid JWT");
     }
 
     @Test
     void decodeShouldRejectTokenWithoutIssuer() {
         String token = jwtWithoutIssuer();
-        MultiRealmJwtDecoder decoder = new MultiRealmJwtDecoder(
-            KEYCLOAK_URL,
-            TUM_REALM,
-            EXTERNAL_REALM,
-            issuer -> rawToken -> sampleJwt("x")
-        );
+        MultiRealmJwtDecoder decoder = newDecoder();
 
-        assertThatThrownBy(() -> decoder.decode(token))
-            .isInstanceOf(BadJwtException.class)
-            .hasMessageContaining("Missing token issuer");
+        assertThatThrownBy(() -> decoder.decode(token)).isInstanceOf(BadJwtException.class).hasMessageContaining("Missing token issuer");
+    }
+
+    private static MultiRealmJwtDecoder newDecoder() {
+        return new MultiRealmJwtDecoder(KEYCLOAK_URL, TUM_REALM, APP_ISSUER, appDecoderThatFails(), issuer -> rawToken -> sampleJwt("x"));
+    }
+
+    private static JwtDecoder appDecoderThatFails() {
+        return rawToken -> {
+            throw new AssertionError("app decoder should not be called for non-app issuers");
+        };
     }
 
     private static Jwt sampleJwt(String subject) {

--- a/src/test/java/de/tum/cit/aet/core/service/AppTokenServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/core/service/AppTokenServiceTest.java
@@ -1,0 +1,173 @@
+package de.tum.cit.aet.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import de.tum.cit.aet.core.exception.UnauthorizedException;
+import de.tum.cit.aet.usermanagement.domain.AppRefreshToken;
+import de.tum.cit.aet.usermanagement.domain.User;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import de.tum.cit.aet.usermanagement.repository.AppRefreshTokenRepository;
+import de.tum.cit.aet.usermanagement.repository.UserRepository;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AppTokenServiceTest {
+
+    private static final String ISSUER = "https://tumapply.test";
+    private static final String KID = "tumapply-test";
+
+    @Mock
+    private AppRefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private JwtDecoder decoder;
+    private AppTokenService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        RSAKey rsaKey = new RSAKey.Builder(publicKey)
+            .privateKey(privateKey)
+            .keyID(KID)
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+        JWKSource<SecurityContext> jwkSource = new ImmutableJWKSet<>(new JWKSet(rsaKey));
+
+        NimbusJwtDecoder nimbusDecoder = NimbusJwtDecoder.withPublicKey(publicKey).signatureAlgorithm(SignatureAlgorithm.RS256).build();
+        nimbusDecoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(ISSUER));
+        this.decoder = nimbusDecoder;
+
+        this.service = new AppTokenService(
+            new NimbusJwtEncoder(jwkSource),
+            nimbusDecoder,
+            refreshTokenRepository,
+            userRepository,
+            ISSUER,
+            KID,
+            "tumapply-internal",
+            300,
+            2_592_000
+        );
+    }
+
+    private static User user(UUID id) {
+        User user = new User();
+        user.setUserId(id);
+        user.setEmail("applicant@example.org");
+        user.setFirstName("Ada");
+        user.setLastName("Lovelace");
+        return user;
+    }
+
+    @Test
+    void issueForMintsAccessTokenWithExpectedClaims() {
+        UUID id = UUID.randomUUID();
+
+        AuthResponseDTO tokens = service.issueFor(user(id));
+
+        Jwt access = decoder.decode(tokens.accessToken());
+        assertThat(access.getSubject()).isEqualTo(id.toString());
+        assertThat(access.getClaimAsString("email")).isEqualTo("applicant@example.org");
+        assertThat(access.getClaimAsString("given_name")).isEqualTo("Ada");
+        assertThat(access.getClaimAsString("family_name")).isEqualTo("Lovelace");
+        assertThat(access.getClaimAsString("typ")).isEqualTo("access");
+        assertThat(access.getClaimAsString("azp")).isEqualTo("tumapply-internal");
+        assertThat(tokens.expiresIn()).isEqualTo(300);
+        assertThat(tokens.refreshExpiresIn()).isEqualTo(2_592_000);
+        // The refresh token id must be persisted so it can later be revoked.
+        verify(refreshTokenRepository).save(any(AppRefreshToken.class));
+    }
+
+    @Test
+    void refreshRotatesTokenAndRevokesPrevious() {
+        UUID id = UUID.randomUUID();
+        User user = user(id);
+        AuthResponseDTO issued = service.issueFor(user);
+        String refreshJti = decoder.decode(issued.refreshToken()).getId();
+
+        AppRefreshToken record = new AppRefreshToken();
+        record.setJti(refreshJti);
+        record.setUserId(id);
+        record.setExpiresAt(Instant.now().plusSeconds(1000));
+        record.setRevoked(false);
+        when(refreshTokenRepository.findById(refreshJti)).thenReturn(Optional.of(record));
+        when(userRepository.findById(id)).thenReturn(Optional.of(user));
+
+        AuthResponseDTO refreshed = service.refresh(issued.refreshToken());
+
+        assertThat(decoder.decode(refreshed.accessToken()).getSubject()).isEqualTo(id.toString());
+        verify(refreshTokenRepository).revokeIfActive(refreshJti);
+        verify(refreshTokenRepository, never()).revokeAllForUser(any());
+    }
+
+    @Test
+    void refreshOfRevokedTokenIsTreatedAsReplayAndRevokesAll() {
+        UUID id = UUID.randomUUID();
+        AuthResponseDTO issued = service.issueFor(user(id));
+        String refreshJti = decoder.decode(issued.refreshToken()).getId();
+
+        AppRefreshToken record = new AppRefreshToken();
+        record.setJti(refreshJti);
+        record.setUserId(id);
+        record.setExpiresAt(Instant.now().plusSeconds(1000));
+        record.setRevoked(true);
+        when(refreshTokenRepository.findById(refreshJti)).thenReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> service.refresh(issued.refreshToken())).isInstanceOf(UnauthorizedException.class);
+        verify(refreshTokenRepository).revokeAllForUser(id);
+    }
+
+    @Test
+    void refreshOfUnknownTokenIsRejected() {
+        UUID id = UUID.randomUUID();
+        AuthResponseDTO issued = service.issueFor(user(id));
+        when(refreshTokenRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.refresh(issued.refreshToken())).isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void accessTokenCannotBeUsedAsRefreshToken() {
+        AuthResponseDTO issued = service.issueFor(user(UUID.randomUUID()));
+
+        // The access token has typ=access; the refresh path must reject it.
+        assertThatThrownBy(() -> service.refresh(issued.accessToken())).isInstanceOf(UnauthorizedException.class);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/usermanagement/web/rest/UserResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/usermanagement/web/rest/UserResourceTest.java
@@ -161,7 +161,7 @@ public class UserResourceTest extends AbstractResourceTest {
         @Test
         void returnsNoContentWhenPasswordUpdateSucceeds() {
             String newPassword = "StrongPassword123!";
-            when(keycloakUserService.setPassword(anyString(), eq(newPassword), any())).thenReturn(true);
+            when(userService.setLocalPassword(anyString(), eq(newPassword))).thenReturn(true);
 
             UpdatePasswordDTO dto = new UpdatePasswordDTO(newPassword);
 
@@ -169,13 +169,13 @@ public class UserResourceTest extends AbstractResourceTest {
                 .with(JwtPostProcessors.jwtUser(currentUser.getUserId(), "ROLE_APPLICANT"))
                 .putAndRead(API_BASE_PATH + "/password", dto, Void.class, 204);
 
-            verify(keycloakUserService).setPassword(eq(currentUser.getUserId().toString()), eq(newPassword), any());
+            verify(userService).setLocalPassword(eq(currentUser.getUserId().toString()), eq(newPassword));
         }
 
         @Test
         void returns400WhenPasswordUpdateFails() {
             String newPassword = "AnotherStrongPassword!";
-            when(keycloakUserService.setPassword(anyString(), eq(newPassword), any())).thenReturn(false);
+            when(userService.setLocalPassword(anyString(), eq(newPassword))).thenReturn(false);
 
             UpdatePasswordDTO dto = new UpdatePasswordDTO(newPassword);
 

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -131,3 +131,13 @@ security:
     max-attempts: 6
     resend-cooldown-seconds: 60
     hmac-secret: 3vWK1lE1FnrjAovOmWwn8O9xqq5WTtNOY/NUdSAKmoQ=
+
+app:
+  token:
+    issuer: https://tumapply.test
+    kid: tumapply-test
+    azp: tumapply-internal
+    access-ttl-seconds: 300
+    refresh-ttl-seconds: 2592000
+    rsa-private-key:
+    rsa-public-key:


### PR DESCRIPTION
## Context

We decided that Keycloak should only be the gateway to **login.tum.de** (the `tumidpldap` realm) plus TUM-staff passkeys. The `external-login` Keycloak realm — which today backs applicant **registration**, **email/password + OTP login**, and **Google/Apple** sign-in — is being **decommissioned**. Applicant identity must therefore be handled by **TUM Apply's own internal user management**, independent of Keycloak.

This PR is **phase 1** of that migration: TUM Apply becomes its own token issuer for applicants and serves registration + email/OTP/password login internally. It is a self-contained, reviewable slice; Google/Apple and passkeys follow in later PRs.

Full plan lives in `.claude/plans/we-decided-to-remove-peaceful-cerf.md`.

## What this PR does

- **App as JWT issuer** — `AppTokenService` mints RS256-signed access/refresh JWTs (`sub` = local `User.userId`, plus `email`/`given_name`/`family_name`/`azp`, kept compatible with the existing resource-server pipeline). `AppTokenKeyConfiguration` loads the RSA keypair from config (ephemeral dev fallback, **prod startup assertion** that the key is set). Public keys published at `/.well-known/jwks.json`.
- **Decoder** — `MultiRealmJwtDecoder` drops the `external-login` issuer and trusts the app issuer **locally** (no network), keeping the `tumidpldap` remote decoder.
- **Refresh revocation** — `app_refresh_token` table (migration `00000000000044`) tracks issued refresh-token JTIs; refresh **rotates** with **replay detection** (reuse of a revoked token revokes the whole family) and `/logout` revokes the JTI.
- **Credentials** — `users.password_hash` + `users.email_verified`; `BCryptPasswordEncoder`.
- **Retargeted flows** — `OtpFlowService`, `/login`, `/refresh`, `/logout`, `/password` now use internal management via `LocalAuthenticationService` + `TokenRefreshDispatcher` (routes refresh/logout app-vs-Keycloak **by token issuer**). **TUM staff login via login.tum.de is unchanged.**

## Result

Applicant **registration (OTP)**, **email/OTP login**, and **email/password login** work entirely in-app with no Keycloak dependency.

## Verification

- `compileJava`, `spotlessApply`, `checkstyleMain` — clean
- `AppTokenServiceTest` + `MultiRealmJwtDecoderTest` — 12/12 (mint↔decode, rotation, replay, unknown/expired/access-as-refresh rejection, app-issuer-local vs untrusted)
- `UserResourceTest` — 17/17 (context boots, migration `044` applies, password endpoint)

## Follow-ups (separate PRs)

- **WS-2** — direct Google + Apple OIDC (replaces Keycloak IdP brokering; Google/Apple buttons remain broken until then)
- **WS-1f** — in-app WebAuthn (Spring Security 7 built-in) for applicant passkeys
- **WS-3** — remove dead Keycloak external-realm code/config + realm JSON, frontend rewire, server-side OTP cooldown (SEC-32)

> ⚠️ Rollout note: per the decision to "start from scratch with an empty user list", there is **no** credential migration; existing applicant accounts must re-register. Coordinate the data cutover with go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)