### PR TITLE
`Bugfix`: Stabilize the job creation form

### DIFF
--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.html
@@ -182,6 +182,7 @@
                   tooltipText="jobCreationForm.positionDetailsSection.jobDescription.toolTipText"
                   [required]="true"
                   [characterLimit]="5000"
+                  [loading]="isViewingTranslationTarget()"
                   [model]="jobDescriptionSignal()"
                   [control]="basicInfoForm.get('jobDescription') ?? undefined"
                   icon="circle-info"

--- a/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
+++ b/src/main/webapp/app/job/job-creation-form/job-creation-form.component.ts
@@ -192,6 +192,11 @@ export class JobCreationFormComponent {
   /** The target language of the active translation, or undefined if idle */
   translationTargetLang = signal<Language | undefined>(undefined);
 
+  /** Whether the editor currently shows the language being translated (AI-streamed content). */
+  readonly isViewingTranslationTarget = computed(
+    () => this.isTranslating() && this.translationTargetLang() === this.currentDescriptionLanguage(),
+  );
+
   /** AbortController for cancelling active translation streams */
   private translationAbortController: AbortController | undefined;
 
@@ -656,6 +661,27 @@ export class JobCreationFormComponent {
     this.translationTargetLang.set(undefined);
   }
 
+  /**
+   * Clears the transient translation state for a run, but only when it is still
+   * the active one. A newer translation that superseded this run owns the state.
+   *
+   * @param abortController - The AbortController created for this run
+   * @param activeRequest - The dedup descriptor created for this run
+   */
+  private clearTranslationState(
+    abortController: AbortController,
+    activeRequest: { sourceLang: Language; sourceText: string; targetLang: Language },
+  ): void {
+    if (this.translationAbortController === abortController) {
+      this.isTranslating.set(false);
+      this.translationTargetLang.set(undefined);
+      this.translationAbortController = undefined;
+    }
+    if (this.activeTranslationRequest === activeRequest) {
+      this.activeTranslationRequest = undefined;
+    }
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // LANGUAGE SWITCHING METHODS
   // ═══════════════════════════════════════════════════════════════════════════
@@ -670,11 +696,13 @@ export class JobCreationFormComponent {
     const currentLang = this.currentDescriptionLanguage();
     if (newLang === currentLang) return;
 
-    // If a save is pending, flush it immediately so we don't lose text.
-    // syncCurrentEditorIntoLanguageSignals copies the editor HTML into the
-    // language signal, but the languageChangeEffect below sets the form
-    // value with emitEvent:false — so the autosave effect won't re-trigger.
-    void this.autoSave.flush();
+    // Only flush when there are unsaved edits. A pure view switch must not start
+    // a save/translation cycle — otherwise toggling languages re-translates even
+    // though the content never changed. When edits are pending, flushing runs
+    // syncCurrentEditorIntoLanguageSignals to preserve them before the switch.
+    if (this.autoSave.hasPending()) {
+      void this.autoSave.flush();
+    }
 
     this.currentDescriptionLanguage.set(newLang);
   }
@@ -1709,61 +1737,60 @@ export class JobCreationFormComponent {
         abortController.signal,
       );
 
-      if (accumulatedContent) {
-        const finalContent = this.extractTranslatedTextFromStream(accumulatedContent);
+      const finalContent = accumulatedContent ? this.extractTranslatedTextFromStream(accumulatedContent) : undefined;
+      let hasTranslation = false;
 
-        if (finalContent && finalContent.length > 0) {
-          // 5) Update the target language signal and translation baselines
-          if (targetLang === 'en') {
-            this.jobDescriptionEN.set(finalContent);
-            this.lastTranslatedEN.set(finalContent);
-            this.lastTranslatedDE.set(text);
-          } else {
-            this.jobDescriptionDE.set(finalContent);
-            this.lastTranslatedDE.set(finalContent);
-            this.lastTranslatedEN.set(text);
-          }
+      if (finalContent && finalContent.length > 0) {
+        hasTranslation = true;
+        // 5) Update the target language signal and translation baselines
+        if (targetLang === 'en') {
+          this.jobDescriptionEN.set(finalContent);
+          this.lastTranslatedEN.set(finalContent);
+          this.lastTranslatedDE.set(text);
+        } else {
+          this.jobDescriptionDE.set(finalContent);
+          this.lastTranslatedDE.set(finalContent);
+          this.lastTranslatedEN.set(text);
+        }
 
-          // 6) If user is viewing the target language, finalize the editor
-          if (this.currentDescriptionLanguage() === targetLang) {
-            this.basicInfoForm.get('jobDescription')?.setValue(finalContent, { emitEvent: false });
-            this.jobDescriptionSignal.set(finalContent);
-            this.jobDescriptionEditor()?.forceUpdate(finalContent);
-          }
+        // 6) If user is viewing the target language, finalize the editor
+        if (this.currentDescriptionLanguage() === targetLang) {
+          this.basicInfoForm.get('jobDescription')?.setValue(finalContent, { emitEvent: false });
+          this.jobDescriptionSignal.set(finalContent);
+          this.jobDescriptionEditor()?.forceUpdate(finalContent);
+        }
+      }
 
-          // 7) Persist the translated content and run target compliance analysis.
-          //    Set isAnalyzing BEFORE the finally block clears isTranslating,
-          //    so isScoreLoading never drops to false between the two states.
-          const jobId = this.jobId();
-          if (jobId) {
-            try {
-              const currentData = this.createJobDTO(JobFormDTOStateEnum.Draft);
-              const saved = await firstValueFrom(this.jobApi.updateJob(jobId, currentData));
-              this.lastSavedData.set(saved);
-              this.isAnalyzing.set(true);
-              await this.analyzeAndUpdateScore(targetLang);
-            } catch {
-              // Silent save failure — will be caught by next autosave
-            }
-          }
+      // 7) Streaming is done. For the active run, hand off from "translating" to
+      //    "analyzing": pre-set isAnalyzing so the sidebar score keeps loading,
+      //    then clear the translation spinner so the editor shows the finished
+      //    translation immediately instead of waiting for compliance analysis.
+      const jobId = this.jobId();
+      const runAnalysis = this.translationAbortController === abortController && hasTranslation && !!jobId;
+      if (runAnalysis) {
+        this.isAnalyzing.set(true);
+      }
+      this.clearTranslationState(abortController, activeRequest);
+
+      // 8) Persist the translated content and run compliance analysis for the
+      //    freshly translated language, decoupled from the translation spinner.
+      if (runAnalysis) {
+        try {
+          const currentData = this.createJobDTO(JobFormDTOStateEnum.Draft);
+          const saved = await firstValueFrom(this.jobApi.updateJob(jobId, currentData));
+          this.lastSavedData.set(saved);
+          await this.analyzeAndUpdateScore(targetLang);
+        } catch {
+          // Silent save failure — will be caught by next autosave
+          this.isAnalyzing.set(false);
         }
       }
     } catch (e) {
+      this.clearTranslationState(abortController, activeRequest);
       if (e instanceof DOMException && e.name === 'AbortError') {
         return; // Cancelled — silently ignore
       }
       this.toastService.showErrorKey('jobCreationForm.toastMessages.aiTranslationFailed');
-    } finally {
-      // 8) Clear translation state only if this is still the active run
-      if (this.translationAbortController === abortController) {
-        this.isTranslating.set(false);
-        this.translationTargetLang.set(undefined);
-        this.translationAbortController = undefined;
-      }
-      // Clear only if this is still the same request.
-      if (this.activeTranslationRequest === activeRequest) {
-        this.activeTranslationRequest = undefined;
-      }
     }
   }
 

--- a/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
+++ b/src/main/webapp/app/shared/components/atoms/editor/editor.component.ts
@@ -119,6 +119,10 @@ export class EditorComponent extends BaseInputDirective<string> {
   height = input<string>('12.5rem');
   helperText = input<string | undefined>(undefined); // Optional helper text to display below the editor field
   showGenderDecoderButton = input<boolean>(false);
+  // When true the editor is showing externally-streamed content (e.g. an AI
+  // translation); the empty/required error is suppressed so it does not flash
+  // while the first chunks arrive.
+  loading = input<boolean>(false);
   genderDecoderClick = output<string>();
   openAnalysisDialog = output<GenderBiasAnalysisResponse>();
   quillEditorComponent = viewChild(QuillEditorComponent);
@@ -156,7 +160,7 @@ export class EditorComponent extends BaseInputDirective<string> {
     const count = this.characterCount();
     return count - limit >= STANDARD_CHARACTER_BUFFER;
   });
-  isEmpty = computed(() => extractTextFromHtml(this.htmlValue()) === '' && !this.isFocused() && this.isTouched());
+  isEmpty = computed(() => !this.loading() && extractTextFromHtml(this.htmlValue()) === '' && !this.isFocused() && this.isTouched());
 
   errorMessage = computed(() => {
     this.langChange();
@@ -286,7 +290,7 @@ export class EditorComponent extends BaseInputDirective<string> {
       const maxChars = limit + STANDARD_CHARACTER_BUFFER;
       if (source !== 'user') {
         // Allow programmatic changes but still update htmlValue
-        const html = editor.root.innerHTML;
+        const html = this.stripHighlightMarkup(editor.root.innerHTML);
         this.htmlValue.set(html);
         return;
       }
@@ -304,7 +308,7 @@ export class EditorComponent extends BaseInputDirective<string> {
       }
     }
 
-    const html = editor.root.innerHTML;
+    const html = this.stripHighlightMarkup(editor.root.innerHTML);
     this.htmlValue.set(html);
 
     const ctrl = this.formControl();
@@ -445,6 +449,30 @@ export class EditorComponent extends BaseInputDirective<string> {
     if (target.classList.contains('compliance-highlight')) {
       this.highlightHovered.emit(undefined);
     }
+  }
+
+  /**
+   * Removes compliance-highlight span wrappers from serialized editor HTML while
+   * keeping their inner content. Highlights are a visual-only overlay, so their
+   * markup must never reach the form control or model value.
+   *
+   * @param html - The raw editor HTML, possibly containing highlight spans
+   * @returns The HTML with all compliance-highlight wrappers unwrapped
+   */
+  private stripHighlightMarkup(html: string): string {
+    if (!html.includes(HighlightBlot.className)) return html;
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    container.querySelectorAll(`span.${HighlightBlot.className}`).forEach(span => {
+      const parent = span.parentNode;
+      if (!parent) return;
+      // Unwrap the highlight span: move each child out in place, then drop the span.
+      while (span.firstChild) {
+        parent.insertBefore(span.firstChild, span);
+      }
+      parent.removeChild(span);
+    });
+    return container.innerHTML;
   }
 
   private mapToLanguageCode(francCode: string): string {

--- a/src/main/webapp/app/shared/util/auto-save-controller.ts
+++ b/src/main/webapp/app/shared/util/auto-save-controller.ts
@@ -43,7 +43,19 @@ export class AutoSaveController {
   notifyChanged(): void {
     this.cancelTimer();
     this._state.set(SavingStates.SAVING);
-    this.timer = setTimeout(() => void this.runSave(), this.delayMs);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.runSave();
+    }, this.delayMs);
+  }
+
+  /**
+   * Whether there are debounced edits still waiting to be saved (the timer is
+   * armed). Returns `false` while a save is in flight or once it has settled.
+   * Callers use this to avoid forcing a redundant save when nothing changed.
+   */
+  hasPending(): boolean {
+    return this.timer !== undefined;
   }
 
   /**

--- a/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
+++ b/src/test/webapp/app/job/job-creation-form/job-creation-form.component.spec.ts
@@ -95,6 +95,8 @@ type ComponentPrivate = {
   extractJobDescriptionFromStream: (content: string) => string | null;
   loadSupervisingProfessors: () => Promise<void>;
   setDefaultSupervisingProfessor: (preselectId?: string) => void;
+  translateAndStoreOtherLanguage: (currentLang: 'en' | 'de', currentText: string) => Promise<void>;
+  analyzeAndUpdateScore: (lang: string) => Promise<void>;
 };
 
 function getPrivate(component: JobCreationFormComponent): ComponentPrivate {
@@ -662,6 +664,72 @@ describe('JobCreationFormComponent', () => {
       mockAiStreamingService.generateJobApplicationDraftStream.mockRejectedValue(new Error('fail'));
       await component.generateJobApplicationDraft();
       expect(cancelSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Language switching', () => {
+    it('should not run a save when switching languages with no pending edits', () => {
+      getPrivate(component).autoSaveInitialized = true;
+      component.autoSave.reset();
+      component.currentDescriptionLanguage.set('en');
+      const flushSpy = vi.spyOn(component.autoSave, 'flush');
+
+      component.changeDescriptionLanguage('de');
+
+      expect(flushSpy).not.toHaveBeenCalled();
+      expect(component.currentDescriptionLanguage()).toBe('de');
+    });
+
+    it('should flush pending edits before switching languages', () => {
+      getPrivate(component).autoSaveInitialized = true;
+      component.currentDescriptionLanguage.set('en');
+      component.autoSave.notifyChanged();
+      const flushSpy = vi.spyOn(component.autoSave, 'flush').mockResolvedValue();
+
+      component.changeDescriptionLanguage('de');
+
+      expect(flushSpy).toHaveBeenCalledOnce();
+      expect(component.currentDescriptionLanguage()).toBe('de');
+    });
+  });
+
+  describe('Translation and compliance', () => {
+    it('should clear the translation spinner once streaming ends, before compliance analysis finishes', async () => {
+      component.jobId.set('job1');
+      component.currentDescriptionLanguage.set('en');
+      component.lastTranslatedEN.set('');
+      mockAiStreamingService.translateJobDescriptionStream.mockResolvedValue('{"translatedText":"<p>Hallo</p>"}');
+
+      let resolveAnalysis!: () => void;
+      const analysisDone = new Promise<void>(resolve => {
+        resolveAnalysis = resolve;
+      });
+      const analyzeSpy = vi.spyOn(getPrivate(component), 'analyzeAndUpdateScore').mockImplementation(async () => {
+        await analysisDone;
+        component.isAnalyzing.set(false);
+      });
+
+      const promise = getPrivate(component).translateAndStoreOtherLanguage('en', 'Hello EN');
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(component.isTranslating()).toBe(false);
+      expect(component.isAnalyzing()).toBe(true);
+      expect(analyzeSpy).toHaveBeenCalledWith('de');
+
+      resolveAnalysis();
+      await promise;
+      expect(component.isAnalyzing()).toBe(false);
+    });
+
+    it('should skip translation when the source text matches the last translated baseline', async () => {
+      component.jobId.set('job1');
+      component.currentDescriptionLanguage.set('en');
+      component.lastTranslatedEN.set('Hello EN');
+
+      await getPrivate(component).translateAndStoreOtherLanguage('en', 'Hello EN');
+
+      expect(mockAiStreamingService.translateJobDescriptionStream).not.toHaveBeenCalled();
+      expect(component.isTranslating()).toBe(false);
     });
   });
 });

--- a/src/test/webapp/app/shared/components/atoms/editor/editor.component.spec.ts
+++ b/src/test/webapp/app/shared/components/atoms/editor/editor.component.spec.ts
@@ -148,8 +148,7 @@ describe('EditorComponent', () => {
       vi.spyOn(comp, 'formControl').mockReturnValue(ctrl);
       vi.spyOn(comp as unknown as { hasFormControl: () => boolean }, 'hasFormControl').mockReturnValue(true);
 
-      const highlighted =
-        '<p>Hello <span class="compliance-highlight border-b-2" data-category="CRITICAL_AGG">young</span> world</p>';
+      const highlighted = '<p>Hello <span class="compliance-highlight border-b-2" data-category="CRITICAL_AGG">young</span> world</p>';
       (comp as unknown as { textChanged: (e: unknown) => void }).textChanged(makeEditorEvent(highlighted));
 
       expect(ctrl.value).toBe('<p>Hello young world</p>');

--- a/src/test/webapp/app/shared/components/atoms/editor/editor.component.spec.ts
+++ b/src/test/webapp/app/shared/components/atoms/editor/editor.component.spec.ts
@@ -93,6 +93,21 @@ describe('EditorComponent', () => {
   });
 
   describe('Error handling', () => {
+    it('should not flag empty content as an error while loading (AI streaming)', () => {
+      const fixture = createFixture();
+      const comp = fixture.componentInstance;
+
+      (comp as unknown as { htmlValue: { set: (v: string) => void } }).htmlValue.set('<p></p>');
+      vi.spyOn(comp, 'isFocused').mockReturnValue(false);
+      vi.spyOn(comp, 'isTouched').mockReturnValue(true);
+
+      fixture.componentRef.setInput('loading', false);
+      expect(comp.isEmpty()).toBe(true);
+
+      fixture.componentRef.setInput('loading', true);
+      expect(comp.isEmpty()).toBe(false);
+    });
+
     it('should return required error when input is empty and required is true', () => {
       const fixture = TestBed.createComponent(EditorComponent);
       const comp = fixture.componentInstance;
@@ -124,6 +139,33 @@ describe('EditorComponent', () => {
       (comp as unknown as { textChanged: (e: unknown) => void }).textChanged(makeEditorEvent('<p>Updated</p>'));
       expect(ctrl.value).toBe('<p>Updated</p>');
       expect(ctrl.dirty).toBe(true);
+    });
+
+    it('should strip compliance-highlight spans before writing to the form control', () => {
+      const fixture = createFixture();
+      const comp = fixture.componentInstance;
+      const ctrl = new FormControl('');
+      vi.spyOn(comp, 'formControl').mockReturnValue(ctrl);
+      vi.spyOn(comp as unknown as { hasFormControl: () => boolean }, 'hasFormControl').mockReturnValue(true);
+
+      const highlighted =
+        '<p>Hello <span class="compliance-highlight border-b-2" data-category="CRITICAL_AGG">young</span> world</p>';
+      (comp as unknown as { textChanged: (e: unknown) => void }).textChanged(makeEditorEvent(highlighted));
+
+      expect(ctrl.value).toBe('<p>Hello young world</p>');
+    });
+
+    it('should keep inner formatting when stripping a compliance-highlight span', () => {
+      const fixture = createFixture();
+      const comp = fixture.componentInstance;
+      const ctrl = new FormControl('');
+      vi.spyOn(comp, 'formControl').mockReturnValue(ctrl);
+      vi.spyOn(comp as unknown as { hasFormControl: () => boolean }, 'hasFormControl').mockReturnValue(true);
+
+      const highlighted = '<p><span class="compliance-highlight" data-category="TRANSPARENCY"><strong>Bold</strong></span> text</p>';
+      (comp as unknown as { textChanged: (e: unknown) => void }).textChanged(makeEditorEvent(highlighted));
+
+      expect(ctrl.value).toBe('<p><strong>Bold</strong> text</p>');
     });
 
     it('should return empty string from editorValue when formControl value is null', () => {

--- a/src/test/webapp/app/shared/util/auto-save-controller.spec.ts
+++ b/src/test/webapp/app/shared/util/auto-save-controller.spec.ts
@@ -93,6 +93,32 @@ describe('AutoSaveController', () => {
     expect(save).toHaveBeenCalledOnce();
   });
 
+  it('should report no pending save until notifyChanged is called', () => {
+    const controller = new AutoSaveController({ save: vi.fn().mockResolvedValue(true) });
+    expect(controller.hasPending()).toBe(false);
+
+    controller.notifyChanged();
+    expect(controller.hasPending()).toBe(true);
+  });
+
+  it('should clear the pending flag once the debounced save fires', async () => {
+    const controller = new AutoSaveController({ save: vi.fn().mockResolvedValue(true) });
+
+    controller.notifyChanged();
+    await vi.advanceTimersByTimeAsync(AUTO_SAVE_DELAY_MS);
+
+    expect(controller.hasPending()).toBe(false);
+  });
+
+  it('should clear the pending flag after flush', async () => {
+    const controller = new AutoSaveController({ save: vi.fn().mockResolvedValue(true) });
+
+    controller.notifyChanged();
+    await controller.flush();
+
+    expect(controller.hasPending()).toBe(false);
+  });
+
   it('should cancel the pending timer without saving when dispose is called', () => {
     const save = vi.fn().mockResolvedValue(true);
     const controller = new AutoSaveController({ save });


### PR DESCRIPTION
### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://ls1intum.github.io/tum-apply/developer/client-guidelines/language-guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://ls1intum.github.io/tum-apply/developer/general-guidelines/pull-request-guidelines).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding and design guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [client test guidelines](https://ls1intum.github.io/tum-apply/developer/client-guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The AI translation in the job creation form became fragile after the compliance text-highlighting feature was introduced. Reported symptoms:

- Translation kept re-triggering randomly after compliance ran.
- Toggling between the German and English job-description tabs (just to compare) re-triggered translation.
- The "translating…" spinner did not disappear when the translation finished, because the compliance analysis ran inside the same step.
- While a translation streamed into the tab being viewed, a "required" error and an empty box flashed just before the text started streaming.

No linked issue exists for this; it was reported directly.

### Description

All changes are client-side.

1. **Highlights no longer leak into the model.** Compliance issues are painted as inline `compliance-highlight` spans in the Quill editor. When the user then edited, the editor serialized that markup into the form control, so the highlight spans ended up in the saved description **and** in the translation source text. That made the translation de-duplication baselines (`lastTranslatedEN`/`lastTranslatedDE`) never match, so translation re-fired. The editor now strips highlight spans before writing to the form control, keeping highlights a purely visual overlay.
2. **Language switching no longer forces a save/translation.** `changeDescriptionLanguage` flushed the auto-save on every switch, and `flush()` always ran a full save (which triggers translation). Added `AutoSaveController.hasPending()` and only flush when there are genuinely unsaved edits, so a pure view switch does nothing.
3. **Translation spinner is decoupled from compliance.** As soon as streaming finishes and the text is written, the editor's translation spinner clears; the compliance analysis then runs under the sidebar's loading state (`isAnalyzing`), so the sidebar keeps loading continuously while the editor shows the finished translation.
4. **No false "required" error during streaming.** The editor got a `loading` input; while it shows AI-streamed content (bound to `isViewingTranslationTarget`), the empty/required error is suppressed, so the first (text-less) HTML chunk no longer flashes an error.

### Steps for Testing

Prerequisites:

1. Log in to TUMApply as a Professor or Employee.
2. Start creating or editing a job posting and enable the AI assistance toggle for the job description.

Then:

1. Type an English description and pause — after the typing break it should translate to German once. Keep typing — the in-flight translation should early-cancel and restart, not stack up.
2. Wait for the compliance highlights to appear, then continue editing — translation should **not** keep re-triggering on its own.
3. Toggle repeatedly between the English and German tabs **without editing** — no translation should be triggered.
4. Trigger a translation and watch the **target** tab: the "translating…" spinner should disappear the moment the text finishes streaming, while the right-hand score keeps loading; no "required" error should flash before the text appears.

### Review Progress

#### Code Review

- [ ] Code Review 1

#### Manual Tests

- [ ] Test 1

### Screenshots

The fixes are behavioural/timing-related (translation triggering, spinner lifecycle, and a transient validation flash). A short screencast of steps 3 and 4 above best demonstrates them; to be added by the author.
