### PR TITLE
`Bugfix`: Fix UI layout for evaluation details

### DIFF
--- a/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
+++ b/src/main/webapp/app/evaluation/application-detail/application-detail.component.html
@@ -326,15 +326,9 @@
             }
 
             <jhi-section titleKey="evaluation.details.documentTitle" icon="file-lines">
-              <jhi-document-section
-                #docSection
-                [idsDTO]="currentDocumentIds()"
-                [applicationId]="currentApplicationId()"
-                [referenceLetters]="currentReferenceRequests()"
-              />
               <ng-container actions>
                 @if (docSection.hasDocuments()) {
-                  <div class="flex flex-wrap ml-auto gap-2">
+                  <div class="flex flex-wrap gap-2">
                     <jhi-button
                       class="whitespace-nowrap"
                       label="evaluation.details.documentView"
@@ -356,6 +350,12 @@
                   </div>
                 }
               </ng-container>
+              <jhi-document-section
+                #docSection
+                [idsDTO]="currentDocumentIds()"
+                [applicationId]="currentApplicationId()"
+                [referenceLetters]="currentReferenceRequests()"
+              />
             </jhi-section>
           </div>
         </div>

--- a/src/main/webapp/app/shared/components/atoms/section/section.html
+++ b/src/main/webapp/app/shared/components/atoms/section/section.html
@@ -3,7 +3,7 @@
     @if (icon(); as icon) {
       <fa-icon class="text-primary-default" [icon]="icon" />
     }
-    <h2 class="text-lg font-bold" [jhiTranslate]="titleKey()"></h2>
+    <h2 class="text-lg font-bold break-words flex-1" [jhiTranslate]="titleKey()"></h2>
     <ng-content select="[actions]" />
   </header>
   <div class="ml-3 mt-3">


### PR DESCRIPTION
<!-- Thanks for contributing to TUMApply! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

#### General

<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #2606 
Closes #2607 

### Description

<!-- Describe your changes in detail -->
* In `application-detail.component.html`, the `<jhi-document-section>` is now rendered after the actions area, ensuring that action buttons are displayed before the document section.
* In `section.html`, the section header's `<h2>` now includes `break-words` and `flex-1` classes to improve text wrapping and layout, preventing long titles from overflowing.

### Steps for Testing

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:

1. Log in to TUMApply as professor
2. Go the Evaluation page
3. Zoom in and see that the buttons next to the Documents header are left-aligned
4. Zoom in and see that the header for the recommendation letter status breaks to the next line (in German)

### Review Progress

<!-- Each PR should be reviewed by at least one other developers. The code, the functionality (= manual test). -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="582" height="508" alt="image" src="https://github.com/user-attachments/assets/202d8764-6cda-4f4e-aa14-1ae23042c578" />


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/local-pr-coverage/README.md) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-12 01:42:21 UTC_

