### PR TITLE
`Development`: Direct Google sign-in via in-app OIDC (no Keycloak)

### DIFF
--- a/src/main/java/de/tum/cit/aet/core/config/OAuth2LoginSecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/core/config/OAuth2LoginSecurityConfiguration.java
@@ -1,0 +1,77 @@
+package de.tum.cit.aet.core.config;
+
+import de.tum.cit.aet.core.security.oauth2.OAuth2LoginSuccessHandler;
+import de.tum.cit.aet.core.service.AppTokenService;
+import de.tum.cit.aet.usermanagement.service.UserService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+/**
+ * Security chain that lets TUMApply perform Google/Apple sign-in directly (replacing Keycloak IdP
+ * brokering for the decommissioned external-login realm). It is a separate, higher-priority filter chain
+ * matching only the OAuth2 endpoints, so the stateless resource-server chain ({@code /api/**}) is untouched.
+ * <p>
+ * Activated only under the {@code social-login} profile: this keeps the {@code ClientRegistrationRepository}
+ * auto-configuration (and this chain) out of dev/test/CI, where no OAuth2 client credentials are configured.
+ * Enable in deployments via {@code SPRING_PROFILES_ACTIVE=...,social-login} together with the provider
+ * client credentials.
+ */
+@Configuration
+@Profile("social-login")
+public class OAuth2LoginSecurityConfiguration {
+
+    /**
+     * Success handler that turns a completed Google/Apple sign-in into an app-issued cookie session.
+     *
+     * @param userService     provisions the local user from the verified provider identity
+     * @param appTokenService mints the app access/refresh tokens
+     * @param clientUrl       SPA base URL to redirect back to after login
+     * @return the configured success handler
+     */
+    @Bean
+    public OAuth2LoginSuccessHandler oauth2LoginSuccessHandler(
+        UserService userService,
+        AppTokenService appTokenService,
+        @Value("${aet.client.url}") String clientUrl
+    ) {
+        return new OAuth2LoginSuccessHandler(userService, appTokenService, clientUrl);
+    }
+
+    /**
+     * Higher-priority filter chain that handles only the OAuth2 login endpoints via redirect-based
+     * {@code oauth2Login}, leaving the stateless resource-server chain to serve {@code /api/**}.
+     *
+     * @param http                       the HTTP security builder
+     * @param oauth2LoginSuccessHandler  handler that issues the app session on success
+     * @param clientUrl                  SPA base URL used to build the failure redirect
+     * @return the OAuth2 login security filter chain
+     * @throws Exception if the chain cannot be built
+     */
+    @Bean
+    @Order(1)
+    public SecurityFilterChain oauth2LoginFilterChain(
+        HttpSecurity http,
+        OAuth2LoginSuccessHandler oauth2LoginSuccessHandler,
+        @Value("${aet.client.url}") String clientUrl
+    ) throws Exception {
+        String redirectBase = clientUrl.endsWith("/") ? clientUrl.substring(0, clientUrl.length() - 1) : clientUrl;
+        AuthenticationFailureHandler failureHandler = (request, response, exception) ->
+            response.sendRedirect(redirectBase + "/?login_error=oauth");
+
+        http
+            // Only the redirect-based OAuth2 endpoints; the resource-server chain handles everything else.
+            .securityMatcher("/oauth2/**", "/login/oauth2/**")
+            // OAuth2 login relies on the `state` parameter for CSRF protection on these endpoints.
+            .csrf(CsrfConfigurer::disable)
+            .authorizeHttpRequests(requests -> requests.anyRequest().permitAll())
+            .oauth2Login(oauth -> oauth.successHandler(oauth2LoginSuccessHandler).failureHandler(failureHandler));
+        return http.build();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/core/security/oauth2/AppleUserAttributesFilter.java
+++ b/src/main/java/de/tum/cit/aet/core/security/oauth2/AppleUserAttributesFilter.java
@@ -1,0 +1,64 @@
+package de.tum.cit.aet.core.security.oauth2;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Captures the user's name from Apple's sign-in callback. Apple returns the {@code name} only on the user's
+ * FIRST authorization, as a {@code user} form field on the {@code form_post} callback (it is not in the id
+ * token). This filter parses it and stashes the first/last name as request attributes so
+ * {@link OAuth2LoginSuccessHandler} can apply them when provisioning the user. Must run before
+ * {@code OAuth2LoginAuthenticationFilter} on the OAuth2 login chain.
+ */
+@Slf4j
+public class AppleUserAttributesFilter extends OncePerRequestFilter {
+
+    public static final String FIRST_NAME_ATTRIBUTE = "apple.user.firstName";
+    public static final String LAST_NAME_ATTRIBUTE = "apple.user.lastName";
+
+    private static final String CALLBACK_SUFFIX = "/login/oauth2/code/apple";
+
+    private final ObjectMapper objectMapper;
+
+    public AppleUserAttributesFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        if ("POST".equalsIgnoreCase(request.getMethod()) && request.getRequestURI().endsWith(CALLBACK_SUFFIX)) {
+            captureName(request);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void captureName(HttpServletRequest request) {
+        String userJson = request.getParameter("user");
+        if (userJson == null || userJson.isBlank()) {
+            return;
+        }
+        try {
+            Map<?, ?> root = objectMapper.readValue(userJson, Map.class);
+            if (root.get("name") instanceof Map<?, ?> name) {
+                setIfPresent(request, FIRST_NAME_ATTRIBUTE, name.get("firstName"));
+                setIfPresent(request, LAST_NAME_ATTRIBUTE, name.get("lastName"));
+            }
+        } catch (RuntimeException e) {
+            log.debug("Could not parse Apple 'user' payload: {}", e.getMessage());
+        }
+    }
+
+    private void setIfPresent(HttpServletRequest request, String attribute, Object value) {
+        if (value != null && !String.valueOf(value).isBlank()) {
+            request.setAttribute(attribute, String.valueOf(value));
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/core/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/de/tum/cit/aet/core/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,95 @@
+package de.tum.cit.aet.core.security.oauth2;
+
+import de.tum.cit.aet.core.service.AppTokenService;
+import de.tum.cit.aet.core.util.CookieUtils;
+import de.tum.cit.aet.usermanagement.domain.User;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import de.tum.cit.aet.usermanagement.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+/**
+ * Completes a Google/Apple sign-in handled directly by TUMApply (no Keycloak brokering): extracts the
+ * verified email + name from the provider, provisions a local user, mints app-issued tokens via
+ * {@link AppTokenService}, sets the auth cookies, and redirects back to the SPA.
+ */
+@Slf4j
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private static final String APPLE = "apple";
+
+    private final UserService userService;
+    private final AppTokenService appTokenService;
+    private final String clientUrl;
+
+    public OAuth2LoginSuccessHandler(UserService userService, AppTokenService appTokenService, String clientUrl) {
+        this.userService = userService;
+        this.appTokenService = appTokenService;
+        this.clientUrl = stripTrailingSlash(clientUrl);
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+        throws IOException {
+        if (!(authentication instanceof OAuth2AuthenticationToken token)) {
+            response.sendRedirect(clientUrl + "/?login_error=provider");
+            return;
+        }
+        String registrationId = token.getAuthorizedClientRegistrationId();
+        OAuth2User principal = token.getPrincipal();
+
+        String email = principal.getAttribute("email");
+        if (email == null || email.isBlank() || !isEmailVerified(registrationId, principal)) {
+            log.warn("Rejecting {} login: missing or unverified email", registrationId);
+            response.sendRedirect(clientUrl + "/?login_error=email");
+            return;
+        }
+
+        User user = userService.provisionExternalUser(email, firstName(registrationId, principal, request), lastName(registrationId, principal, request));
+        AuthResponseDTO tokens = appTokenService.issueFor(user);
+        CookieUtils.setAuthCookies(response, tokens);
+        response.sendRedirect(clientUrl + "/");
+    }
+
+    /**
+     * Apple only returns verified emails. For Google we require the {@code email_verified} claim to be true.
+     */
+    private boolean isEmailVerified(String registrationId, OAuth2User principal) {
+        if (APPLE.equals(registrationId)) {
+            return true;
+        }
+        return isTrue(principal.getAttribute("email_verified"));
+    }
+
+    /**
+     * Google exposes {@code given_name}; Apple sends the name only on first consent as a form field, captured
+     * into a request attribute by {@link AppleUserAttributesFilter}.
+     */
+    private String firstName(String registrationId, OAuth2User principal, HttpServletRequest request) {
+        if (APPLE.equals(registrationId)) {
+            return (String) request.getAttribute(AppleUserAttributesFilter.FIRST_NAME_ATTRIBUTE);
+        }
+        return principal.getAttribute("given_name");
+    }
+
+    private String lastName(String registrationId, OAuth2User principal, HttpServletRequest request) {
+        if (APPLE.equals(registrationId)) {
+            return (String) request.getAttribute(AppleUserAttributesFilter.LAST_NAME_ATTRIBUTE);
+        }
+        return principal.getAttribute("family_name");
+    }
+
+    private static boolean isTrue(Object value) {
+        return value instanceof Boolean bool ? bool : Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -407,3 +407,23 @@ app:
     refresh-ttl-seconds: ${APP_TOKEN_REFRESH_TTL_SECONDS:2592000}
     rsa-private-key: ${APP_TOKEN_RSA_PRIVATE_KEY:}
     rsa-public-key: ${APP_TOKEN_RSA_PUBLIC_KEY:}
+
+# ===================================================================
+# Direct Google/Apple sign-in (replaces Keycloak IdP brokering).
+# Activated only under the `social-login` profile so dev/test/CI (no client credentials) are unaffected.
+# Enable with SPRING_PROFILES_ACTIVE=...,social-login plus the provider credentials below.
+# ===================================================================
+---
+spring:
+  config:
+    activate:
+      on-profile: social-login
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: openid,email,profile
+            client-name: Google

--- a/src/main/webapp/app/core/auth/auth-facade.service.ts
+++ b/src/main/webapp/app/core/auth/auth-facade.service.ts
@@ -87,6 +87,9 @@ export class AuthFacadeService {
           return true;
         }
         this.authMethod = 'server';
+        // A direct Google/Apple sign-in returns as a server (cookie) session; send the
+        // registration confirmation email here if this round-trip completed a registration.
+        await this.handlePendingIdpRegistration();
         return true;
       }
 
@@ -261,7 +264,22 @@ export class AuthFacadeService {
 
   // --------------- IdPs ---------------
   /**
-   * Logs in via a Keycloak identity provider.
+   * Starts a direct backend OIDC login for Google/Apple (no Keycloak brokering). Performs a full-page
+   * redirect to the backend authorization endpoint; the backend verifies the identity, provisions the
+   * local user, sets the session cookies and redirects back to the SPA, where `initAuth` resumes the session.
+   *
+   * @param provider the external identity provider (Google or Apple)
+   * @param isRegistration if true, marks the flow so a registration confirmation email is sent on return
+   */
+  loginWithSocialProvider(provider: IdpProvider, isRegistration = false): void {
+    if (isRegistration) {
+      localStorage.setItem(this.REGISTRATION_KEY, 'true');
+    }
+    window.location.href = `/oauth2/authorization/${provider}`;
+  }
+
+  /**
+   * Logs in via a Keycloak identity provider (TUM SSO).
    * @param provider Google, Apple, Microsoft, etc.
    * @param redirectUri optional post-login redirect
    * @param isRegistration if true, sends a registration email after login

--- a/src/main/webapp/app/shared/components/molecules/auth-idp-buttons/auth-idp-buttons.ts
+++ b/src/main/webapp/app/shared/components/molecules/auth-idp-buttons/auth-idp-buttons.ts
@@ -3,7 +3,6 @@ import { Component, computed, inject, input } from '@angular/core';
 import ButtonGroupComponent, { ButtonGroupData } from '../../molecules/button-group/button-group.component';
 import { IdpProvider } from '../../../../core/auth/keycloak-authentication.service';
 import { AuthFacadeService } from '../../../../core/auth/auth-facade.service';
-import { AuthOrchestratorService } from '../../../../core/auth/auth-orchestrator.service';
 
 @Component({
   selector: 'jhi-auth-idp-buttons',
@@ -13,7 +12,6 @@ import { AuthOrchestratorService } from '../../../../core/auth/auth-orchestrator
 })
 export class AuthIdpButtons {
   authFacadeService = inject(AuthFacadeService);
-  authOrchestratorService = inject(AuthOrchestratorService);
   isRegistration = input<boolean>(false);
 
   readonly idpButtons = computed<ButtonGroupData>(() => ({
@@ -28,7 +26,7 @@ export class AuthIdpButtons {
         disabled: false,
         fullWidth: true,
         onClick: () => {
-          void this.authFacadeService.loginWithProvider(IdpProvider.Apple, this.redirectUri(), this.isRegistration());
+          this.authFacadeService.loginWithSocialProvider(IdpProvider.Apple, this.isRegistration());
         },
       },
       {
@@ -39,13 +37,9 @@ export class AuthIdpButtons {
         disabled: false,
         fullWidth: true,
         onClick: () => {
-          void this.authFacadeService.loginWithProvider(IdpProvider.Google, this.redirectUri(), this.isRegistration());
+          this.authFacadeService.loginWithSocialProvider(IdpProvider.Google, this.isRegistration());
         },
       },
     ],
   }));
-
-  private redirectUri(): string {
-    return this.authOrchestratorService.redirectUri() ?? window.location.origin;
-  }
 }

--- a/src/test/java/de/tum/cit/aet/core/security/oauth2/OAuth2LoginSuccessHandlerTest.java
+++ b/src/test/java/de/tum/cit/aet/core/security/oauth2/OAuth2LoginSuccessHandlerTest.java
@@ -1,0 +1,94 @@
+package de.tum.cit.aet.core.security.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.core.service.AppTokenService;
+import de.tum.cit.aet.usermanagement.domain.User;
+import de.tum.cit.aet.usermanagement.dto.auth.AuthResponseDTO;
+import de.tum.cit.aet.usermanagement.service.UserService;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginSuccessHandlerTest {
+
+    private static final String CLIENT_URL = "https://app.test";
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private AppTokenService appTokenService;
+
+    private OAuth2LoginSuccessHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new OAuth2LoginSuccessHandler(userService, appTokenService, CLIENT_URL + "/");
+    }
+
+    private static OAuth2AuthenticationToken googleToken(Map<String, Object> attributes) {
+        OAuth2User principal = new DefaultOAuth2User(AuthorityUtils.createAuthorityList("ROLE_USER"), attributes, "sub");
+        return new OAuth2AuthenticationToken(principal, List.of(), "google");
+    }
+
+    @Test
+    void provisionsUserAndSetsCookiesOnVerifiedGoogleLogin() throws Exception {
+        Map<String, Object> attributes = Map.of(
+            "sub",
+            "google-123",
+            "email",
+            "applicant@gmail.com",
+            "email_verified",
+            true,
+            "given_name",
+            "Ada",
+            "family_name",
+            "Lovelace"
+        );
+        User user = new User();
+        user.setUserId(UUID.randomUUID());
+        when(userService.provisionExternalUser("applicant@gmail.com", "Ada", "Lovelace")).thenReturn(user);
+        when(appTokenService.issueFor(user)).thenReturn(new AuthResponseDTO("access", "refresh", 300, 2_592_000));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(request, response, googleToken(attributes));
+
+        verify(userService).provisionExternalUser("applicant@gmail.com", "Ada", "Lovelace");
+        verify(appTokenService).issueFor(user);
+        assertThat(response.getRedirectedUrl()).isEqualTo(CLIENT_URL + "/");
+        assertThat(response.getHeaders("Set-Cookie")).anyMatch(c -> c.startsWith("access_token="));
+        assertThat(response.getHeaders("Set-Cookie")).anyMatch(c -> c.startsWith("refresh_token="));
+    }
+
+    @Test
+    void rejectsUnverifiedGoogleEmailWithoutProvisioning() throws Exception {
+        Map<String, Object> attributes = Map.of("sub", "google-123", "email", "applicant@gmail.com", "email_verified", false);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        handler.onAuthenticationSuccess(request, response, googleToken(attributes));
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(CLIENT_URL + "/?login_error=email");
+        verify(userService, never()).provisionExternalUser(any(), any(), any());
+        verify(appTokenService, never()).issueFor(any());
+    }
+}


### PR DESCRIPTION
Stacked on #2588 (internal user management). Part of moving applicant auth off the Keycloak `external-login` realm.

## What this PR does

Handles **Google sign-in directly in TUM Apply** instead of brokering it through Keycloak. (Apple, WebAuthn, and the Keycloak external-realm cleanup follow in later PRs.)

- **`OAuth2LoginSecurityConfiguration`** — a higher-priority `SecurityFilterChain` matching only `/oauth2/**` + `/login/oauth2/**`, **gated behind the `social-login` Spring profile** so dev/test/CI (no client credentials) and the stateless `/api/**` resource-server chain are completely unaffected.
- **`OAuth2LoginSuccessHandler`** — extracts the **verified** email + name, provisions a local user (`UserService.provisionExternalUser`), mints app tokens (`AppTokenService`), sets the HttpOnly cookies, and redirects to the SPA. Rejects unverified Google emails.
- **`AppleUserAttributesFilter`** — captures the name Apple returns only on first consent (scaffolding for the Apple follow-up).
- **Config** — Google client registration under the `social-login` profile (`application.yml`).
- **Frontend** — Google/Apple buttons now do a full-page redirect to the backend `/oauth2/authorization/{provider}`; the registration confirmation email is sent on return via the server-session branch of `initAuth`. **TUM SSO stays on Keycloak.**

## Enabling

Set `SPRING_PROFILES_ACTIVE=...,social-login` plus `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, and register `https://<env>/login/oauth2/code/google` in the Google console.

## Verification

- `compileJava`, `spotlessApply`, `checkstyleMain` — clean
- `tsc --noEmit` (frontend) + Prettier — clean
- `OAuth2LoginSuccessHandlerTest` — 2/2 (verified-email provisioning + cookies + redirect; unverified-email rejection)
- `UserResourceTest` — 17/17 (context still boots **without** the `social-login` profile)

## Follow-ups (separate PRs)

- **Apple** — ES256 `client_assertion` generator, `response_mode=form_post` request resolver, cookie-based `AuthorizationRequestRepository` (SameSite=None) so the cross-site callback survives. The success handler + name-capture filter are already Apple-aware.
- **WS-1f** — in-app WebAuthn for applicant passkeys
- **WS-3** — remove dead Keycloak external-realm code/config + realm JSON, collapse the frontend keycloak service to TUM-only, server-side OTP cooldown (SEC-32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)